### PR TITLE
Proj0803: Only use VersionOverride when CPM is enabled

### DIFF
--- a/projects/MisuseVersionOverride/MisuseVersionOverride.csproj
+++ b/projects/MisuseVersionOverride/MisuseVersionOverride.csproj
@@ -1,12 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Qowaiv" VersionOverride="7.0.4" />
+  <ItemGroup Label="Version is also added to satisfy Buildalizer">
+    <PackageReference Include="Qowaiv" Version="7.0.3" VersionOverride="7.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/projects/UseCPM/Directory.Packages.props
+++ b/projects/UseCPM/Directory.Packages.props
@@ -5,6 +5,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Qowaiv" Version="7.0.0" />
+  </ItemGroup>
   
   <ItemGroup>
     <AdditionalFiles Include="Directory.Packages.props" Link="Properties/Directory.Packages.props" />

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_VersionOverride_only_with_CPM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_VersionOverride_only_with_CPM.cs
@@ -1,0 +1,27 @@
+﻿namespace Rules.MS_Build.Use_VersionOverride_only_with_CPM;
+
+public class Reports
+{
+    [Test]
+    public void project_with_VersionOverride_without_CPM()
+        => new UseVersionOverrideOnlyWithCpm()
+        .ForProject("MisuseVersionOverride.cs")
+        .HasIssue(new Issue("Proj0803", "Use Version instead of VersionOverride when CPM is not enabled.")
+        .WithSpan(07, 04, 07, 81));
+}
+
+public class Guards
+{
+    [Test]
+    public void project_with_VersionOverride_with_CPM_enabled()
+       => new UseVersionOverrideOnlyWithCpm()
+       .ForProject("UseCPM.cs")
+       .HasNoIssues();
+
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_withtout_VersionOverride(string project)
+         => new UseVersionOverrideOnlyWithCpm()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseVersionOverrideOnlyWithCpm.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseVersionOverrideOnlyWithCpm.cs
@@ -1,0 +1,19 @@
+﻿namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class UseVersionOverrideOnlyWithCpm()
+    : MsBuildProjectFileAnalyzer(Rule.UseVersionOverrideOnlyWithCpm)
+{
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (context.Project.ManagePackageVersionsCentrally() is not true)
+        {
+            foreach (var reference in context.Project.ItemGroups
+                .SelectMany(g => g.PackageReferences)
+                .Where(r => r.VersionOverride is { Length: > 0 }))
+            {
+                context.ReportDiagnostic(Descriptor, reference);
+            }
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -31,6 +31,7 @@ ToBeReleased
 - Proj0800: Configure CPM. (NEW RULE)
 - Proj0801: Include CPM file. (NEW RULE)
 - Proj0802: Enable Central Package Management centrally. (NEW RULE)
+- Proj0803: Only use VersionOverride when CPM is enabled. (NEW RULE)
 = Proj1101: Report on &lt;PackageVersion&gt; too. (FN) 
 = Proj1101: Report on &lt;PackageReference VersionOverride&gt; too. (FN) 
 - Proj2100: Indent RESX. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -55,6 +55,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0800** Configure Central Package Management](https://dotnet-project-file-analyzers.github.io/rules/Proj0800.html)
 * [**Proj0801** Include 'Directory.Packages.props'](https://dotnet-project-file-analyzers.github.io/rules/Proj0801.html)
 * [**Proj0802** Enable Central Package Management centrally](https://dotnet-project-file-analyzers.github.io/rules/Proj0802.html)
+* [**Proj0803** Only use VersionOverride when CPM is enabled](https://dotnet-project-file-analyzers.github.io/rules/Proj0803.html)
 
 ### Analyzers
 * [**Proj1000** Use the .NET project file analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1000.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -483,7 +483,15 @@ public static class Rule
         title: "Enable Central Package Management centrally",
         message: "Enable <ManagePackageVersionsCentrally> in 'Directory.Packages.props' or a shared props file.",
         description: "Enabling it per project would defy the purpose of CPM.",
-        tags: ["Maintanability"],
+        tags: ["Maintainability"],
+        category: Category.CPM);
+
+    public static DiagnosticDescriptor UseVersionOverrideOnlyWithCpm => New(
+        id: 0803,
+        title: "Use VersionOverride only with Central Package Management enabled",
+        message: "Use Version instead of VersionOverride when CPM is not enabled.",
+        description: "Enabling it per project would defy the purpose of CPM.",
+        tags: ["Maintainability"],
         category: Category.CPM);
 
     public static DiagnosticDescriptor UseDotNetProjectFileAnalyzers => New(

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -490,7 +490,9 @@ public static class Rule
         id: 0803,
         title: "Use VersionOverride only with Central Package Management enabled",
         message: "Use Version instead of VersionOverride when CPM is not enabled.",
-        description: "Enabling it per project would defy the purpose of CPM.",
+        description:
+            "When CPM is not enabled the use of <PackageReference VersionOveride /> " +
+            "`has no effect, and is most likely a mistake.",
         tags: ["Maintainability"],
         category: Category.CPM);
 


### PR DESCRIPTION
When CPM is not enabled the use of `<PackageReference VersionOveride />` is pointless, and most likely a mistake.

See #130 