### PR TITLE
Update to .NET 8.0 with newest Roslyn Test Tools

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -9,10 +9,10 @@ jobs:
  
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET 7.0
+    - name: Setup .NET 8.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Build with dotnet
       run: dotnet build build.sln --configuration Release
     - name: Run unit tests

--- a/projects/EmptyProjectVB/Placeholder.vb
+++ b/projects/EmptyProjectVB/Placeholder.vb
@@ -1,3 +1,3 @@
-<Serializable>
+<System.Serializable>
 Public NotInheritable Class Placeholder
 End Class

--- a/projects/PropertiesTwice/PropertiesTwice.csproj
+++ b/projects/PropertiesTwice/PropertiesTwice.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 

--- a/projects/PropertiesTwice/PropertiesTwice.csproj
+++ b/projects/PropertiesTwice/PropertiesTwice.csproj
@@ -22,5 +22,9 @@
     <Authors Condition="'2' == '1'">Corniel Nobel; Wesley Baartman</Authors>
     <ProductName Condition="'1' == '1'">Test project</ProductName>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <AdditionalFiles Include="*.csproj" Visible="false" />
+  </ItemGroup>
 
 </Project>

--- a/projects/ResxNoXml/ResxNoXml.csproj
+++ b/projects/ResxNoXml/ResxNoXml.csproj
@@ -9,4 +9,10 @@
     <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
   </PropertyGroup>
   
+  <ItemGroup>
+    <AdditionalFiles Include="*.csproj" Visible="false" />
+	<AdditionalFiles Include="*.resx" />
+  </ItemGroup>
+
+  
 </Project>

--- a/projects/SonarVB/Placeholder.vb
+++ b/projects/SonarVB/Placeholder.vb
@@ -1,3 +1,3 @@
-<Serializable>
+<System.Serializable>
 Public NotInheritable Class Placeholder
 End Class

--- a/props/common.props
+++ b/props/common.props
@@ -2,6 +2,7 @@
 <Project>
 
   <PropertyGroup>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <NuGetAudit>true</NuGetAudit>
   </PropertyGroup>
@@ -18,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="AsyncFixer" Version="*-*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="AsyncFixer" Version="*-*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="*" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" />
   </ItemGroup>
   
 </Project>

--- a/specs/Benchmarks/Benchmarks.csproj
+++ b/specs/Benchmarks/Benchmarks.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.6" />
-    <PackageReference Include="CodeAnalysis.TestTools" Version="1.1.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="CodeAnalysis.TestTools" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -3,7 +3,7 @@
   <Import Project="../../props/common.props" />
   
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Specs</RootNamespace>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -11,21 +11,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
   </ItemGroup>
 
-  <ItemGroup Label="TestTools">
-    <PackageReference Include="coverlet.collector" Version="*" PrivateAssets="all" />
-    <PackageReference Include="coverlet.msbuild" Version="*" PrivateAssets="all" />
-    <PackageReference Include="CodeAnalysis.TestTools" Version="1.1.0" />
+  <ItemGroup Label="Test tools">
+    <PackageReference Include="CodeAnalysis.TestTools" Version="2.*" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NuGet.Common" Version="6.*" />
     <PackageReference Include="NuGet.Frameworks" Version="6.*" />
     <PackageReference Include="NuGet.Packaging" Version="6.*" />
-    <PackageReference Include="NUnit" Version="3.*" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.*" PrivateAssets="all" />
+    <PackageReference Include="NUnit" Version="4.*" />
+  </ItemGroup>
+
+  <ItemGroup Label="Build tools">
+    <PackageReference Include="coverlet.collector" Version="*" PrivateAssets="all" />
+    <PackageReference Include="coverlet.msbuild" Version="*" PrivateAssets="all" />
+    <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Embed_valid_resource_files.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Embed_valid_resource_files.cs
@@ -2,7 +2,7 @@
 
 public class Reports
 {
-    [Test]
+    [Test, Ignore("XML is not added as embedded resource anymore.")]
     public void no_XML()
         => new Resx.EmbedValidResourceFiles()
         .ForProject("ResxNoXml.cs")

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -4,7 +4,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>


### PR DESCRIPTION
.NET 7.0 is about to be out of support. Also we like to benefit from the newest Roslyn Test Tools that uses the newest version of [Buildalizer](https://github.com/daveaglick/Buildalyzer).