### PR TITLE
Proj1702: Omit XML declarations

### DIFF
--- a/projects/XmlDeclaration/XmlDeclaration.csproj
+++ b/projects/XmlDeclaration/XmlDeclaration.csproj
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Ommit_XML_declaration.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Ommit_XML_declaration.cs
@@ -1,4 +1,4 @@
-﻿namespace Rules.MS_Build.Ommit_XML_declaration;
+﻿namespace Rules.MS_Build.Omit_XML_declaration;
 
 public class Reports
 {

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Ommit_XML_declaration.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Ommit_XML_declaration.cs
@@ -1,0 +1,21 @@
+﻿namespace Rules.MS_Build.Ommit_XML_declaration;
+
+public class Reports
+{
+    [Test]
+    public void on_double_imports()
+       => new OmitXmlDeclarations()
+       .ForProject("XmlDeclaration.cs")
+       .HasIssue(new Issue("Proj1702", "Remove the XML declaration as it is redundant.")
+       .WithSpan(00, 00, 01, 00));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project)
+         => new OmitXmlDeclarations()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OmitXmlDeclarations.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OmitXmlDeclarations.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.CodeAnalysis.Text;
+
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class OmitXmlDeclarations() : MsBuildProjectFileAnalyzer(Rule.OmitXmlDeclarations)
+{
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (context.Project.Element.Document.Declaration is { })
+        {
+            var span = new LinePositionSpan(default, context.Project.Positions.StartElement.Start);
+            context.ReportDiagnostic(Descriptor, span);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -24,11 +24,11 @@
     <RepositoryUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;csproj;vbproj;resx;MS Build;resources</PackageTags>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
-ToBeReleased
+v1.4.1
 - Proj1101: Resolve version in project files only. (FP)
 - Proj1701: Use <![CDATA[ for large texts. (NEW RULE)
 - Proj1702: Omit XML declarations. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -31,6 +31,7 @@
 ToBeReleased
 - Proj1101: Resolve version in project files only. (FP)
 - Proj1701: Use <![CDATA[ for large texts. (NEW RULE)
+- Proj1702: Omit XML declarations. (NEW RULE)
 - Bound Directory.Build.props and Directory.Packages.props to other props files. (BUG)
 v1.4.0
 - Proj0800: Configure CPM. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -5,7 +5,12 @@ namespace DotNetProjectFile.MsBuild;
 public sealed class Project : Node
 {
     private Project(IOFile path, SourceText text, Projects projects, AdditionalText? additionalText)
-        : base(XElement.Parse(text.ToString(), LoadOptions), null, null)
+        : this(path, text, XDocument.Parse(text.ToString(), LoadOptions), projects, additionalText)
+    {
+    }
+
+    private Project(IOFile path, SourceText text, XDocument document, Projects projects, AdditionalText? additionalText)
+        : base(document.Root, null, null)
     {
         Path = path;
         Text = text;

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -70,6 +70,7 @@ The package contains analyzers that analyze .NET project files.
 ### Formatting
 * [**Proj1700** Indent XML](https://dotnet-project-file-analyzers.github.io/rules/Proj1700.html)
 * [**Proj1701** Use CDATA for large texts](https://dotnet-project-file-analyzers.github.io/rules/Proj1701.html)
+* [**Proj1702** Omit XML declarations](https://dotnet-project-file-analyzers.github.io/rules/Proj1702.html)
 
 ### Other
 * [**Proj1100** Avoid using Moq](https://dotnet-project-file-analyzers.github.io/rules/Proj1100.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -616,6 +616,14 @@ public static class Rule
         tags: ["XML", "CDATA"],
         category: Category.Formatting);
 
+    public static DiagnosticDescriptor OmitXmlDeclarations => New(
+        id: 1702,
+        title: "Omit XML declarations",
+        message: "Remove the XML declaration as it is redundant.",
+        description: "The XML declaration is redundant for MS Build project files.",
+        tags: ["XML", "declaration"],
+        category: Category.Formatting);
+
     public static DiagnosticDescriptor EmbedValidResourceFiles => New(
         id: 2000,
         title: "Embed valid resource files",


### PR DESCRIPTION
The XML declaration is redundant for MS Build project files.