### PR TITLE
Remove XML declarations from test props files

### DIFF
--- a/projects/BloatedDirectoryPackagesProps/Directory.Packages.props
+++ b/projects/BloatedDirectoryPackagesProps/Directory.Packages.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/projects/EnableCPMLocally/Directory.Packages.props
+++ b/projects/EnableCPMLocally/Directory.Packages.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/projects/MisuseVersion/Directory.Packages.props
+++ b/projects/MisuseVersion/Directory.Packages.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/projects/TargetFrameworksSingleWithBase/common.props
+++ b/projects/TargetFrameworksSingleWithBase/common.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/projects/UnstableVersionsCPM/Directory.Packages.props
+++ b/projects/UnstableVersionsCPM/Directory.Packages.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/projects/UseCPM/Directory.Packages.props
+++ b/projects/UseCPM/Directory.Packages.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/projects/VersionUpdateNotDifferent/Directory.Packages.props
+++ b/projects/VersionUpdateNotDifferent/Directory.Packages.props
@@ -1,14 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
+
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-  <ItemGroup>
+  
+    <ItemGroup>
     <PackageVersion Include="Qowaiv" Version="7.0.4" />
     <PackageVersion Include="System.Text.Json" Version="6.0.9" />
   </ItemGroup>
+  
   <ItemGroup>
     <AdditionalFiles Include="Directory.Packages.props" Link="Properties/Directory.Packages.props" />
   </ItemGroup>
+
 </Project>

--- a/projects/props/DoublePackageReferences.props
+++ b/projects/props/DoublePackageReferences.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <ItemGroup>

--- a/projects/props/common.props
+++ b/projects/props/common.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/projects/props/common1.props
+++ b/projects/props/common1.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/projects/props/common2.props
+++ b/projects/props/common2.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <Import Project="common1.props"/>

--- a/projects/props/simple.props
+++ b/projects/props/simple.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <ItemGroup>

--- a/props/common.props
+++ b/props/common.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <PropertyGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Use_Directory_Packages_props_only_for_CPM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Use_Directory_Packages_props_only_for_CPM.cs
@@ -7,10 +7,10 @@ public class Reports
         => new UseDirectoryPackagesPropsOnlyForCPM()
         .ForProject("BloatedDirectoryPackagesProps.cs")
         .HasIssues(
-            new Issue("Proj0807", "As <TargetFramework> is not about Central Package Management it should not be in Directory.Packages.props." /*..*/).WithSpan(04, 04, 04, 53),
-            new Issue("Proj0807", "As <OutputType> is not about Central Package Management it should not be in Directory.Packages.props." /*.......*/).WithSpan(05, 04, 05, 36),
-            new Issue("Proj0807", "As <PackageReference> is not about Central Package Management it should not be in Directory.Packages.props." /*.*/).WithSpan(22, 04, 22, 64),
-            new Issue("Proj0807", "As <AdditionalFiles> is not about Central Package Management it should not be in Directory.Packages.props." /*..*/).WithSpan(27, 04, 27, 38));
+            new Issue("Proj0807", "As <TargetFramework> is not about Central Package Management it should not be in Directory.Packages.props." /*..*/).WithSpan(03, 04, 03, 53),
+            new Issue("Proj0807", "As <OutputType> is not about Central Package Management it should not be in Directory.Packages.props." /*.......*/).WithSpan(04, 04, 04, 36),
+            new Issue("Proj0807", "As <PackageReference> is not about Central Package Management it should not be in Directory.Packages.props." /*.*/).WithSpan(21, 04, 21, 64),
+            new Issue("Proj0807", "As <AdditionalFiles> is not about Central Package Management it should not be in Directory.Packages.props." /*..*/).WithSpan(26, 04, 26, 38));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_package_references_once.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_package_references_once.cs
@@ -7,8 +7,8 @@ public class Reports
        => new IncludePackageReferencesOnce()
        .ForProject("DoublePackageReferences.cs")
        .HasIssues(
-            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(05, 04, 05, 57),
-            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(06, 04, 06, 56),
+            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(04, 04, 04, 57),
+            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(05, 04, 05, 56),
             new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(10, 04, 10, 57),
             new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(11, 04, 11, 57),
             new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(13, 04, 13, 56));

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Reassign_properties_with_different_value.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Reassign_properties_with_different_value.cs
@@ -7,9 +7,9 @@ public class Reports
        => new ReassignPropertiesWithDifferentValue()
        .ForProject("ReassignProperties.cs")
        .HasIssues(
-            new Issue("Proj0012", "Property <OutputType> has been previously defined with the same value.").WithSpan(/*.*/6, 04, 6, 36),
-            new Issue("Proj0012", "Property <Nullable> has been previously defined with the same value.").WithSpan(/*...*/6, 04, 6, 31),
-            new Issue("Proj0012", "Property <OutputType> has been previously defined with the same value.").WithSpan(/*.*/7, 04, 7, 36));
+            new Issue("Proj0012", "Property <OutputType> has been previously defined with the same value." /*.*/).WithSpan(05, 04, 05, 36),
+            new Issue("Proj0012", "Property <Nullable> has been previously defined with the same value." /*...*/).WithSpan(06, 04, 06, 31),
+            new Issue("Proj0012", "Property <OutputType> has been previously defined with the same value." /*.*/).WithSpan(07, 04, 07, 36));
 }
 
 public class Guards


### PR DESCRIPTION
Just apply [Proj1702](https://dotnet-project-file-analyzers.github.io/rules/Proj1702.html) to are test examples as much as possible.