### PR TITLE
FP/FN: Sorting of referencese should be case insensitive

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/IO/File_path_compare.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/IO/File_path_compare.cs
@@ -27,4 +27,13 @@ public class Compares
             @"..\Root.AspNetCore.Builder.Abstractions\Root.AspNetCore.Builder.Abstractions.csproj",
         }
         .Should().BeInAscendingOrder(FileSystem.PathCompare);
+
+    [Test]
+    public void case_insensitive()
+         => new[]
+        {
+            @"covlet",
+            @"Qowaiv",
+        }
+        .Should().BeInAscendingOrder(FileSystem.PathCompare);
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Choose_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Choose_specs.cs
@@ -1,7 +1,7 @@
 ﻿using DotNetProjectFile;
 using DotNetProjectFile.Diagnostics;
 
-namespace MS_Build.Choose_specs;
+namespace Rules.MS_Build.Choose_specs;
 
 public class Project_contains
 {

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -27,6 +27,8 @@
     <Version>1.0.11</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeRelaesed
+- Proj0015, Proj0016: Order references case-insensitive. (FP &amp; FN)
 v1.0.11
 - Proj0015, Proj0016: Order references that are substrings of each other. (FP &amp; FN)
 - Proj1100: Avoid using Moq. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/IO/FilePathComparer.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/FilePathComparer.cs
@@ -23,6 +23,9 @@ public sealed class FilePathComparer : IComparer<string?>
         int compare = Update(x).CompareTo(Update(y));
         return compare == 0 ? null : compare;
 
-        static char Update(char ch) => ch == '/' || ch == '\\' ? char.MinValue : ch;
+        static char Update(char ch)
+            => ch == '/' || ch == '\\'
+            ? char.MinValue
+            : char.ToUpperInvariant(ch);
     }
 }


### PR DESCRIPTION
The following should be compliant:

``` XML
 <PackageReference Include="CodeAnalysis.TestTools" Version="1.1.0" />
 <PackageReference Include="coverlet.collector" Version="*" PrivateAssets="all" />
````