### PR TITLE
Do not check for unstable versions in <PackageVersion> but at the loc…

### DIFF
--- a/projects/UnstableVersionsCPM/Directory.Packages.props
+++ b/projects/UnstableVersionsCPM/Directory.Packages.props
@@ -3,9 +3,11 @@
 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="StyleCop.Analyzers" Version="*-*" />
     <PackageVersion Include="System.IO.Hashing" Version="9.0.0-preview.7.24405.7" />
   </ItemGroup>
   

--- a/projects/UnstableVersionsCPM/UnstableVersionsCPM.csproj
+++ b/projects/UnstableVersionsCPM/UnstableVersionsCPM.csproj
@@ -6,11 +6,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Hashing" VersionOverride="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="System.IO.Hashing" />
+    <PackageReference Update="System.IO.Hashing" VersionOverride="9.0.0-preview.7.24405.7" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzer">
+    <ProjectReference
+      Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj"
+      PrivateAssets="all"
+      ReferenceOutputAssembly="false"
+      OutputItemType="Analyzer"
+      SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
 </Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -45,6 +45,7 @@
     <None Include="../../projects/*/*.csproj" Visible="true" Link="Projects/C#/%(Filename)%(Extension)" />
     <None Include="../../projects/*/*.vbproj" Visible="true" Link="Projects/VB/%(Filename)%(Extension)" />
     <None Include="../../projects/*/*.resx" Visible="true" Link="Projects/RESX/%(Filename)%(Extension)" />
+    <None Include="../../projects/*/*.props" Visible="true" Link="Projects/Props/%(Directory)/%(Filename)%(Extension)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
@@ -16,8 +16,8 @@ public class Reports
         => new PackageReferencesShouldBeStable()
         .ForProject("UnstableVersionsCPM.cs")
         .HasIssues(
-            new Issue("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'.").WithSpan(08, 04, 08, 84),
-            new Issue("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'.").WithSpan(08, 04, 08, 94));
+            new Issue("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'.").WithSpan(08, 04, 08, 52),
+            new Issue("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'.").WithSpan(09, 04, 09, 93));
 }
 
 public class Guards

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PackageReferencesShouldBeStable.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PackageReferencesShouldBeStable.cs
@@ -9,23 +9,12 @@ public sealed class PackageReferencesShouldBeStable() : MsBuildProjectFileAnalyz
             .SelectMany(i => i.PackageReferences)
             .Where(IsUnstable))
         {
-            context.ReportDiagnostic(Descriptor, package, package.IncludeOrUpdate, package.VersionOrVersionOverride);
-        }
-
-        foreach (var package in context.Project.ItemGroups
-            .SelectMany(i => i.PackageVersions)
-            .Where(IsUnstable))
-        {
-            context.ReportDiagnostic(Descriptor, package, package.IncludeOrUpdate, package.Version);
+            context.ReportDiagnostic(Descriptor, package, package.IncludeOrUpdate, package.ResolveVersion());
         }
     }
 
     private static bool IsUnstable(PackageReference package)
-        => package.VersionOrVersionOverride is { Length: > 0 } version
+        => package.ResolveVersion() is { Length: > 0 } version
         && version.Contains('-')
         && !"ALL".Equals(package.PrivateAssets, StringComparison.OrdinalIgnoreCase);
-
-    private static bool IsUnstable(PackageVersion package)
-        => package.Version is { Length: > 0 } version
-        && version.Contains('-');
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -29,6 +29,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased
+- Proj1101: Resolve version in project files only. (FP)
 - Proj1701: Use <![CDATA[ for large texts. (NEW RULE)
 v1.4.0
 - Proj0800: Configure CPM. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
@@ -1,4 +1,6 @@
-﻿namespace DotNetProjectFile.MsBuild;
+﻿using DotNetProjectFile.NuGet;
+
+namespace DotNetProjectFile.MsBuild;
 
 public sealed class PackageReference(XElement element, Node parent, MsBuildProject project)
     : Node(element, parent, project)
@@ -16,4 +18,14 @@ public sealed class PackageReference(XElement element, Node parent, MsBuildProje
     public string VersionOrVersionOverride => Version ?? VersionOverride ?? string.Empty;
 
     public string? PrivateAssets => Attribute() ?? Child();
+
+    /// <summary>Resolves the version taking CPM into account.</summary>
+    public string? ResolveVersion()
+        => Project.ManagePackageVersionsCentrally() is true
+            ? VersionOverride ?? Project
+            .ImportsAndSelf()
+            .SelectMany(g => g.ItemGroups)
+            .SelectMany(v => v.PackageVersions)
+            .LastOrDefault(v => v.Include == IncludeOrUpdate)?.Version
+        : Version;
 }


### PR DESCRIPTION
With CPM enabled, it is not possible (a the `Directory.Packages.props`) to check if the version is used with `PrivateAssets="all"` to allow those releases even if they are nightlies or beta's. With this fix, the actual version is resolved for every `<PackageReference>` in based on the version and if  `PrivateAssets="all"` is set, the warnings are generated (or not).

Closes #158 