### PR TITLE
Include `Directory.Packages.props` when regestering actions

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
@@ -15,7 +15,8 @@ public class Reports
     public void unstable_versions_via_CPM()
         => new PackageReferencesShouldBeStable()
         .ForProject("UnstableVersionsCPM.cs")
-        .HasIssue(
+        .HasIssues(
+            new Issue("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'.").WithSpan(08, 04, 08, 84),
             new Issue("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'.").WithSpan(08, 04, 08, 94));
 }
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -77,6 +77,11 @@ public sealed class Project : Node
             yield return DirectoryBuildProps;
         }
 
+        if (DirectoryPackagesProps is { })
+        {
+            yield return DirectoryPackagesProps;
+        }
+
         foreach (var import in Imports)
         {
             if (import.Value is { } project)
@@ -94,6 +99,7 @@ public sealed class Project : Node
     public IEnumerable<Project> SelfAndImports()
     {
         yield return this;
+
         foreach (var import in Imports)
         {
             if (import.Value is { } project)


### PR DESCRIPTION
Was missing.