### PR TITLE
FP Proj0202: Support both <Description> and <PackageDescription>

### DIFF
--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -148,6 +148,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DoubleProjectReferences", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChooseWhen", "projects\ChooseWhen\ChooseWhen.csproj", "{12251088-DE11-4DF8-871A-AD731663D2FC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackageDescription", "projects\PackageDescription\PackageDescription.csproj", "{B0A4EBF1-7614-4E4D-BCF0-FC00F181728F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -366,6 +368,10 @@ Global
 		{12251088-DE11-4DF8-871A-AD731663D2FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{12251088-DE11-4DF8-871A-AD731663D2FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{12251088-DE11-4DF8-871A-AD731663D2FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0A4EBF1-7614-4E4D-BCF0-FC00F181728F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0A4EBF1-7614-4E4D-BCF0-FC00F181728F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0A4EBF1-7614-4E4D-BCF0-FC00F181728F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0A4EBF1-7614-4E4D-BCF0-FC00F181728F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -426,6 +432,7 @@ Global
 		{B7FC4C41-DB01-4601-BD69-D3A6E901CBDB} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{52DD6A7B-995B-40F7-9500-5F643064E960} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{12251088-DE11-4DF8-871A-AD731663D2FC} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{B0A4EBF1-7614-4E4D-BCF0-FC00F181728F} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/PackageDescription/PackageDescription.csproj
+++ b/projects/PackageDescription/PackageDescription.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Label="PackageInfo">
+    <Version>1.0.0</Version>
+    <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
+    <PackageDescription>Awesome library</PackageDescription>
+    <PackageTags>analyzer; coolthings</PackageTags>
+    <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>
+    <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
+    <PackageReleaseNotes>
+      v1.0.0
+      - Proj0001: MS Build project file could not be located. (NEW RULE)
+      - Proj0002: Upgrade legacy MS Build project file. (NEW RULE)
+      - Proj0003: Define usings explicit. (NEW RULE)
+      - Proj1001: Use analyzers for packages. (NEW RULE)
+    </PackageReleaseNotes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>logo_128x128.png</PackageIcon>
+    <PackageIconUrl>https://raw.githubusercontent.com/Corniel/dotnet-project-file-analyzers/main/design/logo_128x128.png</PackageIconUrl>
+  </PropertyGroup>
+
+</Project>

--- a/projects/PackageDescription/Placeholder.cs
+++ b/projects/PackageDescription/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace PackageDescription;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_package_info.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_package_info.cs
@@ -8,7 +8,7 @@ public class Reports
        .ForProject("NoPackageInfo.cs")
        .HasIssues(
            new Issue("Proj0201", "Define the <Version> node explicitly or define the <IsPackable> node with value 'false'."),
-           new Issue("Proj0202", "Define the <Description> node explicitly or define the <IsPackable> node with value 'false'."),
+           new Issue("Proj0202", "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'."),
            new Issue("Proj0203", "Define the <Authors> node explicitly or define the <IsPackable> node with value 'false'."),
            new Issue("Proj0204", "Define the <PackageTags> node explicitly or define the <IsPackable> node with value 'false'."),
            new Issue("Proj0205", "Define the <RepositoryUrl> node explicitly or define the <IsPackable> node with value 'false'."),
@@ -33,7 +33,7 @@ public class Reports
        => new DefinePackageInfo()
        .ForProject("NoDescription.cs")
        .HasIssue(
-           new Issue("Proj0202", "Define the <Description> node explicitly or define the <IsPackable> node with value 'false'."));
+           new Issue("Proj0202", "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'."));
 
     [Test]
     public void on_no_authors()
@@ -110,6 +110,7 @@ public class Guards
 {
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
+    [TestCase("PackageDescription.cs")]
     [TestCase("WithLicenseFile.cs")]
     public void Projects_without_issues(string project)
          => new DefinePackageInfo()

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
@@ -25,7 +25,7 @@ public sealed class DefinePackageInfo : MsBuildProjectFileAnalyzer
         if (!IsPackable(context.Project)) { return; }
 
         Analyze(context, Rule.DefineVersion, g => g.Version);
-        Analyze(context, Rule.DefineDescription, g => g.Description);
+        Analyze(context, Rule.DefineDescription, g => Nodes.Concat(g.Description, g.PackageDescription));
         Analyze(context, Rule.DefineAuthors, g => g.Authors);
         Analyze(context, Rule.DefineTags, g => g.PackageTags);
         Analyze(context, Rule.DefineRepositoryUrl, g => g.RepositoryUrl);
@@ -36,13 +36,7 @@ public sealed class DefinePackageInfo : MsBuildProjectFileAnalyzer
         Analyze(context, Rule.DefineIcon, g => g.PackageIcon);
         Analyze(context, Rule.DefineIconUrl, g => g.PackageIconUrl);
         Analyze(context, Rule.DefinePackageId, g => g.PackageId);
-
-        Analyze(context, Rule.DefineLicense, g =>
-        {
-            var files = g.PackageLicenseFile as IEnumerable<Node>;
-            var expressions = g.PackageLicenseExpression as IEnumerable<Node>;
-            return files.Concat(expressions);
-        });
+        Analyze(context, Rule.DefineLicense, g => Nodes.Concat(g.PackageLicenseFile, g.PackageLicenseExpression));
     }
 
     private static bool IsPackable(MsBuildProject project)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -28,6 +28,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
 ToBeReleased
+- Proj0202: Both &lt;Description&gt; and &lt;PackageDescription&gt; are fine. (FP)
 - Improved message for Proj2002 to be more informative.
 v1.0.9
 - Proj0016: Improve ordering of file paths. (FP &amp; FN)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.T.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.T.cs
@@ -1,0 +1,51 @@
+﻿using System.Globalization;
+
+namespace DotNetProjectFile.MsBuild;
+
+/// <summary>Represents a collection of <see cref="Node"/>s.</summary>
+[DebuggerTypeProxy(typeof(CollectionDebugView))]
+[DebuggerDisplay("{DebuggerDisplay}")]
+public sealed class Nodes<T> : IReadOnlyList<T> where T : Node
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly IReadOnlyList<T> Items;
+
+    /// <summary>Initializes a new instance of the <see cref="Nodes{T}"/> class.</summary>
+    public Nodes(IReadOnlyList<T> items) => Items = items;
+
+    /// <summary>Gets the number of items.</summary>
+    public int Count => Items.Count;
+
+    /// <summary>Gets the specified item.</summary>
+    /// <param name="index">
+    /// The index of the item.
+    /// </param>
+    public T this[int index] => Items[index];
+
+    public Nodes<TOut> Typed<TOut>() where TOut : T
+        => new(Items.OfType<TOut>().ToArray());
+
+    public Nodes<TOut> NestedTyped<TOut>() where TOut : T
+        => new(Items.SelectMany(Walk).OfType<TOut>().ToArray());
+
+    private static IEnumerable<Node> Walk(Node node)
+    {
+        yield return node;
+        foreach (var child in node.Children.SelectMany(Walk))
+        {
+            yield return child;
+        }
+    }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    [ExcludeFromCodeCoverage/* Justification = "Debug experience only." */]
+    private string DebuggerDisplay
+        => string.Format(CultureInfo.InvariantCulture, "{0} Count = {1}", typeof(T).Name, Count);
+
+    /// <inheritdoc />
+    public IEnumerator<T> GetEnumerator() => Items.GetEnumerator();
+
+    /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
@@ -1,51 +1,6 @@
-﻿using System.Globalization;
+﻿namespace DotNetProjectFile.MsBuild;
 
-namespace DotNetProjectFile.MsBuild;
-
-/// <summary>Represents a collection of <see cref="Node"/>s.</summary>
-[DebuggerTypeProxy(typeof(CollectionDebugView))]
-[DebuggerDisplay("{DebuggerDisplay}")]
-public sealed class Nodes<T> : IReadOnlyList<T> where T : Node
+internal static class Nodes
 {
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private readonly IReadOnlyList<T> Items;
-
-    /// <summary>Initializes a new instance of the <see cref="Nodes{T}"/> class.</summary>
-    public Nodes(IReadOnlyList<T> items) => Items = items;
-
-    /// <summary>Gets the number of items.</summary>
-    public int Count => Items.Count;
-
-    /// <summary>Gets the specified item.</summary>
-    /// <param name="index">
-    /// The index of the item.
-    /// </param>
-    public T this[int index] => Items[index];
-
-    public Nodes<TOut> Typed<TOut>() where TOut : T
-        => new(Items.OfType<TOut>().ToArray());
-
-    public Nodes<TOut> NestedTyped<TOut>() where TOut : T
-        => new(Items.SelectMany(Walk).OfType<TOut>().ToArray());
-
-    private static IEnumerable<Node> Walk(Node node)
-    {
-        yield return node;
-        foreach (var child in node.Children.SelectMany(Walk))
-        {
-            yield return child;
-        }
-    }
-
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    [ExcludeFromCodeCoverage/* Justification = "Debug experience only." */]
-    private string DebuggerDisplay
-        => string.Format(CultureInfo.InvariantCulture, "{0} Count = {1}", typeof(T).Name, Count);
-
-    /// <inheritdoc />
-    public IEnumerator<T> GetEnumerator() => Items.GetEnumerator();
-
-    /// <inheritdoc />
-    [ExcludeFromCodeCoverage]
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    public static IEnumerable<Node> Concat(IEnumerable<Node> first, IEnumerable<Node> second) => first.Concat(second);
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageDescription.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageDescription.cs
@@ -1,0 +1,6 @@
+﻿namespace DotNetProjectFile.MsBuild;
+
+public sealed class PackageDescription : Node<string>
+{
+    public PackageDescription(XElement element, Node parent, Project project) : base(element, parent, project) { }
+}

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
@@ -20,14 +20,15 @@ public sealed class PropertyGroup : Node
         RepositoryUrl = Children.Typed<RepositoryUrl>();
         PackageProjectUrl = Children.Typed<PackageProjectUrl>();
         Copyright = Children.Typed<Copyright>();
+        PackageDescription = Children.Typed<PackageDescription>();
         PackageId = Children.Typed<PackageId>();
-        PackageReleaseNotes = Children.Typed<PackageReleaseNotes>();
-        PackageReadmeFile = Children.Typed<PackageReadmeFile>();
         PackageLicenseExpression = Children.Typed<PackageLicenseExpression>();
         PackageLicenseFile = Children.Typed<PackageLicenseFile>();
         PackageLicenseUrl = Children.Typed<PackageLicenseUrl>();
         PackageIcon = Children.Typed<PackageIcon>();
         PackageIconUrl = Children.Typed<PackageIconUrl>();
+        PackageReleaseNotes = Children.Typed<PackageReleaseNotes>();
+        PackageReadmeFile = Children.Typed<PackageReadmeFile>();
     }
 
     public Nodes<TargetFramework> TargetFramework { get; }
@@ -60,7 +61,7 @@ public sealed class PropertyGroup : Node
 
     public Nodes<PackageReleaseNotes> PackageReleaseNotes { get; }
 
-    public Nodes<PackageReadmeFile> PackageReadmeFile { get; }
+    public Nodes<PackageDescription> PackageDescription { get; }
 
     public Nodes<PackageLicenseExpression> PackageLicenseExpression { get; }
 
@@ -71,6 +72,8 @@ public sealed class PropertyGroup : Node
     public Nodes<PackageIcon> PackageIcon { get; }
 
     public Nodes<PackageIconUrl> PackageIconUrl { get; }
+
+    public Nodes<PackageReadmeFile> PackageReadmeFile { get; }
 
     public Nodes<IsPublishable> IsPublishable { get; }
 }

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -207,12 +207,11 @@ public static class Rule
     public static DiagnosticDescriptor DefineDescription => New(
         id: 0202,
         title: "Define the project description explicitly",
-        message: "Define the <Description> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'.",
         description:
-            "To ensure the creation of well-formed packages, " +
-            "explicitly define the <Description> node or " +
-            "disable package generation by defining the " +
-            "<IsPackable> node with value 'false'.",
+            "To ensure the creation of well-formed packages, explicitly define " +
+            "the <Description> or <PackageDescription> node or disable package " +
+            "generation by defining the <IsPackable> node with value 'false'.",
         tags: new[] { "Configuration", "NuGet", "package" },
         category: Category.Configuration,
         severity: DiagnosticSeverity.Warning,


### PR DESCRIPTION
Using `<PackageDescription>` and `<Description>` both give the desired result.

See: https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers.github.io/pull/1