### PR TITLE
Adjust Proj0004 to solve issue of NugetAudit being broken for the .NET 7 SDK

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Run_NuGet_security_audits_automatically.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Run_NuGet_security_audits_automatically.cs
@@ -8,19 +8,13 @@ public class Reports
        .ForProject("DisabledNugetAudit.cs")
        .HasIssue(
            new Issue("Proj0004", "Run NuGet security audits automatically."));
-
-    [Test]
-    public void on_not_configured_NuGet_audit()
-        => new RunNuGetSecurityAuditsAutomatically()
-        .ForProject("NoNugetAudit.cs")
-        .HasIssue(
-            new Issue("Proj0004", "Run NuGet security audits automatically."));
 }
 
 public class Guards
 {
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
+    [TestCase("NoNugetAudit.cs")]
     public void Projects_without_issues(string project)
          => new RunNuGetSecurityAuditsAutomatically()
         .ForProject(project)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
@@ -9,7 +9,7 @@ public sealed class RunNuGetSecurityAuditsAutomatically : MsBuildProjectFileAnal
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.Property<bool?, NuGetAudit>(g => g.NuGetAudit, MsBuildDefaults.NuGetAudit) != true)
+        if (context.Project.Property<bool?, NuGetAudit>(g => g.NuGetAudit, MsBuildDefaults.NuGetAudit) == false)
         {
             context.ReportDiagnostic(Descriptor, context.Project);
         }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -24,9 +24,11 @@
     <RepositoryUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;csproj;vbproj;resx;MS Build;resources</PackageTags>
-    <Version>1.0.12</Version>
+    <Version>1.0.13</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+v1.0.13
+- Proj0004: Only report when &lt;NuGetAudit&gt; is explicitly disabled. (FP)
 v1.0.12
 - Proj1200: Exclude private assets as project file dependency. (NEW RULE)
 - Proj0015, Proj0016: Order references case-insensitive. (FP &amp; FN)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildDefaults.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildDefaults.cs
@@ -3,5 +3,5 @@
 public static class MsBuildDefaults
 {
     public static readonly bool IsPackage = true;
-    public static readonly bool NuGetAudit = false;
+    public static readonly bool NuGetAudit = true;
 }


### PR DESCRIPTION
From now on, only report when the feature is explicitly disabled.

See #93