### PR TITLE
Support Directory.Build.props

### DIFF
--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -150,7 +150,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PackageDescription", "proje
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UsesMoq", "projects\UsesMoq\UsesMoq.csproj", "{3B627642-EFE1-4789-A4FE-8214BFB7BE97}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrivateAssets", "projects\PrivateAssets\PrivateAssets.csproj", "{954865D2-22D1-4DDE-9735-6496E137A860}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrivateAssets", "projects\PrivateAssets\PrivateAssets.csproj", "{954865D2-22D1-4DDE-9735-6496E137A860}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WithDirectoryBuildProps", "projects\WithDirectoryBuildProps\WithDirectoryBuildProps.csproj", "{5B16F4F0-0B24-4ED8-A4F9-13C05A03DBAB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -378,6 +380,10 @@ Global
 		{954865D2-22D1-4DDE-9735-6496E137A860}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{954865D2-22D1-4DDE-9735-6496E137A860}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{954865D2-22D1-4DDE-9735-6496E137A860}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B16F4F0-0B24-4ED8-A4F9-13C05A03DBAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B16F4F0-0B24-4ED8-A4F9-13C05A03DBAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B16F4F0-0B24-4ED8-A4F9-13C05A03DBAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B16F4F0-0B24-4ED8-A4F9-13C05A03DBAB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -440,6 +446,7 @@ Global
 		{B0A4EBF1-7614-4E4D-BCF0-FC00F181728F} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{3B627642-EFE1-4789-A4FE-8214BFB7BE97} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{954865D2-22D1-4DDE-9735-6496E137A860} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{5B16F4F0-0B24-4ED8-A4F9-13C05A03DBAB} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/WithDirectoryBuildProps/Directory.Build.props
+++ b/projects/WithDirectoryBuildProps/Directory.Build.props
@@ -1,0 +1,8 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/projects/WithDirectoryBuildProps/Placeholder.cs
+++ b/projects/WithDirectoryBuildProps/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace WithDirectoryBuildProps;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/WithDirectoryBuildProps/WithDirectoryBuildProps.csproj
+++ b/projects/WithDirectoryBuildProps/WithDirectoryBuildProps.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/projects/WithDirectoryBuildProps/WithDirectoryBuildProps.csproj
+++ b/projects/WithDirectoryBuildProps/WithDirectoryBuildProps.csproj
@@ -5,4 +5,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="*.csproj" Visible="false" />
+  </ItemGroup>
+
 </Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Directory_Build_props_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Directory_Build_props_specs.cs
@@ -1,0 +1,29 @@
+﻿using DotNetProjectFile;
+using DotNetProjectFile.Diagnostics;
+
+namespace Rules.MS_Build.Directory_Build_props_specs;
+
+public class Project_relies_on
+{
+    [Test]
+    public void Directory_Build_props()
+        => new NodeReporter()
+        .ForProject("WithDirectoryBuildProps.cs")
+        .HasIssue(
+            new Issue("Proj9999", "Found Directory.Build.props."));
+    
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    private sealed class NodeReporter : MsBuildProjectFileAnalyzer
+    {
+        public NodeReporter() 
+            : base(Rule.New(9999, "", "Found {0}.", "", Array.Empty<string>(), Category.Reliability)) { }
+
+        protected override void Register(ProjectFileAnalysisContext context)
+        {
+            if (context.Project.DirectoryBuildProps is { } prop)
+            {
+                context.ReportDiagnostic(Descriptor, prop, prop.Path.Name);
+            }
+        }
+    }
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
@@ -8,6 +8,13 @@ public class Reports
         .ForProject("EmptyProject.cs")
         .HasIssue(
             new Issue("Proj0006", "Add 'EmptyProject.csproj' to the additional files."));
+
+    [Test]
+    public void Directory_Build_props_not_being_added()
+        => new AddAdditionalFile()
+        .ForProject("WithDirectoryBuildProps.cs")
+        .HasIssue(
+            new Issue("Proj0006", "Add 'Directory.Build.props' to the additional files."));
 }
 
 public class Guards

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GuardUnsupported.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GuardUnsupported.cs
@@ -13,8 +13,7 @@ public sealed class GuardUnsupported : MsBuildProjectFileAnalyzer
 
     private void Locate(CompilationAnalysisContext context)
     {
-        var projects = Projects.Init(context);
-        if (projects.EntryPoint(context.Compilation.Assembly) is not { } project)
+        if (Projects.Init(context).EntryPoint(context) is not { } project)
         {
             context.ReportDiagnostic(
                 Diagnostic.Create(

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -4,7 +4,7 @@
 public readonly struct ProjectFileAnalysisContext
 {
     /// <summary>Gets the project file.</summary>
-    public readonly MsBuild.Project Project;
+    public readonly MsBuildProject Project;
 
     /// <summary>Gets the compilation.</summary>
     public readonly Compilation Compilation;
@@ -19,7 +19,7 @@ public readonly struct ProjectFileAnalysisContext
     private readonly Action<Diagnostic> Report;
 
     /// <summary>Initializes a new instance of the <see cref="ProjectFileAnalysisContext"/> struct.</summary>
-    public ProjectFileAnalysisContext(MsBuild.Project project, Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken, Action<Diagnostic> report)
+    public ProjectFileAnalysisContext(MsBuildProject project, Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken, Action<Diagnostic> report)
     {
         Project = project;
         Compilation = compilation;

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -24,9 +24,11 @@
     <RepositoryUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;csproj;vbproj;resx;MS Build;resources</PackageTags>
-    <Version>1.0.14</Version>
+    <Version>1.1.0</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+v1.1.0
+- Support of Directory.Build.props.
 v1.0.14
 - Proj0018: Fix false positive reports always triggering. (FP)
 - Proj0018: Fix typo in message.

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
@@ -7,8 +7,7 @@ internal static class AnalysisContextExtensions
     public static void RegisterProjectFileAction(this AnalysisContext context, Action<ProjectFileAnalysisContext> action)
         => context.RegisterCompilationAction(c =>
         {
-            var projects = Projects.Init(c);
-            if (projects.EntryPoint(c.Compilation.Assembly) is { } project
+            if (Projects.Init(c).EntryPoint(c) is { } project
                 && string.IsNullOrEmpty(project.Element.Name.NamespaceName))
             {
                 foreach (var p in project.ImportsAndSelf())

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.IO.FileSystemInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.IO.FileSystemInfo.cs
@@ -11,4 +11,6 @@ internal static class SystemFileSystemInfoExtensions
             current = current.Parent;
         }
     }
+
+    public static FileInfo File(this DirectoryInfo dir, string name) => new(Path.Combine(dir.FullName, name));
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -18,6 +18,10 @@ public sealed class Project : Node
         ItemGroups = Children.NestedTyped<ItemGroup>();
     }
 
+    public Project? DirectoryBuildProps { get; internal set; }
+
+    public bool IsDirectoryBuildProps => "Directory.Build.props".Equals(Path.Name, StringComparison.OrdinalIgnoreCase);
+
     public bool IsAdditional { get; }
 
     public bool IsProject { get; }
@@ -53,6 +57,11 @@ public sealed class Project : Node
     /// <summary>Loops through all imports and self.</summary>
     public IEnumerable<Project> ImportsAndSelf()
     {
+        if (DirectoryBuildProps is { })
+        {
+            yield return DirectoryBuildProps;
+        }
+
         foreach (var import in Imports)
         {
             if (import.Value is { } project)
@@ -79,6 +88,11 @@ public sealed class Project : Node
                     yield return p;
                 }
             }
+        }
+
+        if (DirectoryBuildProps is { })
+        {
+            yield return DirectoryBuildProps;
         }
     }
 


### PR DESCRIPTION
A build can be [customized by directory](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory). Those `Directory.Build.props` should be validated by themselves, and have impact on validation project files too, as they can serve as the first ancestor in the inheritance chain.