### PR TITLE
Downgrade version Roslyn dependency

### DIFF
--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -100,7 +100,7 @@ v1.0.0
   </ItemGroup>
 
   <ItemGroup Label="Roslyn dependencies">
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.6.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.0.1" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -30,6 +30,7 @@
 ToBeReleased
 - Proj0202: Both &lt;Description&gt; and &lt;PackageDescription&gt; are fine. (FP)
 - Improved message for Proj2002 to be more informative.
+- Depend on Microsoft.CodeAnalysis.Workspaces.Common version 4.0.1.
 v1.0.9
 - Proj0016: Improve ordering of file paths. (FP &amp; FN)
 v1.0.8


### PR DESCRIPTION
Use the oldest version possible to prevent issues with other Roslyn tooling.