### PR TITLE
New Rule 1002: Use Microsoft's analyzers

### DIFF
--- a/build.sln
+++ b/build.sln
@@ -18,6 +18,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{D43D7549-495B-4A32-A13C-9AF7B6EA893A}"
+	ProjectSection(SolutionItems) = preProject
+		projects\DisableNetAnalyzers\DisableNetAnalyzers.csproj = projects\DisableNetAnalyzers\DisableNetAnalyzers.csproj
+		projects\NoEnableNetAnalyzers\NoEnableNetAnalyzers.csproj = projects\NoEnableNetAnalyzers\NoEnableNetAnalyzers.csproj
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -173,6 +173,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MultipleBuildActionTasks", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TargetFrameworksSingleWithBase", "projects\TargetFrameworksSingleWithBase\TargetFrameworksSingleWithBase.csproj", "{DCE06E60-5029-4701-A783-AD1E9C3A1828}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DisableNetAnalyzers", "projects\DisableNetAnalyzers\DisableNetAnalyzers.csproj", "{005CFB9E-F7BA-4AD6-AF95-02FC14C728F9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NoEnableNetAnalyzers", "projects\NoEnableNetAnalyzers\NoEnableNetAnalyzers.csproj", "{EEBD0E27-E3A5-4664-BE51-96BBED7E60F0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -431,6 +435,14 @@ Global
 		{DCE06E60-5029-4701-A783-AD1E9C3A1828}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DCE06E60-5029-4701-A783-AD1E9C3A1828}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DCE06E60-5029-4701-A783-AD1E9C3A1828}.Release|Any CPU.Build.0 = Release|Any CPU
