### PR TITLE
FN & FP: Fix sorting check

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="CodeAnalysis.TestTools" Version="1.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="NuGet.Common" Version="6.7.0.111" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.7.0.111" />
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0.111" />
+    <PackageReference Include="NuGet.Common" Version="6.6.1" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.6.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.6.1" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.*" PrivateAssets="all" />
   </ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="CodeAnalysis.TestTools" Version="1.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-    <PackageReference Include="NuGet.Common" Version="6.6.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.6.1" />
-    <PackageReference Include="NuGet.Packaging" Version="6.6.1" />
+    <PackageReference Include="NuGet.Common" Version="6.7.0.111" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.7.0.111" />
+    <PackageReference Include="NuGet.Packaging" Version="6.7.0.111" />
     <PackageReference Include="NUnit" Version="3.*" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.*" />
   </ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="coverlet.msbuild" Version="*" PrivateAssets="all" />
     <PackageReference Include="CodeAnalysis.TestTools" Version="1.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0" />
     <PackageReference Include="NuGet.Common" Version="6.6.1" />
     <PackageReference Include="NuGet.Frameworks" Version="6.6.1" />
     <PackageReference Include="NuGet.Packaging" Version="6.6.1" />

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup Label="TestTools">
-    <PackageReference Include="coverlet.collector" Version="*" />
-    <PackageReference Include="coverlet.msbuild" Version="*" />
+    <PackageReference Include="coverlet.collector" Version="*" PrivateAssets="all" />
+    <PackageReference Include="coverlet.msbuild" Version="*" PrivateAssets="all" />
     <PackageReference Include="CodeAnalysis.TestTools" Version="1.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
@@ -25,12 +25,12 @@
     <PackageReference Include="NuGet.Frameworks" Version="6.7.0.111" />
     <PackageReference Include="NuGet.Packaging" Version="6.7.0.111" />
     <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="FluentAssertions.Analyzers" Version="*" />
-    <PackageReference Include="NUnit.Analyzers" Version="*" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/IO/File_path_compare.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/IO/File_path_compare.cs
@@ -17,22 +17,14 @@ public class Compares
             "substring",
             "sub",
         }
-        .OrderBy(x => x, FileSystem.PathCompare)
-        .Should().BeEquivalentTo(
-            "sub",
-            "substring"
-        );
+        .Should().BeInDescendingOrder(FileSystem.PathCompare);
 
     [Test]
     public void shorter_paths_first()
-        => new[] 
+        => new[]
         {
+            @"..\Root.AspNetCore\Root.AspNetCore.csproj",
             @"..\Root.AspNetCore.Builder.Abstractions\Root.AspNetCore.Builder.Abstractions.csproj",
-            @"..\Root.AspNetCore\Root.AspNetCore.csproj",
         }
-        .OrderBy(x => x, FileSystem.PathCompare)
-        .Should().BeEquivalentTo(
-            @"..\Root.AspNetCore\Root.AspNetCore.csproj",
-            @"..\Root.AspNetCore.Builder.Abstractions\Root.AspNetCore.Builder.Abstractions.csproj"
-        );
+        .Should().BeInAscendingOrder(FileSystem.PathCompare);
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -27,6 +27,8 @@
     <Version>1.0.10</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased:
+- Proj0015, Proj0016: Order references that are substrings of each other. (FP &amp; FN)
 v1.0.10
 - Proj0017: Can't create alias for static using directive. (NEW RULE)
 - Proj0018: Order using directives by type. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/IO/FilePathComparer.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/FilePathComparer.cs
@@ -15,7 +15,7 @@ public sealed class FilePathComparer : IComparer<string?>
         {
             compare = Compare(xs.Current, ys.Current);
         }
-        return compare ?? y.Length.CompareTo(x.Length);
+        return compare ?? x.Length.CompareTo(y.Length);
     }
 
     private int? Compare(char x, char y)


### PR DESCRIPTION
The actual unit test for this scenario did not check the order, just if the two members are in the set. (Oops)