### PR TITLE
Disable Proj1100:  Avoid using Moq

### DIFF
--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -31,6 +31,7 @@ ToBeReleased
 - Proj0026: Remove IncludeAssets when redundant. (NEW RULE)
 - Proj0027: Override <TargetFrameworks> with <TargetFrameworks>. (NEW RULE)
 - Proj0028: Define conditions on level 1. (NEW RULE)
+- Proj1100: Disable rule by default. (FP)
 - Proj2100: Space preserved closing nodes should not be reported. (FP)
 v1.4.2
 - Proj0025: Migrate from ruleset file to .editorconfig file. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -664,7 +664,8 @@ public static class Rule
         message: "Do not use Moq.",
         description: "Moq has built in data harvesting that violates GDPR.",
         tags: ["GDPR", "privacy"],
-        category: Category.Security);
+        category: Category.Security,
+        isEnabled: false);
 
     public static DiagnosticDescriptor PackageReferencesShouldBeStable => New(
         id: 1101,


### PR DESCRIPTION
Rule [Proj1100: Avoid using Moq](https://dotnet-project-file-analyzers.github.io/rules/Proj1100.html) states that Moq is doing things considered strongly immoral and potentially illegal and hence should not be used.

As this is not longer the case, should we disable the rule by default.