+		{005CFB9E-F7BA-4AD6-AF95-02FC14C728F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{005CFB9E-F7BA-4AD6-AF95-02FC14C728F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{005CFB9E-F7BA-4AD6-AF95-02FC14C728F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{005CFB9E-F7BA-4AD6-AF95-02FC14C728F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEBD0E27-E3A5-4664-BE51-96BBED7E60F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEBD0E27-E3A5-4664-BE51-96BBED7E60F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEBD0E27-E3A5-4664-BE51-96BBED7E60F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEBD0E27-E3A5-4664-BE51-96BBED7E60F0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -502,6 +514,8 @@ Global
 		{592B2922-28EC-4FCE-8953-0853DDCF3445} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{02CFB996-D984-4A89-9D49-78B0BA7C31FD} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{DCE06E60-5029-4701-A783-AD1E9C3A1828} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{005CFB9E-F7BA-4AD6-AF95-02FC14C728F9} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{EEBD0E27-E3A5-4664-BE51-96BBED7E60F0} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/CompliantCSharp/CompliantCSharp.csproj
+++ b/projects/CompliantCSharp/CompliantCSharp.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <NuGetAudit>true</NuGetAudit>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <IsPackable>false</IsPackable>
     <IsPublishable>true</IsPublishable>
   </PropertyGroup>

--- a/projects/CompliantCSharpPackage/CompliantCSharpPackage.csproj
+++ b/projects/CompliantCSharpPackage/CompliantCSharpPackage.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <OutputType>Library</OutputType>
     <NuGetAudit>true</NuGetAudit>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <IsPackable>true</IsPackable>
     <IsPublishable>false</IsPublishable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/projects/DisableNetAnalyzers/DisableNetAnalyzers.csproj
+++ b/projects/DisableNetAnalyzers/DisableNetAnalyzers.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/projects/NoEnableNetAnalyzers/NoEnableNetAnalyzers.csproj
+++ b/projects/NoEnableNetAnalyzers/NoEnableNetAnalyzers.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/props/common.props
+++ b/props/common.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <NuGetAudit>true</NuGetAudit>
   </PropertyGroup>
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_NET_analyzers.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_NET_analyzers.cs
@@ -1,0 +1,21 @@
+﻿namespace Rules.MS_Build.Use_NET_analyzers;
+
+public class Reports
+{
+    [TestCase("DisableNetAnalyzers.cs")]
+    [TestCase("NoEnableNetAnalyzers.cs")]
+    public void on_not_enabled_NET_analyzers(string project)
+       => new UseDotNetAnalyzers()
+       .ForProject(project)
+       .HasIssue(
+            new Issue("Proj1002", "Use Microsoft's .NET analyzers by setting <EnableNETAnalyzers> to true."));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    public void Projects_without_issues(string project)
+         => new UseDotNetAnalyzers()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseDotNetAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseDotNetAnalyzers.cs
@@ -1,0 +1,15 @@
+﻿namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class UseDotNetAnalyzers() : MsBuildProjectFileAnalyzer(Rule.UseDotNetAnalyzers)
+{
+    protected override bool ApplyToProps => false;
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (!context.Project.NETAnalyzersEnabled())
+        {
+            context.ReportDiagnostic(Descriptor, context.Project);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -27,6 +27,8 @@
     <Version>1.2.2</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+v1.2.3
+- Proj1002: Use Microsoft's .NET analyzers. (NEW RULE)
 v1.2.2
 - Proj0009: TargetFrameworks allowed when overriding imports. (FP)
 v1.2.1

--- a/src/DotNetProjectFile.Analyzers/Extensions/DotNetProjectFile.MsBuild.Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/DotNetProjectFile.MsBuild.Project.cs
@@ -6,6 +6,9 @@ internal static class DotNetProjectFileAnalyzerProjectExtensions
     public static bool IsPackable(this MsBuildProject project)
         => project.Property<bool?, IsPackable>(g => g.IsPackable, MsBuildDefaults.IsPackable).GetValueOrDefault();
 
+    public static bool NETAnalyzersEnabled(this MsBuildProject project)
+        => project.Property<bool?, EnableNETAnalyzers>(g => g.EnableNETAnalyzers, MsBuildDefaults.EnableNETAnalyzers).GetValueOrDefault();
+
     public static bool PackageValidationEnabled(this MsBuildProject project)
         => project.Property<bool?, EnablePackageValidation>(g => g.EnablePackageValidation, MsBuildDefaults.EnablePackageValidation).GetValueOrDefault();
 

--- a/src/DotNetProjectFile.Analyzers/IO/FileSystemSelector.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/FileSystemSelector.cs
@@ -54,7 +54,7 @@ public static class FileSystemSelector
             }
         }
         return enumerator
-            .SelectMany(d => d.EnumerateFiles(parts[parts.Length - 1]));
+            .SelectMany(d => d.EnumerateFiles(parts[^1]));
     }
 
     private sealed class RootDirectory(DirectoryInfo root) : IEnumerable<DirectoryInfo>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/EnableNETAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/EnableNETAnalyzers.cs
@@ -1,0 +1,4 @@
+﻿namespace DotNetProjectFile.MsBuild;
+
+public sealed class EnableNETAnalyzers(XElement element, Node? parent, MsBuildProject? project)
+    : Node<bool?>(element, parent, project);

--- a/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildDefaults.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildDefaults.cs
@@ -4,6 +4,7 @@ public static class MsBuildDefaults
 {
     public const bool IsPackable = true;
     public const bool NuGetAudit = true;
+    public const bool EnableNETAnalyzers = false;
     public const bool EnablePackageValidation = false;
     public const bool DevelopmentDependency = false;
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -31,6 +31,8 @@ public sealed class Project : Node
 
     public bool IsProject { get; }
 
+    public string? Sdk => Attribute();
+
     public FileInfo Path { get; }
 
     public SourceText Text { get; }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
@@ -9,6 +9,7 @@ public sealed class PropertyGroup : Node
         TargetFrameworks = Children.Typed<TargetFrameworks>();
         ImplicitUsings = Children.Typed<ImplicitUsings>();
         NuGetAudit = Children.Typed<NuGetAudit>();
+        EnableNETAnalyzers = Children.Typed<EnableNETAnalyzers>();
         OutputType = Children.Typed<OutputType>();
 
         DevelopmentDependency = Children.Typed<DevelopmentDependency>();
@@ -44,6 +45,8 @@ public sealed class PropertyGroup : Node
     public Nodes<ImplicitUsings> ImplicitUsings { get; }
 
     public Nodes<NuGetAudit> NuGetAudit { get; }
+
+    public Nodes<EnableNETAnalyzers> EnableNETAnalyzers { get; }
 
     public Nodes<OutputType> OutputType { get; }
 

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -45,6 +45,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0600** Avoid generating packages on build if not packable](https://dotnet-project-file-analyzers.github.io/rules/Proj0600.html)
 * [**Proj1000** Use the .NET project file analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1000.html)
 * [**Proj1001** Use analyzers for packages](https://dotnet-project-file-analyzers.github.io/rules/Proj1001.html)
+* [**Proj1002** Use Microsoft's analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1002.html)
 * [**Proj1003** Use Sonar analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1003.html)
 * [**Proj1100** Avoid using Moq](https://dotnet-project-file-analyzers.github.io/rules/Proj1100.html)
 * [**Proj1200** Exclude private assets as project file dependency](https://dotnet-project-file-analyzers.github.io/rules/Proj1200.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -449,12 +449,20 @@ public static class Rule
         tags: ["roslyn", "analyzer", "NuGet"],
         category: Category.CodeQuality);
 
+    public static DiagnosticDescriptor UseDotNetAnalyzers => New(
+        id: 1002,
+        title: "Use Microsoft's .NET analyzers",
+        message: "Use Microsoft's .NET analyzers by setting <EnableNETAnalyzers> to true.",
+        description: "Improve the code quality by adding Microsoft's Roslyn analyzers.",
+        tags: ["roslyn", "analyzer", "Microsoft"],
+        category: Category.CodeQuality);
+
     public static DiagnosticDescriptor UseSonarAnalyzers => New(
         id: 1003,
         title: "Use Sonar analyzers for packages",
         message: "Add {0}.",
         description: "Improve the code quality by adding Sonar's Roslyn analyzers.",
-        tags: ["roslyn", "analyzer", "NuGet", "Sonar"],
+        tags: ["roslyn", "analyzer", "Sonar"],
         category: Category.CodeQuality);
 
     public static DiagnosticDescriptor AvoidUsingMoq => New(


### PR DESCRIPTION
Enable .NET analyzers by setting `<EnableNETAnalyzers>` to `true`.

See: #27.