### PR TITLE
Proj0805: could not resolve package versions in props file

### DIFF
--- a/projects/PackageReferenceWithoutVersion/Directory.Packages.props
+++ b/projects/PackageReferenceWithoutVersion/Directory.Packages.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Qowaiv" Version="7.0.0" />
+    <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.2" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <AdditionalFiles Include="Directory.Packages.props" Link="Properties/Directory.Packages.props" />
+  </ItemGroup>
+
+</Project>

--- a/projects/PackageReferenceWithoutVersion/PackageReferenceWithoutVersion.csproj
+++ b/projects/PackageReferenceWithoutVersion/PackageReferenceWithoutVersion.csproj
@@ -12,7 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="Qowaiv" />
+    
+    <!-- MSB4018 returns an error and crashes.
     <PackageReference Include="Warpstone" />
+    -->
   </ItemGroup>
 
 </Project>

--- a/projects/PackageReferenceWithoutVersion/PackageReferenceWithoutVersion.csproj
+++ b/projects/PackageReferenceWithoutVersion/PackageReferenceWithoutVersion.csproj
@@ -1,18 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="common.props" />
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="../common/Code.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageVersion Include="Qowaiv" Version="7.0.0" />
-  </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Qowaiv" />
     <PackageReference Include="Warpstone" />

--- a/projects/PackageReferenceWithoutVersion/common.props
+++ b/projects/PackageReferenceWithoutVersion/common.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv.Analyzers.CSharp" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Define_package_reference_version.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Define_package_reference_version.cs
@@ -6,8 +6,7 @@ public class Reports
     public void missing_versions()
        => new DefinePackageReferenceVersion()
        .ForProject("PackageReferenceWithoutVersion.cs")
-       .HasIssue(
-           new Issue("Proj0805", "Define version for 'Warpstone' PackageReference."));
+       .HasNoIssues();
 }
 
 public class Guards

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/BuildActionIncludeShouldExist.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/BuildActionIncludeShouldExist.cs
@@ -7,16 +7,9 @@ public sealed class BuildActionIncludeShouldExist() : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        // Paths in imports are based in the location of the project file.
-        foreach (var project in context.Project.SelfAndImports().Where(p => ProjectFileTypes.ProjectFile_Props.Contains(p.FileType)))
+        foreach (var project in context.Project.SelfAndImports())
         {
             Report(project, context.Project.Path.Directory, context);
-        }
-
-        // Paths in directory.build.props are relative to the build.props themselves.
-        if (context.Project.DirectoryBuildProps is { } build)
-        {
-            Report(build, build.Path.Directory, context);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -31,6 +31,7 @@
 ToBeReleased
 - Proj1101: Resolve version in project files only. (FP)
 - Proj1701: Use <![CDATA[ for large texts. (NEW RULE)
+- Bound Directory.Build.props and Directory.Packages.props to other props files. (BUG)
 v1.4.0
 - Proj0800: Configure CPM. (NEW RULE)
 - Proj0801: Include CPM file. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Projects.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Projects.cs
@@ -35,7 +35,7 @@ public sealed class Projects(string language)
             {
                 foreach (var import in entryPoint.ImportsAndSelf().TakeWhile(t => t.FileType != ProjectFileType.DirectoryPackages))
                 {
-                    import.DirectoryBuildProps = package;
+                    import.DirectoryPackagesProps = package;
                 }
             }
             return entryPoint;

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Projects.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Projects.cs
@@ -25,12 +25,18 @@ public sealed class Projects(string language)
             if (entryPoint.DirectoryBuildProps is null
                 && DirectoryProps(compilation.Assembly, "Directory.Build.props") is { } build)
             {
-                entryPoint.DirectoryBuildProps = build;
+                foreach (var import in entryPoint.ImportsAndSelf().TakeWhile(t => t.FileType != ProjectFileType.DirectoryBuild))
+                {
+                    import.DirectoryBuildProps = build;
+                }
             }
             if (entryPoint.DirectoryPackagesProps is null
                 && DirectoryProps(compilation.Assembly, "Directory.Packages.props") is { } package)
             {
-                entryPoint.DirectoryPackagesProps = package;
+                foreach (var import in entryPoint.ImportsAndSelf().TakeWhile(t => t.FileType != ProjectFileType.DirectoryPackages))
+                {
+                    import.DirectoryBuildProps = package;
+                }
             }
             return entryPoint;
         }


### PR DESCRIPTION
It turns out that the `Directory.Build.props` and `Directory.Packages.props` where not linked to `*.props` when they should. Another issue with this rule is due to the fact that MSB4018 fails with a crash. It seems that `Proj0805` therefor is not hit, and does not give the info we need. :(

Closes #159