### PR TITLE
FP Proj0006: Directory.Build.Props is not required to be added as additional file

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
@@ -8,13 +8,6 @@ public class Reports
         .ForProject("EmptyProject.cs")
         .HasIssue(
             new Issue("Proj0006", "Add 'EmptyProject.csproj' to the additional files."));
-
-    [Test]
-    public void Directory_Build_props_not_being_added()
-        => new AddAdditionalFile()
-        .ForProject("WithDirectoryBuildProps.cs")
-        .HasIssue(
-            new Issue("Proj0006", "Add 'Directory.Build.props' to the additional files."));
 }
 
 public class Guards
@@ -24,5 +17,11 @@ public class Guards
     public void project_files_as_additional(string project)
          => new AddAdditionalFile()
         .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void Directory_Build_props_not_being_added()
+        => new AddAdditionalFile()
+        .ForProject("WithDirectoryBuildProps.cs")
         .HasNoIssues();
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AddAdditionalFile.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AddAdditionalFile.cs
@@ -5,7 +5,7 @@ public sealed class AddAdditionalFile() : MsBuildProjectFileAnalyzer(Rule.AddAdd
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (!context.Project.IsAdditional)
+        if (!context.Project.IsAdditional && !context.Project.IsDirectoryBuildProps)
         {
             context.ReportDiagnostic(Descriptor, context.Project, context.Project.Path.Name);
         }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -26,6 +26,8 @@
     <Version>1.1.0</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased:
+- Proj0006: Directory.Build.Props is not required to be added as additional file. (FP)
 v1.1.0
 - Support of Directory.Build.props.
 v1.0.14


### PR DESCRIPTION
It is far from trivial to include the directory build props. Furthermore, it might be even available in all scenario's. #41