### PR TITLE
Introduction of case-insensitive string.IsMatch(string?)

### DIFF
--- a/dictionary.dic
+++ b/dictionary.dic
@@ -2,6 +2,8 @@
 CPM
 fallback
 MOQ
+pragmas
 README
+ruleset
 RESX
 usings

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Indent_RESX.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Indent_RESX.cs
@@ -3,7 +3,7 @@
 public class Reports
 {
     [Test]
-    public void faultly_indented()
+    public void faulty_indented()
         => new Resx.IndentResx()
         .ForProject("FaultyIndenting.cs")
         .HasIssues(

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidUsingMoq.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidUsingMoq.cs
@@ -30,8 +30,7 @@ public sealed class AvoidUsingMoq() : MsBuildProjectFileAnalyzer(Rule.AvoidUsing
         => IsMoq(assembly.Name)
         && assembly.Version >= new System.Version(4, 20);
 
-    private static bool IsMoq(string? name)
-        => string.Equals(name, "Moq", StringComparison.OrdinalIgnoreCase);
+    private static bool IsMoq(string? name) => name.IsMatch("Moq");
 
     private static bool IsSuspiciousVersion(string version)
         => version.Contains("*")

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
@@ -16,6 +16,6 @@ public sealed class ExcludePrivateAssetDependencies() : MsBuildProjectFileAnalyz
     }
 
     private static bool ShoudBePrivateAssets(PackageReference reference)
-        => !string.Equals(reference.PrivateAssets, "all", StringComparison.OrdinalIgnoreCase)
+        => !reference.PrivateAssets.IsMatch("all")
         && NuGet.Packages.All.TryGet(reference.Include) is { IsPrivateAsset: true };
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PackageReferencesShouldBeStable.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PackageReferencesShouldBeStable.cs
@@ -16,5 +16,5 @@ public sealed class PackageReferencesShouldBeStable() : MsBuildProjectFileAnalyz
     private static bool IsUnstable(PackageReference package)
         => package.ResolveVersion() is { Length: > 0 } version
         && version.Contains('-')
-        && !"ALL".Equals(package.PrivateAssets, StringComparison.OrdinalIgnoreCase);
+        && !package.PrivateAssets.IsMatch("all");
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseSonarAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseSonarAnalyzers.cs
@@ -11,14 +11,11 @@ public sealed class UseSonarAnalyzers() : MsBuildProjectFileAnalyzer(Rule.UseSon
             && context.Project
                 .ImportsAndSelf()
                 .SelectMany(p => p.ItemGroups)
-                .SelectMany(i => i.PackageReferences).None(p => Includes(p, include)))
+                .SelectMany(i => i.PackageReferences).None(p => p.Include.IsMatch(include)))
         {
             context.ReportDiagnostic(Descriptor, context.Project, include);
         }
     }
