### PR TITLE
Proj0452 & Proj0453: Microsoft.NET.Test.Sdk and IsTestProject should tell the same story

### DIFF
--- a/projects/TestProjectWithoutSdk/TestProjectWithoutSdk.csproj
+++ b/projects/TestProjectWithoutSdk/TestProjectWithoutSdk.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/projects/TestSdkOnly/TestSdkOnly.csproj
+++ b/projects/TestSdkOnly/TestSdkOnly.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Label="Build tools">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" PrivateAssets="all" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -48,12 +48,7 @@
 
   <ItemGroup Label="Analyzer">
     <!-- #pragma disable Proj0014 -->
-    <ProjectReference
-      Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj"
-      PrivateAssets="all"
-      ReferenceOutputAssembly="false"
-      OutputItemType="Analyzer"
-      SetTargetFramework="TargetFramework=netstandard2.0" />
+    <ProjectReference Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj" PrivateAssets="all" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test projects">

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
@@ -8,6 +8,13 @@ public class Reports
         .ForProject("TestProjectWithoutSdk.cs")
         .HasIssue(new Issue("Proj0452", @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />.")
         .WithSpan(00, 00, 11, 10));
+
+    [Test]
+    public void SDK_without_test_project()
+        => new TestProjectsRequireSdk()
+        .ForProject("TestSdkOnly.cs")
+        .HasIssue(new Issue("Proj0453", "Set <IsTestProject> to true.")
+        .WithSpan(00, 00, 14, 10));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
@@ -1,0 +1,27 @@
+﻿namespace Rules.MS_Build.Test_projects.Require_SDK;
+
+public class Reports
+{
+    [Test]
+    public void publishable_test_project()
+        => new TestProjectsRequireSdk()
+        .ForProject("TestProjectWithoutSdk.cs")
+        .HasIssue(new Issue("Proj0452", @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />.")
+        .WithSpan(00, 00, 11, 10));
+}
+
+public class Guards
+{
+    [Test]
+    public void non_publishable_test_project()
+        => new TestProjectsRequireSdk()
+        .ForProject("TestProject.cs")
+        .HasNoIssues();
+
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void non_test_project(string project)
+         => new TestProjectsRequireSdk()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_packable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_packable.cs
@@ -1,4 +1,4 @@
-﻿namespace Rules.MS_Build.Test_project_should_not_be_packable;
+﻿namespace Rules.MS_Build.Test_projects.Should_not_be_packable;
 
 public class Reports
 {

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_publishable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_publishable.cs
@@ -1,4 +1,4 @@
-﻿namespace Rules.MS_Build.Test_project_should_not_be_publishable;
+﻿namespace Rules.MS_Build.Test_projects.Should_not_be_publishable;
 
 public class Reports
 {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
@@ -1,17 +1,26 @@
 ﻿namespace DotNetProjectFile.Analyzers.MsBuild;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-public sealed class TestProjectsRequireSdk() : MsBuildProjectFileAnalyzer(Rule.TestProjectsRequireSdk)
+public sealed class TestProjectsRequireSdk() : MsBuildProjectFileAnalyzer(
+    Rule.TestProjectsRequireSdk,
+    Rule.UsingMicrosoftNetTestSdkImpliesTestProject)
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.IsTestProject() && context.Project
+        var isTest = context.Project.IsTestProject();
+        var hasSdk = context.Project
             .SelfAndImports()
             .SelectMany(p => p.ItemGroups)
             .SelectMany(g => g.PackageReferences)
-            .None(r => r.IncludeOrUpdate == "Microsoft.NET.Test.Sdk"))
+            .Any(r => r.IncludeOrUpdate == NuGet.Packages.Microsoft_NET_Test_Sdk.Name);
+
+        if (isTest && !hasSdk)
         {
-            context.ReportDiagnostic(Descriptor, context.Project);
+            context.ReportDiagnostic(Rule.TestProjectsRequireSdk, context.Project);
+        }
+        else if (!isTest && hasSdk)
+        {
+            context.ReportDiagnostic(Rule.UsingMicrosoftNetTestSdkImpliesTestProject, context.Project);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
@@ -1,0 +1,17 @@
+﻿namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class TestProjectsRequireSdk() : MsBuildProjectFileAnalyzer(Rule.TestProjectsRequireSdk)
+{
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (context.Project.IsTestProject() && context.Project
+            .SelfAndImports()
+            .SelectMany(p => p.ItemGroups)
+            .SelectMany(g => g.PackageReferences)
+            .None(r => r.IncludeOrUpdate == "Microsoft.NET.Test.Sdk"))
+        {
+            context.ReportDiagnostic(Descriptor, context.Project);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -31,6 +31,8 @@ ToBeReleased
 - Proj02??: Do not report on projects with <IsTestProject> set to true. (FP)
 - Proj0450: Test projects should not be packable. (NEW RULE)
 - Proj0451: Test projects should not be publishable. (NEW RULE)
+- Proj0452: Test projects require Microsoft.NET.Test.Sdk. (NEW RULE)
+- Proj0453: Using Microsoft.NET.Test.Sdk implies a test project. (NEW RULE)
 - Proj1200: Added 48 more compile-time dependencies to the private-asset list. (FN)
 v1.4.1
 - Proj1101: Resolve version in project files only. (FP)

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
@@ -2,6 +2,8 @@
 
 public sealed class Packages : IReadOnlyCollection<Package>
 {
+    public static readonly Package Microsoft_NET_Test_Sdk = new("Microsoft.NET.Test.Sdk", isPrivateAsset: true);
+
     public static readonly Packages All = new(
 
         // Generic analyzers
@@ -97,7 +99,7 @@ public sealed class Packages : IReadOnlyCollection<Package>
         // Private assets
         new Package("coverlet.collector", isPrivateAsset: true),
         new Package("coverlet.msbuild", isPrivateAsset: true),
-        new Package("Microsoft.NET.Test.Sdk", isPrivateAsset: true),
+        Microsoft_NET_Test_Sdk,
         new Package("NUnit3TestAdapter", isPrivateAsset: true));
 
     private readonly Dictionary<string, Package> items;

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -54,6 +54,8 @@ The package contains analyzers that analyze .NET project files.
 ### Test projects
 * [**Proj0450** Test projects should not be packable](https://dotnet-project-file-analyzers.github.io/rules/Proj0450.html)
 * [**Proj0451** Test projects should not be publishable](https://dotnet-project-file-analyzers.github.io/rules/Proj0451.html)
+* [**Proj0452** Test projects require Microsoft.NET.Test.Sdk](https://dotnet-project-file-analyzers.github.io/rules/Proj0452.html)
+* [**Proj0453** Using Microsoft.NET.Test.Sdk implies a test project](https://dotnet-project-file-analyzers.github.io/rules/Proj0453.html)
 
 ### Central Package Management
 * [**Proj0800** Configure Central Package Management](https://dotnet-project-file-analyzers.github.io/rules/Proj0800.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -454,7 +454,7 @@ public static class Rule
         description:
             "Test projects should only be responsible for running tests. Hence " +
             "they should not be packable.",
-        tags: ["Configuration"],
+        tags: ["Configuration", "Unit Testing"],
         category: Category.Bug);
 
     public static DiagnosticDescriptor TestProjectShouldNotBePublishable => New(
@@ -464,17 +464,23 @@ public static class Rule
         description:
             "Test projects should only be responsible for running tests. Hence " +
             "they should not be publishable.",
-        tags: ["Configuration"],
+        tags: ["Configuration", "Unit Testing"],
         category: Category.Bug);
 
     public static DiagnosticDescriptor TestProjectsRequireSdk => New(
         id: 0452,
         title: "Test projects require Microsoft.NET.Test.Sdk",
         message: @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />.",
-        description:
-            "Test projects should only be responsible for running tests. Hence " +
-            "they should not be publishable.",
-        tags: ["Configuration"],
+        description: "Tests in a test projects do not run properly without the Microsoft.NET.Test.Sdk being included.",
+        tags: ["Unit Testing"],
+        category: Category.Bug);
+
+    public static DiagnosticDescriptor UsingMicrosoftNetTestSdkImpliesTestProject => New(
+        id: 0453,
+        title: "Using Microsoft.NET.Test.Sdk implies a test project",
+        message: @"Set <IsTestProject> to true.",
+        description: "Including the Microsoft.NET.Test.Sdk is only useful for test projects.",
+        tags: ["Unit Testing"],
         category: Category.Bug);
 
     public static DiagnosticDescriptor AvoidGeneratePackageOnBuildWhenNotPackable => New(

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -467,6 +467,16 @@ public static class Rule
         tags: ["Configuration"],
         category: Category.Bug);
 
+    public static DiagnosticDescriptor TestProjectsRequireSdk => New(
+        id: 0452,
+        title: "Test projects require Microsoft.NET.Test.Sdk",
+        message: @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />.",
+        description:
+            "Test projects should only be responsible for running tests. Hence " +
+            "they should not be publishable.",
+        tags: ["Configuration"],
+        category: Category.Bug);
+
     public static DiagnosticDescriptor AvoidGeneratePackageOnBuildWhenNotPackable => New(
         id: 0600,
         title: "Avoid generating packages on build if not packable",


### PR DESCRIPTION
If 'Microsoft.NET.Test.Sdk' is included, `<IsTestProject>` should be true, and vice versa.