### PR TITLE
Proj1200: Microsoft.NET.Test.Sdk should be considered a private asset

### DIFF
--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -28,6 +28,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased
+- Proj1200: Microsoft.NET.Test.Sdk should be considered a private asset. (FN)
 v1.4.1
 - Proj1101: Resolve version in project files only. (FP)
 - Proj1701: Use <![CDATA[ for large texts. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
@@ -41,6 +41,7 @@ public sealed class Packages : IReadOnlyCollection<Package>
         // Private assets
         new Package("coverlet.collector", isPrivateAsset: true),
         new Package("coverlet.msbuild", isPrivateAsset: true),
+        new Package("Microsoft.NET.Test.Sdk", isPrivateAsset: true),
         new Package("NUnit3TestAdapter", isPrivateAsset: true),
         new Package("Polyfill", isPrivateAsset: true),
         new Package("PolySharp", isPrivateAsset: true),


### PR DESCRIPTION
It's an SDK dependency that does only adjust the build targets.