-
-    private static bool Includes(PackageReference reference, string include)
-        => string.Equals(reference.Include, include, StringComparison.OrdinalIgnoreCase);
 
     private static string? Include(string language) => language switch
     {

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.String.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.String.cs
@@ -4,4 +4,8 @@ internal static class StringExtensions
 {
     public static bool Contains(this string? str, string value, StringComparison comparisonType)
         => str is { } && str.IndexOf(value, comparisonType) != -1;
+
+    /// <summary>Matches both strings ignoring casting.</summary>
+    public static bool Matches(this string? str, string other)
+        => string.Equals(str, other, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.String.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.String.cs
@@ -6,6 +6,6 @@ internal static class StringExtensions
         => str is { } && str.IndexOf(value, comparisonType) != -1;
 
     /// <summary>Matches both strings ignoring casting.</summary>
-    public static bool Matches(this string? str, string other)
+    public static bool IsMatch(this string? str, string? other)
         => string.Equals(str, other, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.Text;
+using System;
 
 namespace DotNetProjectFile.MsBuild;
 
@@ -39,10 +40,10 @@ public sealed class Project : Node
 
     public ProjectFileType FileType => Path switch
     {
-        _ when Path.Extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase)
-            || Path.Extension.Equals(".vbproj", StringComparison.OrdinalIgnoreCase) => ProjectFileType.ProjectFile,
-        _ when Path.Name.Equals("Directory.Build.props", StringComparison.OrdinalIgnoreCase) => ProjectFileType.DirectoryBuild,
-        _ when Path.Name.Equals("Directory.Packages.props", StringComparison.OrdinalIgnoreCase) => ProjectFileType.DirectoryPackages,
+        _ when Path.Extension.IsMatch(".csproj")
+            || Path.Extension.IsMatch(".vbproj") => ProjectFileType.ProjectFile,
+        _ when Path.Name.IsMatch("Directory.Build.props") => ProjectFileType.DirectoryBuild,
+        _ when Path.Name.IsMatch("Directory.Packages.props") => ProjectFileType.DirectoryPackages,
         _ => ProjectFileType.Props,
     };
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Projects.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Projects.cs
@@ -112,16 +112,16 @@ public sealed class Projects(string language)
         && IsSupportedExtension(location.Extension);
 
     private bool IsSupportedExtension(string extension)
-        => string.Equals(extension, ".props", StringComparison.OrdinalIgnoreCase)
+        => extension.IsMatch(".props")
         || Language switch
         {
-            LanguageNames.CSharp => string.Equals(extension, ".csproj", StringComparison.OrdinalIgnoreCase),
-            LanguageNames.VisualBasic => string.Equals(extension, ".vbproj", StringComparison.OrdinalIgnoreCase),
+            LanguageNames.CSharp => extension.IsMatch(".csproj"),
+            LanguageNames.VisualBasic => extension.IsMatch(".vbproj"),
             _ => false,
         };
 
     private static bool HasName(IOFile file, string? name)
-        => string.Equals(file.NameWithoutExtension, name, StringComparison.OrdinalIgnoreCase);
+        => file.NameWithoutExtension.IsMatch(name);
 
     public static Projects Init(CompilationAnalysisContext context)
         => Cache.Get(context.Compilation, () => New(context));

--- a/src/DotNetProjectFile.Analyzers/NuGet/Analyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Analyzer.cs
@@ -12,8 +12,7 @@ public sealed record Analyzer : Package
     public bool IsApplicable(string compilationLanguage)
         => Language is null || Language == compilationLanguage;
 
-    public bool IsMatch(PackageReference reference)
-        => string.Equals(reference.Include, Name, StringComparison.OrdinalIgnoreCase);
+    public bool IsMatch(PackageReference reference) => reference.Include.IsMatch(Name);
 
     public bool IsMatch(AssemblyIdentity assembly)
         => assembly.Name.StartsWith(Match, StringComparison.OrdinalIgnoreCase)

--- a/src/DotNetProjectFile.Analyzers/Resx/Resources.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Resources.cs
@@ -30,8 +30,7 @@ public sealed class Resources : IReadOnlyCollection<Resource>
     {
         var resources = new Resources();
 
-        foreach (var additional in additionalFiles
-            .Where(a => string.Equals(Path.GetExtension(a.Path), ".resx", StringComparison.OrdinalIgnoreCase)))
+        foreach (var additional in additionalFiles.Where(a => Path.GetExtension(a.Path).IsMatch(".resx")))
         {
             var resource = Resource.Load(additional, resources);
             resources.items[resource.Path] = resource;

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -1,8 +1,5 @@
 #pragma warning disable SA1118 // Parameter should not span multiple lines: readability for descriptions.
 
-using static System.Net.Mime.MediaTypeNames;
-using System.Net.NetworkInformation;
-
 namespace DotNetProjectFile;
 
 public static class Rule


### PR DESCRIPTION
To shorten the tons of places where `string.Equals(l, r, StringComparison.OrdinalIgnoreCase)` where applied.