### PR TITLE
Proj2100: Indent RESX

### DIFF
--- a/dictionary.dic
+++ b/dictionary.dic
@@ -1,3 +1,4 @@
 ﻿fallback
 README
+RESX
 usings

--- a/projects/FaultyIndenting/FaultyIndenting.csproj
+++ b/projects/FaultyIndenting/FaultyIndenting.csproj
@@ -12,4 +12,8 @@
 
   <ItemGroup><Folder Include="Same line" /></ItemGroup>
 
+  <PropertyGroup>
+    <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
+  </PropertyGroup>
+
 </Project>

--- a/projects/FaultyIndenting/FaultyIndenting.resx
+++ b/projects/FaultyIndenting/FaultyIndenting.resx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+   <resheader name="reader">
+    <value>System.Resources.ResXResourceReader</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter</value>
+  </resheader>
+   <data name="King" xml:space="preserve">
+    <value>King</value>
+		</data>
+  <data name="Welcome" xml:space="preserve">
+       <value>Hello, world!</value>
+  </data>
+</root>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -44,10 +44,11 @@
   <ItemGroup Label="Test projects">
     <None Include="../../projects/*/*.csproj" Visible="true" Link="Projects/C#/%(Filename)%(Extension)" />
     <None Include="../../projects/*/*.vbproj" Visible="true" Link="Projects/VB/%(Filename)%(Extension)" />
