### PR TITLE
Enable own analyzer for specs project

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -18,8 +18,9 @@
 
   <ItemGroup>
     <AdditionalFiles Include="../../props/common.props" Link="Properties/common.props" />
+    <AdditionalFiles Include="*.csproj" Visible="false" />
   </ItemGroup>
-
+  
   <ItemGroup Label="Analyzers">
     <PackageReference Include="AsyncFixer" Version="*-*" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="*" />

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -8,11 +8,16 @@
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Specs</RootNamespace>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <OutputType>library</OutputType>
   </PropertyGroup>
 
   <PropertyGroup Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">
     <DefineConstants>Is_Windows</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Label="Project under test">
+    <ProjectReference Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
@@ -23,7 +28,6 @@
   <ItemGroup Label="Test tools">
     <PackageReference Include="CodeAnalysis.TestTools" Version="3.*" />
     <PackageReference Include="FluentAssertions" Version="6.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="NuGet.Common" Version="6.*" />
     <PackageReference Include="NuGet.Frameworks" Version="6.*" />
     <PackageReference Include="NuGet.Packaging" Version="6.*" />
@@ -33,6 +37,7 @@
   <ItemGroup Label="Build tools">
     <PackageReference Include="coverlet.collector" Version="*" PrivateAssets="all" />
     <PackageReference Include="coverlet.msbuild" Version="*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" PrivateAssets="all" />
     <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
@@ -41,15 +46,21 @@
     <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup Label="Analyzer">
+    <!-- #pragma disable Proj0014 -->
+    <ProjectReference
+      Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj"
+      PrivateAssets="all"
+      ReferenceOutputAssembly="false"
+      OutputItemType="Analyzer"
+      SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+
   <ItemGroup Label="Test projects">
     <None Include="../../projects/*/*.csproj" Visible="true" Link="Projects/C#/%(Filename)%(Extension)" />
     <None Include="../../projects/*/*.vbproj" Visible="true" Link="Projects/VB/%(Filename)%(Extension)" />
     <None Include="../../projects/*/*.resx" Visible="true" Link="Projects/RESX/%(Filename)%(Extension)" />
     <None Include="../../projects/*/*.props" Visible="true" Link="Projects/Props/%(Directory)/%(Filename)%(Extension)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -176,8 +176,4 @@ v1.0.0
     <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="*.csproj" Visible="false" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
It is a nice way to test our rules on our own test project. We have a unit test that already checks are main project, but that mechanism does not (yet) support projects with a project reference.

Note that we cannot - with this mechanism - add our analyzers to the project defining them.