### PR TITLE
Suppress dependencies when packing

### DIFF
--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
-  
+
   <PropertyGroup Label="Package settings">
     <RepositoryType>git</RepositoryType>
     <PackageId>DotNetProjectFile.Analyzers</PackageId>
@@ -94,6 +94,7 @@ v1.0.0
     </PackageReleaseNotes>
     <PackageIcon>logo_128x128.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/Corniel/dotnet-project-file-analyzers/main/design/logo_128x128.png</PackageIconUrl>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <ItemGroup Label="Package files">
@@ -119,5 +120,5 @@ v1.0.0
   <ItemGroup>
     <AdditionalFiles Include="*.csproj" Visible="false" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
By suppressing dependencies, the package will not longer contain a fixed dependency on `Microsoft.CodeAnalysis.Workspaces.Common`. This should prevent issues with solutions that have a dependency on `Microsoft.CodeAnalysis.Workspaces.Common` on their own.

Other analyzer projects don't seem to have that dependency either specified: 

- [SerilogAnalyze](https://www.nuget.org/packages/SerilogAnalyzer/0.15.0#dependencies-body-tab)
- [SonarAnalyzer.CSharp](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.6.0.74858#dependencies-body-tab)