### PR TITLE
Rules should only report on nodes defined in MS Build project file of current context

### DIFF
--- a/specs/Benchmarks/README.md
+++ b/specs/Benchmarks/README.md
@@ -3,6 +3,6 @@ To monitor performance.
 
 ## Get Diagnostics
 |------------ |-------------:|
-| CompliantCS |  29,433.9 µs |
-| CompliantVB |     469.1 µs |
-| Project     | 324,856.2 µs |
+| CompliantCS |  28,693.5 µs |
+| CompliantVB |     474.6 µs |
+| Project     | 318,345.9 µs |

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderPackageReferencesAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderPackageReferencesAlphabetically.cs
@@ -5,8 +5,7 @@ public sealed class OrderPackageReferencesAlphabetically() : MsBuildProjectFileA
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var references in context.Project.ItemGroups
-            .Select(g => g.PackageReferences))
+        foreach (var references in context.Project.ItemGroups.Select(g => g.PackageReferences))
         {
             AnalyzeGroup(context, references);
         }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderPackageVersionsAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderPackageVersionsAlphabetically.cs
@@ -5,8 +5,7 @@ public sealed class OrderPackageVersionsAlphabetically() : MsBuildProjectFileAna
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var references in context.Project.ItemGroups
-            .Select(g => g.PackageVersions))
+        foreach (var references in context.Project.ItemGroups.Select(g => g.PackageVersions))
         {
             AnalyzeGroup(context, references);
         }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderProjectReferencesAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderProjectReferencesAlphabetically.cs
@@ -7,10 +7,7 @@ public sealed class OrderProjectReferencesAlphabetically() : MsBuildProjectFileA
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var references in context.Project
-            .ImportsAndSelf()
-            .SelectMany(p => p.ItemGroups)
-            .Select(g => g.ProjectReferences))
+        foreach (var references in context.Project.ItemGroups.Select(g => g.ProjectReferences))
         {
             AnalyzeGroup(context, references);
         }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderUsingDirectivesAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderUsingDirectivesAlphabetically.cs
@@ -5,9 +5,7 @@ public sealed class OrderUsingDirectivesAlphabetically() : MsBuildProjectFileAna
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var group in context.Project
-            .ImportsAndSelf()
-            .SelectMany(p => p.ItemGroups)
+        foreach (var group in context.Project.ItemGroups
             .Select(g => g.Usings)
             .SelectMany(g => g.GroupBy(u => u.Type)))
         {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderUsingDirectivesByType.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderUsingDirectivesByType.cs
@@ -5,10 +5,7 @@ public sealed class OrderUsingDirectivesByType() : MsBuildProjectFileAnalyzer(Ru
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var directives in context.Project
-            .ImportsAndSelf()
-            .SelectMany(p => p.ItemGroups)
-            .Select(g => g.Usings))
+        foreach (var directives in context.Project.ItemGroups.Select(g => g.Usings))
         {
             AnalyzeGroup(context, directives);
         }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/StaticAliasUsingNotSupported.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/StaticAliasUsingNotSupported.cs
@@ -5,9 +5,7 @@ public sealed class StaticAliasUsingNotSupported() : MsBuildProjectFileAnalyzer(
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var directive in context.Project
-            .ImportsAndSelf()
-            .SelectMany(p => p.ItemGroups)
+        foreach (var directive in context.Project.ItemGroups
             .SelectMany(g => g.Usings)
             .Where(u => u.Type == UsingType.StaticAlias))
         {

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -27,6 +27,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased
+- Rules should only report on self, not on imports. (BUG)
 v1.4.3
 - Proj0026: Remove IncludeAssets when redundant. (NEW RULE)
 - Proj0027: Override <TargetFrameworks> with <TargetFrameworks>. (NEW RULE)


### PR DESCRIPTION
As described in issue #194, some analyzers will crash (or misreport issues) on rules that also try to report on imports. This PR contains all straightforward adjustments.