### PR TITLE
FP Proj2100: Space preserved closing nodes should not be reported

### DIFF
--- a/projects/FaultyIndenting/FaultyIndenting.resx
+++ b/projects/FaultyIndenting/FaultyIndenting.resx
@@ -15,4 +15,9 @@
   <data name="Welcome" xml:space="preserve">
        <value>Hello, world!</value>
   </data>
+  <data name="Preserved" xml:space="preserve">
+    <value>Hello, world!
+
+We should preserve what we've got.</value>
+  </data>
 </root>

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
@@ -30,7 +30,7 @@ internal sealed class IdentationChecker<TContext>(char ch, int repeat, Diagnosti
 
         var element = start ? node.Positions.StartElement : node.Positions.EndElement;
 
-        if (!ProperlyIndented(element))
+        if (!ProperlyIndented(element) && !ClosingTagAfterTextWithSpacePreservation(node.Element))
         {
             var name = start ? node.LocalName : '/' + node.LocalName;
             context.ReportDiagnostic(Descriptor, element, name);
@@ -55,5 +55,10 @@ internal sealed class IdentationChecker<TContext>(char ch, int repeat, Diagnosti
                 return indent.All(ch => ch == Char);
             }
         }
+
+        bool ClosingTagAfterTextWithSpacePreservation(XElement element)
+            => !start
+            && element.Elements().None()
+            && element.PreservesSpace();
     }
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -27,6 +27,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased
+- Proj2100: Space preserved closing nodes should not be reported. (FP)
 v1.4.2
 - Proj0025: Migrate from ruleset file to .editorconfig file. (NEW RULE)
 - Proj0215: Provide a compliant NuGet package icon. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.Linq.XElement.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.Linq.XElement.cs
@@ -1,0 +1,12 @@
+﻿namespace System.Xml.Linq;
+
+internal static class XElementExtensions
+{
+    public static bool PreservesSpace(this XElement element) => element
+        .AncestorsAndSelf()
+        .Select(e => e.Attribute(XmlSpace))
+        .OfType<XAttribute>()
+        .FirstOrDefault()?.Value == "preserve";
+
+    private static readonly XName XmlSpace = XNamespace.Xml + "space";
+}

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -23,9 +23,9 @@ public abstract class Node : XmlAnalysisNode
         Depth = AncestorsAndSelf().Count() - 1;
     }
 
-    internal readonly XElement Element;
-
     internal readonly Project Project;
+
+    public XElement Element { get; }
 
     public Node? Parent { get; }
 

--- a/src/DotNetProjectFile.Analyzers/Resx/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Node.cs
@@ -12,7 +12,7 @@ public partial class Node : XmlAnalysisNode
         Depth = element.Ancestors().Count();
     }
 
-    internal XElement Element { get; }
+    public XElement Element { get; }
 
     public Resource Resource { get; }
 

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
@@ -2,6 +2,8 @@
 
 public interface XmlAnalysisNode
 {
+    XElement Element { get; }
+
     XmlPositions Positions { get; }
 
     string LocalName { get; }


### PR DESCRIPTION
If we take a look at the following XML/RESX:

``` XML
<?xml version="1.0" encoding="utf-8"?>
  <data name="Preserved" xml:space="preserve">
    <value>Hello, world!

We should preserve what we've got.</value>
  </data>
</root>

```

There should not be a report on the closing `</value>`. The ` xml:space="preserve"` gives meaning to the (lack of) spacing. This should be fixed now.