+    <None Include="../../projects/*/*.resx" Visible="true" Link="Projects/RESX/%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\DotNetProjectFile.Analyzers\DotNetProjectFile.Analyzers.csproj" />
+    <ProjectReference Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Indent_XML.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Indent_XML.cs
@@ -3,7 +3,7 @@
 public class Reports
 {
     [Test]
-    public void malicious_indented()
+    public void faultly_indented()
         => new IndentXml()
         .ForProject("FaultyIndenting.cs")
         .HasIssues(

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Indent_RESX.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Indent_RESX.cs
@@ -1,0 +1,24 @@
+﻿namespace Rules.RESX.Indent_RESX;
+
+public class Reports
+{
+    [Test]
+    public void faultly_indented()
+        => new Resx.IndentResx()
+        .ForProject("FaultyIndenting.cs")
+        .HasIssues(
+            new Issue("Proj2100", "The element <resheader> has not been properly indented." /*.*/).WithSpan(05, 03, 05, 27),
+            new Issue("Proj2100", "The element <data> has not been properly indented." /*......*/).WithSpan(11, 03, 11, 41),
+            new Issue("Proj2100", "The element </data> has not been properly indented." /*.....*/).WithSpan(13, 02, 13, 09),
+            new Issue("Proj2100", "The element <value> has not been properly indented." /*.....*/).WithSpan(15, 07, 15, 13));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project)
+         => new Resx.IndentResx()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
@@ -1,0 +1,59 @@
+﻿using DotNetProjectFile.Xml;
+using Microsoft.CodeAnalysis.Text;
+
+namespace DotNetProjectFile.Analyzers.Helpers;
+
+internal sealed class IdentationChecker<TContext>(char ch, int repeat, DiagnosticDescriptor descriptor)
+    where TContext : DiagnosticReporter
+{
+    private readonly char Char = ch;
+    private readonly int Repeat = repeat;
+    private readonly DiagnosticDescriptor Descriptor = descriptor;
+
+    public void Walk(XmlAnalysisNode node, SourceText text, TContext context)
+    {
+        Report(node, text, context, true);
+        Report(node, text, context, false);
+
+        foreach (var child in node.Children())
+        {
+            Walk(child, text, context);
+        }
+    }
+
+    private void Report(XmlAnalysisNode node, SourceText text, TContext context, bool start)
+    {
+        var checkSelfClosingEnd = !start && node.Positions.IsSelfClosing;
+        var startAndEndOnSameLine = !start && node.Positions.StartElement.End.Line == node.Positions.EndElement.Start.Line;
+
+        if (checkSelfClosingEnd || startAndEndOnSameLine) { return; }
+
+        var element = start ? node.Positions.StartElement : node.Positions.EndElement;
+
+        if (!ProperlyIndented(element))
+        {
+            var name = start ? node.LocalName : '/' + node.LocalName;
+            context.ReportDiagnostic(Descriptor, element, name);
+        }
+
+        bool ProperlyIndented(LinePositionSpan element)
+        {
+            var width = Repeat * node.Depth;
+
+            if (width != element.Start.Character)
+            {
+                return false;
+            }
+            else if (width == 0)
+            {
+                return true;
+            }
+            else
+            {
+                var span = new LinePositionSpan(new(element.Start.Line, 0), new(element.Start.Line, width));
+                var indent = text.ToString(text.Lines.GetTextSpan(span));
+                return indent.All(ch => ch == Char);
+            }
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IndentXml.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IndentXml.cs
@@ -1,62 +1,62 @@
-﻿using Microsoft.CodeAnalysis.Text;
-
-namespace DotNetProjectFile.Analyzers.MsBuild;
+﻿namespace DotNetProjectFile.Analyzers.MsBuild;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-public sealed class IndentXml(char ch, int repeat) : MsBuildProjectFileAnalyzer(Rule.IndentXml)
+public sealed class IndentXml : MsBuildProjectFileAnalyzer
 {
-    private readonly char Char = ch;
-    private readonly int Repeat = repeat;
+    private readonly IdentationChecker<ProjectFileAnalysisContext> Checker;
 
     public IndentXml() : this(' ', 2) { }
 
+    public IndentXml(char ch, int repeat) : base(Rule.IndentXml)
+        => Checker = new(ch, repeat, Descriptor);
+
     protected override void Register(ProjectFileAnalysisContext context)
-        => Walk(context.Project, context.Project, context.Project.Text, context);
+        => Checker.Walk(context.Project, context.Project.Text, context);
 
-    private void Walk(MsBuildProject project, Node node, SourceText text, ProjectFileAnalysisContext context)
-    {
-        Report(project, node, text, context, true);
-        Report(project, node, text, context, false);
+//    private void Walk(MsBuildProject project, Node node, SourceText text, ProjectFileAnalysisContext context)
+//    {
+//        Report(project, node, text, context, true);
+//        Report(project, node, text, context, false);
 
-        foreach (var child in node.Children)
-        {
-            Walk(project, child, text, context);
-        }
-    }
+//        foreach (var child in node.Children)
+//        {
+//            Walk(project, child, text, context);
+//        }
+//    }
 
-    private void Report(MsBuildProject project, Node node, SourceText text, ProjectFileAnalysisContext context, bool start)
-    {
-        var checkSelfClosingEnd = !start && node.Positions.IsSelfClosing;
-        var startAndEndOnSameLine = !start && node.Positions.StartElement.End.Line == node.Positions.EndElement.Start.Line;
+//    private void Report(MsBuildProject project, Node node, SourceText text, ProjectFileAnalysisContext context, bool start)
+//    {
+//        var checkSelfClosingEnd = !start && node.Positions.IsSelfClosing;
+//        var startAndEndOnSameLine = !start && node.Positions.StartElement.End.Line == node.Positions.EndElement.Start.Line;
 
-        if (checkSelfClosingEnd || startAndEndOnSameLine) { return; }
+//        if (checkSelfClosingEnd || startAndEndOnSameLine) { return; }
 
-        var element = start ? node.Positions.StartElement : node.Positions.EndElement;
+//        var element = start ? node.Positions.StartElement : node.Positions.EndElement;
 
-        if (!ProperlyIndented(element))
-        {
-            var name = start ? node.LocalName : '/' + node.LocalName;
-            context.ReportDiagnostic(Descriptor, project, element, name);
-        }
+//        if (!ProperlyIndented(element))
+//        {
+//            var name = start ? node.LocalName : '/' + node.LocalName;
+//            context.ReportDiagnostic(Descriptor, project, element, name);
+//        }
 
-        bool ProperlyIndented(LinePositionSpan element)
-        {
-            var width = Repeat * node.Depth;
+//        bool ProperlyIndented(LinePositionSpan element)
+//        {
+//            var width = Repeat * node.Depth;
 
-            if (width != element.Start.Character)
-            {
-                return false;
-            }
-            else if (width == 0)
-            {
-                return true;
-            }
-            else
-            {
-                var span = new LinePositionSpan(new(element.Start.Line, 0), new(element.Start.Line, width));
-                var indent = text.ToString(text.Lines.GetTextSpan(span));
-                return indent.All(ch => ch == Char);
-            }
-        }
-    }
+//            if (width != element.Start.Character)
+//            {
+//                return false;
+//            }
+//            else if (width == 0)
+//            {
+//                return true;
+//            }
+//            else
+//            {
+//                var span = new LinePositionSpan(new(element.Start.Line, 0), new(element.Start.Line, width));
+//                var indent = text.ToString(text.Lines.GetTextSpan(span));
+//                return indent.All(ch => ch == Char);
+//            }
+//        }
+//    }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Resx/IndentResx.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Resx/IndentResx.cs
@@ -1,0 +1,15 @@
+﻿namespace DotNetProjectFile.Analyzers.Resx;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class IndentResx : ResourceFileAnalyzer
+{
+    private readonly IdentationChecker<ResourceFileAnalysisContext> Checker;
+
+    public IndentResx() : this(' ', 2) { }
+
+    public IndentResx(char ch, int repeat) : base(Rule.IndentResx)
+        => Checker = new(ch, repeat, Descriptor);
+
+    protected override void Register(ResourceFileAnalysisContext context)
+        => Checker.Walk(context.Resource, context.Resource.Text, context);
+}

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/Locatable.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/Locatable.cs
@@ -1,6 +1,0 @@
-﻿namespace DotNetProjectFile.CodeAnalysis;
-
-public interface Locatable
-{
-    Location Location { get; }
-}

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/Locations.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/Locations.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.Text;
+﻿using DotNetProjectFile.Resx;
+using Microsoft.CodeAnalysis.Text;
 
 namespace DotNetProjectFile.CodeAnalysis;
 
@@ -6,4 +7,7 @@ public static class Locations
 {
     public static Location GetLocation(this MsBuildProject project, LinePositionSpan span)
         => Location.Create(project.Path.ToString(), project.Text.TextSpan(span), span);
+
+    public static Location GetLocation(this Resource resource, LinePositionSpan span)
+        => Location.Create(resource.Path.ToString(), resource.Text.TextSpan(span), span);
 }

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/DiagnosticReporter.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/DiagnosticReporter.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.CodeAnalysis.Text;
+
+namespace DotNetProjectFile.Diagnostics;
+
+public interface DiagnosticReporter
+{
+    void ReportDiagnostic(DiagnosticDescriptor descriptor, LinePositionSpan span, params object?[]? messageArgs);
+}

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ResourceFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ResourceFileAnalysisContext.cs
@@ -1,4 +1,6 @@
 ﻿using DotNetProjectFile.CodeAnalysis;
+using DotNetProjectFile.Xml;
+using Microsoft.CodeAnalysis.Text;
 
 namespace DotNetProjectFile.Diagnostics;
 
@@ -9,7 +11,7 @@ public readonly struct ResourceFileAnalysisContext(
     Compilation compilation,
     AnalyzerOptions options,
     CancellationToken cancellationToken,
-    Action<Diagnostic> report)
+    Action<Diagnostic> report) : DiagnosticReporter
 {
     /// <summary>Gets the project file.</summary>
     public readonly Resx.Resource Resource = resource;
@@ -27,6 +29,10 @@ public readonly struct ResourceFileAnalysisContext(
     private readonly Action<Diagnostic> Report = report;
 
     /// <summary>Reports a diagnostic about the project file.</summary>
-    public void ReportDiagnostic(DiagnosticDescriptor descriptor, Locatable location, params object?[]? messageArgs)
-        => Report(Diagnostic.Create(descriptor, location.Location, messageArgs));
+    public void ReportDiagnostic(DiagnosticDescriptor descriptor, XmlAnalysisNode node, params object?[]? messageArgs)
+        => ReportDiagnostic(descriptor, node.Positions.FullSpan, messageArgs);
+
+    /// <summary>Reports a diagnostic about the project file.</summary>
+    public void ReportDiagnostic(DiagnosticDescriptor descriptor, LinePositionSpan span, params object?[]? messageArgs)
+        => Report(Diagnostic.Create(descriptor, Resource.GetLocation(span), messageArgs));
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -27,6 +27,8 @@
     <Version>1.3.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased
+- Proj2100: Indent RESX. (NEW RULE)
 v1.3.1
 - Proj1101: Package references should have stable versions. (NEW RULE)
 v1.3.0

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -7,7 +7,7 @@ using System.Xml;
 namespace DotNetProjectFile.MsBuild;
 
 /// <summary>Represents node in a MS Build project file.</summary>
-public abstract class Node
+public abstract class Node : XmlAnalysisNode
 {
     /// <summary>Semi-colon separator char(s).</summary>
     protected static readonly char[] SemicolonSeparated = [';'];
@@ -100,6 +100,8 @@ public abstract class Node
 
     protected T? Convert<T>(string? value, [CallerMemberName] string? propertyName = null)
         => Converters.TryConvert<T>(value, GetType(), propertyName!);
+
+    IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
 
     private static readonly TypeConverters Converters = new();
 }

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -61,3 +61,4 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj2002** Sort resource file values alphabetically](https://dotnet-project-file-analyzers.github.io/rules/Proj2002.html)
 * [**Proj2003** Add invariant fallback resources](https://dotnet-project-file-analyzers.github.io/rules/Proj2003.html)
 * [**Proj2004** Add invariant fallback values](https://dotnet-project-file-analyzers.github.io/rules/Proj2004.html)
+* [**Proj2100** Indent RESX](https://dotnet-project-file-analyzers.github.io/rules/Proj2100.html)

--- a/src/DotNetProjectFile.Analyzers/Resx/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Node.cs
@@ -1,25 +1,26 @@
-﻿using DotNetProjectFile.CodeAnalysis;
-using DotNetProjectFile.Xml;
-using Microsoft.CodeAnalysis.Text;
+﻿using DotNetProjectFile.Xml;
 
 namespace DotNetProjectFile.Resx;
 
-public partial class Node : Locatable
+public partial class Node : XmlAnalysisNode
 {
     protected Node(XElement element, Resource? resource)
     {
         Element = element;
         Resource = resource ?? (this as Resource) ?? throw new ArgumentNullException(nameof(resource));
         Positions = XmlPositions.New(element);
+        Depth = element.Ancestors().Count();
     }
 
     internal XElement Element { get; }
 
     public Resource Resource { get; }
 
+    public int Depth { get; }
+
     public XmlPositions Positions { get; }
 
-    public Location Location => location ??= Location.Create(Resource.Path.ToString(), Resource.SourceText.TextSpan(Positions.FullSpan), Positions.FullSpan);
+    public string LocalName => Element.Name.LocalName;
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private Location? location;
@@ -36,4 +37,6 @@ public partial class Node : Locatable
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private Nodes<Node>? children;
+
+    IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children();
 }

--- a/src/DotNetProjectFile.Analyzers/Resx/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Node.cs
@@ -22,9 +22,6 @@ public partial class Node : XmlAnalysisNode
 
     public string LocalName => Element.Name.LocalName;
 
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private Location? location;
-
     /// <summary>Gets the a <see cref="Nodes{T}"/> of children.</summary>
     public Nodes<T> Children<T>() where T : Node => new(this);
 

--- a/src/DotNetProjectFile.Analyzers/Resx/Resource.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Resource.cs
@@ -18,7 +18,7 @@ public sealed class Resource : Node
         : base(element, null)
     {
         Path = path;
-        SourceText = sourceText;
+        Text = sourceText;
         IsXml = isXml;
         Resources = resources;
         Headers = Children<ResHeader>();
@@ -32,7 +32,7 @@ public sealed class Resource : Node
 
     public ResourceFileInfo Path { get; }
 
-    public SourceText SourceText { get; }
+    public SourceText Text { get; }
 
     public CultureInfo Culture => Path.Culture;
 

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -576,6 +576,14 @@ public static class Rule
        tags: ["resx", "resources", "invariant", "localization"],
        category: Category.Bug);
 
+    public static DiagnosticDescriptor IndentResx => New(
+      id: 2100,
+      title: "Indent XML files",
+      message: "The element <{0}> has not been properly indented.",
+      description: "To improve readability, XML elements should be properly indented.",
+      tags: ["XML", "indentation"],
+      category: Category.Formatting);
+
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
     public static DiagnosticDescriptor New(

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
@@ -1,0 +1,12 @@
+﻿namespace DotNetProjectFile.Xml;
+
+public interface XmlAnalysisNode
+{
+    XmlPositions Positions { get; }
+
+    public string LocalName { get; }
+
+    public int Depth { get; }
+
+    IEnumerable<XmlAnalysisNode> Children();
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
@@ -4,9 +4,9 @@ public interface XmlAnalysisNode
 {
     XmlPositions Positions { get; }
 
-    public string LocalName { get; }
+    string LocalName { get; }
 
-    public int Depth { get; }
+    int Depth { get; }
 
     IEnumerable<XmlAnalysisNode> Children();
 }


### PR DESCRIPTION
Simalar to #135 , also RESX files should be properly indented.

The reason that this is a separate rule is both that it can be turned on/of independently, but also because project files and RESX files have a different analyzer context. 