### PR TITLE
Proj1101: Package references should have stable versions

### DIFF
--- a/projects/UnstablePackageReferences/UnstablePackageReferences.csproj
+++ b/projects/UnstablePackageReferences/UnstablePackageReferences.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="7.0.4" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="System.Text.Json" Version="*-*" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="StyleCop.Analyzers" Version="*-*" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
@@ -3,7 +3,7 @@
 public class Reports
 {
     [Test]
-    [Ignore("Buildalizer does not output has not artifacts, hence nothing is analyzed.")]
+    [Ignore("Buildalizer does not output any artifacts, hence nothing is analyzed.")]
     public void unstable_versions()
         => new PackageReferencesShouldBeStable()
         .ForProject("UnstablePackageReferences.cs")

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
@@ -1,0 +1,23 @@
+﻿namespace Rules.MS_Build.Package_references_should_be_stable;
+
+public class Reports
+{
+    [Test]
+    [Ignore("Buildalizer does not output has not artifacts, hence nothing is analyzed.")]
+    public void unstable_versions()
+        => new PackageReferencesShouldBeStable()
+        .ForProject("UnstablePackageReferences.cs")
+        .HasIssues(
+            new Issue("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'.").WithSpan(09, 04, 09, 85),
+            new Issue("Proj1101", "Use a stable version of 'System.Text.Json', instead of *-*'." /*.................*/).WithSpan(10, 04, 10, 65));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void project_files_as_additional(string project)
+         => new AddAdditionalFile()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PackageReferencesShouldBeStable.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PackageReferencesShouldBeStable.cs
@@ -1,0 +1,20 @@
+﻿namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class PackageReferencesShouldBeStable() : MsBuildProjectFileAnalyzer(Rule.PackageReferencesShouldBeStable)
+{
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        foreach (var package in context.Project.ItemGroups
+            .SelectMany(i => i.PackageReferences)
+            .Where(IsUnstable))
+        {
+            context.ReportDiagnostic(Descriptor, package, package.IncludeOrUpdate, package.Version);
+        }
+    }
+
+    private static bool IsUnstable(PackageReference package)
+        => package.Version is { Length: > 0 } version
+        && version.Contains('-')
+        && !"ALL".Equals(package.PrivateAssets, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -24,7 +24,7 @@
     <RepositoryUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;csproj;vbproj;resx;MS Build;resources</PackageTags>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
 v1.3.1

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -27,6 +27,8 @@
     <Version>1.3.0</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+v1.3.1
+- Proj1101: Package references should have stable versions. (NEW RULE)
 v1.3.0
 - Proj0024: Order package versions alphabetically. (NEW RULE)
 - Proj1700: Indent XML. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -51,6 +51,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj1002** Use Microsoft's analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1002.html)
 * [**Proj1003** Use Sonar analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1003.html)
 * [**Proj1100** Avoid using Moq](https://dotnet-project-file-analyzers.github.io/rules/Proj1100.html)
+* [**Proj1101** Package references should have stable versions](https://dotnet-project-file-analyzers.github.io/rules/Proj1101.html)
 * [**Proj1200** Exclude private assets as project file dependency](https://dotnet-project-file-analyzers.github.io/rules/Proj1200.html)
 * [**Proj1700** Indent XML](https://dotnet-project-file-analyzers.github.io/rules/Proj1700.html)
 

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -503,6 +503,14 @@ public static class Rule
         tags: ["GDPR", "privacy"],
         category: Category.Security);
 
+    public static DiagnosticDescriptor PackageReferencesShouldBeStable => New(
+        id: 1101,
+        title: "Package references should have stable versions",
+        message: "Use a stable version of '{0}', instead of {1}.",
+        description: "The use of nightly builds and other pre-releases should be avoided.",
+        tags: ["NuGet", "Versioning"],
+        category: Category.Reliability);
+
     public static DiagnosticDescriptor ExcludePrivateAssetDependencies => New(
       id: 1200,
       title: "Exclude private assets as project file dependency",


### PR DESCRIPTION
he use of nightly builds and other pre-releases should be avoided.