### PR TITLE
Improve on INI grammar

### DIFF
--- a/specs/Benchmarks/IniFile.cs
+++ b/specs/Benchmarks/IniFile.cs
@@ -1,5 +1,5 @@
 ﻿using DotNetProjectFile.Ini;
-using Microsoft.CodeAnalysis.Text;
+using SyntaxTree = DotNetProjectFile.Syntax.SyntaxTree;
 
 namespace Benchmarks;
 
@@ -7,7 +7,7 @@ public class IniFile
 {
     private static readonly string root = string.Join("/", Enumerable.Repeat("..", 7)) + "/Files/";
 
-    private readonly List<SourceText> Texts = [];
+    private readonly List<SyntaxTree> Trees = [];
     
     public IniFile()
     {
@@ -15,7 +15,7 @@ public class IniFile
         foreach(var file in files)
         {
             using var stream = new FileStream(root + file, FileMode.Open, FileAccess.Read);
-            Texts.Add(SourceText.From(stream));
+            Trees.Add(SyntaxTree.From(stream));
         }
     }
 
@@ -23,5 +23,5 @@ public class IniFile
     public int Index { get; set; }
 
     [Benchmark]
-    public IniFileSyntax Parse() => IniFileSyntax.Parse(Texts[Index]);
+    public IniFileSyntax Parse() => IniFileSyntax.Parse(Trees[Index]);
 }

--- a/specs/Benchmarks/README.md
+++ b/specs/Benchmarks/README.md
@@ -9,9 +9,8 @@ To monitor performance.
 
 
 # Parsing INI files
-
 |     File |        Mean |       per LoC |
 |---------:|------------:|--------------:|
-|   27 LoC |    47.07 us |   1.74 us/LoC |
-|   36 LoC |    53.48 us |   1.49 us/LoC |
-| 1220 LoC | 8,562.46 us |   7.02 us/LoC |
+|   27 LoC |    49.71 us |   1.84 us/LoC |
+|   36 LoC |    54.55 us |   1.52 us/LoC |
+| 1220 LoC | 7,819.40 us |   6.41 us/LoC |

--- a/specs/DotNetProjectFile.Analyzers.Specs/Parsing/INI_syntax.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Parsing/INI_syntax.cs
@@ -13,6 +13,8 @@ public class Parses
         var syntax = IniFileSyntax.Parse(tree);
 
         syntax.Should().BeOfType<IniFileSyntax>();
+
+        syntax.Tokens.Should().NotContain(t => t.Kind == TokenKind.UnparsableToken);
     }
 
     [Test]
@@ -35,5 +37,7 @@ indenting = \t"
             ["some_key"] = "value",
             ["indenting"] = "\\t",
         });
+
+        syntax.Tokens.Should().Contain(t => t.Kind == TokenKind.UnparsableToken);
     }
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Parsing/INI_syntax.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Parsing/INI_syntax.cs
@@ -1,5 +1,4 @@
 ﻿using DotNetProjectFile.Ini;
-using Microsoft.CodeAnalysis.Text;
 using System.IO;
 
 namespace Parsing.INI_syntax;
@@ -10,10 +9,31 @@ public class Parses
     public void dot_editorconfig()
     {
         using var file = new FileStream("../../../../../.editorconfig", FileMode.Open, FileAccess.Read);
-        var source = SourceText.From(file);
-        
-        var syntax = IniFileSyntax.Parse(source);
+        var tree = DotNetProjectFile.Syntax.SyntaxTree.From(file);
+        var syntax = IniFileSyntax.Parse(tree);
 
         syntax.Should().BeOfType<IniFileSyntax>();
+    }
+
+    [Test]
+    public void with_garbage()
+    {
+        var tree = DotNetProjectFile.Syntax.SyntaxTree.Parse(@"global = false
+some_key = value
+invalid line
+indenting = \t"
+        );
+
+        var syntax = IniFileSyntax.Parse(tree);
+        syntax.Should().BeOfType<IniFileSyntax>();
+
+        var kvps = syntax.Sections.Single().Kvps.ToArray();
+
+        kvps.Should().BeEquivalentTo(new Dictionary<string, string>()
+        {
+            ["global"] = "false",
+            ["some_key"] = "value",
+            ["indenting"] = "\\t",
+        });
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Collections/Slice.cs
+++ b/src/DotNetProjectFile.Analyzers/Collections/Slice.cs
@@ -1,0 +1,26 @@
+﻿namespace DotNetProjectFile.Collections;
+
+[DebuggerTypeProxy(typeof(CollectionDebugView))]
+[DebuggerDisplay("Count = {Count}, Offset = {Offset}")]
+internal readonly struct Slice<T>(int start, int size, IReadOnlyList<T> list) : IReadOnlyList<T>
+{
+    internal Slice(SliceSpan span, IReadOnlyList<T> list) : this(span.Start, span.Size, list) { }
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly IReadOnlyList<T> List = list;
+
+    public int Count { get; } = size;
+
+    public T this[int index] => List[index + Offset];
+
+    private int Offset { get; } = start;
+
+    /// <inheritdoc />
+    [Pure]
+
+    public IEnumerator<T> GetEnumerator() => List.Skip(Offset).Take(Count).GetEnumerator();
+
+    /// <inheritdoc />
+    [Pure]
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/DotNetProjectFile.Analyzers/Collections/SliceSpan.cs
+++ b/src/DotNetProjectFile.Analyzers/Collections/SliceSpan.cs
@@ -1,0 +1,11 @@
+﻿namespace DotNetProjectFile.Collections;
+
+public readonly record struct SliceSpan(int Start, int Size)
+{
+    public int End => Start + Size;
+
+    public static SliceSpan operator +(SliceSpan left, SliceSpan right)
+        => left == default
+            ? right
+            : new(left.Start, right.Size + right.Start - left.Start);
+}

--- a/src/DotNetProjectFile.Analyzers/Ini/HeaderSyntax.cs
+++ b/src/DotNetProjectFile.Analyzers/Ini/HeaderSyntax.cs
@@ -1,27 +1,22 @@
 ﻿using DotNetProjectFile.Parsing;
-using DotNetProjectFile.Syntax;
 
 namespace DotNetProjectFile.Ini;
 
+[DebuggerDisplay("{FullText}")]
 public sealed record HeaderSyntax : IniSyntax
 {
-    public SourceSpanToken Token { get; init; }
-
-    public string Text => Token.Text;
+    public string Text => Tokens.Single(t => t.Kind == TokenKind.HeaderToken).Text;
 
     internal static IniSyntax New(Parser parser)
     {
-        var ini = parser.Syntax as IniFileSyntax ?? new IniFileSyntax();
+        var ini = IniFileSyntax.Root(parser, init: false);
 
         return ini with
         {
-            Sections = ini.Sections.Add(new()
+            Children = ini.Children.Add(new SectionSyntax()
             {
-                Header = new()
-                {
-                    Token = parser.Tokens.First(t => t.Kind == TokenKind.HeaderToken),
-                    Tokens = parser.Tokens,
-                },
+                Children = [new HeaderSyntax { Span = parser.Span }],
+                Span = parser.Span,
             }),
         };
     }

--- a/src/DotNetProjectFile.Analyzers/Ini/KeySyntax.cs
+++ b/src/DotNetProjectFile.Analyzers/Ini/KeySyntax.cs
@@ -1,26 +1,26 @@
 ﻿using DotNetProjectFile.Parsing;
-using DotNetProjectFile.Syntax;
 
 namespace DotNetProjectFile.Ini;
 
+[DebuggerDisplay("{FullText}")]
 public sealed record KeySyntax : IniSyntax
 {
-    public SourceSpanToken Identifier => Tokens[^1];
-
-    public string Text => Identifier.Text;
+    public string Text => Tokens.Single(t => t.Kind == TokenKind.KeyToken).Text;
 
     internal static IniSyntax New(Parser parser)
     {
-        var ini = parser.Syntax as IniFileSyntax ?? new IniFileSyntax { Sections = [new()] };
+        var root = IniFileSyntax.Root(parser);
 
-        return ini with
+        return root with
         {
-            Sections = ini.Sections.WithLast(s => s with
+            Children = root.Sections.WithLast(s => s with
             {
-                KeyValuePairs = s.KeyValuePairs.Add(new()
+                Children = s.KeyValuePairs.Add(new()
                 {
-                    Key = new() { Tokens = parser.Tokens },
+                    Children = [new KeySyntax() { Span = parser.Span }],
+                    Span = parser.Span,
                 }),
+                Span = s.Span + parser.Span,
             }),
         };
     }

--- a/src/DotNetProjectFile.Analyzers/Ini/_grammar.cs
+++ b/src/DotNetProjectFile.Analyzers/Ini/_grammar.cs
@@ -20,7 +20,7 @@ internal sealed class IniGrammar : Grammar
         & eol)
         + HeaderSyntax.New;
 
-    public static readonly Grammar unparsable = header.Not & line(".*", UnparsableToken);
+    public static readonly Grammar unparsable = ~header & line(".*", UnparsableToken);
 
     public static readonly Grammar comment =
         ws

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.Property.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.Property.cs
@@ -45,7 +45,7 @@ public sealed partial class Project
         .FirstOrDefault();
 
     /// <remarks>
-    /// Walk in reversed order true the nodes.
+    /// Walk in reversed order trough the nodes.
     /// Skip ItemGroups as they can not contain properties.
     /// </remarks>
     private static TNode? Read<TNode>(Node node, ProjectTrace trace) where TNode : Node

--- a/src/DotNetProjectFile.Analyzers/Parsing/ParseBuffer.cs
+++ b/src/DotNetProjectFile.Analyzers/Parsing/ParseBuffer.cs
@@ -1,0 +1,72 @@
+﻿using DotNetProjectFile.Syntax;
+using System.Runtime.CompilerServices;
+
+namespace DotNetProjectFile.Parsing;
+
+/// <summary>This is an append-only collection.</summary>
+/// <remarks>
+/// This buffer is not thread-safe.
+/// As this buffer should eventually lead to one fully parsed token, it does
+/// attempt to keep all branches valid. Once a new branch is created, it will
+/// reassign slots. This is safe for this use case, but could lead to unintended
+/// results in other cases.
+/// </remarks>
+[DebuggerTypeProxy(typeof(CollectionDebugView))]
+[DebuggerDisplay("Count = {Count}")]
+public readonly struct ParseBuffer(int count, SourceSpanToken[] buffer) : IReadOnlyList<SourceSpanToken>
+{
+    public static readonly ParseBuffer Empty = new(0, []);
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly SourceSpanToken[] Buffer = buffer;
+
+    /// <remarks>Internal from .NET.</remarks>
+    private const int MaxCapacity = 0X7FFFFFC7;
+
+    /// <inheritdoc />
+    public int Count { get; } = count;
+
+    /// <inheritdoc />
+    public SourceSpanToken this[int index] => Buffer[index];
+
+    [Pure]
+    public ParseBuffer Add(SourceSpanToken token)
+    {
+        var added = Ensure();
+        added[Count] = token;
+        return new(Count + 1, added);
+    }
+
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private SourceSpanToken[] Ensure()
+    {
+        if (Count < Buffer.Length && Count != 0)
+        {
+            return Buffer;
+        }
+        int capacity = Buffer.Length == 0 ? 8 : 2 * Buffer.Length;
+
+        // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
+        // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
+        if ((uint)capacity > MaxCapacity) capacity = MaxCapacity;
+        return Copy(capacity);
+    }
+
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private SourceSpanToken[] Copy(int capacity)
+    {
+        var copy = new SourceSpanToken[capacity];
+        Array.Copy(Buffer, copy, Count);
+        return copy;
+    }
+
+    /// <inheritdoc />
+    [Pure]
+    public IEnumerator<SourceSpanToken> GetEnumerator() => Buffer.Take(Count).GetEnumerator();
+
+    /// <inheritdoc />
+    [Pure]
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/DotNetProjectFile.Analyzers/Syntax/RootSyntax.cs
+++ b/src/DotNetProjectFile.Analyzers/Syntax/RootSyntax.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNetProjectFile.Syntax;
 
-internal sealed record RootSyntax : SyntaxNode
+internal sealed record RootSyntax(SyntaxTree? tree = null) : SyntaxNode
 {
+    public override SyntaxTree SyntaxTree { get; } = tree!;
 }

--- a/src/DotNetProjectFile.Analyzers/Syntax/SyntaxNodeCollection.cs
+++ b/src/DotNetProjectFile.Analyzers/Syntax/SyntaxNodeCollection.cs
@@ -1,0 +1,37 @@
+﻿namespace DotNetProjectFile.Syntax;
+
+[DebuggerTypeProxy(typeof(CollectionDebugView))]
+[DebuggerDisplay("Count = {Count}")]
+public readonly struct SyntaxNodeCollection<TSyntax>(SyntaxNode parent)
+    : IReadOnlyList<TSyntax> where TSyntax : SyntaxNode
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly ImmutableArray<SyntaxNode> Children = parent.Children;
+
+    /// <inheritdoc />
+    public TSyntax this[int index] => Children.OfType<TSyntax>().Skip(index).First();
+
+    /// <inheritdoc />
+    public int Count => Children.OfType<TSyntax>().Count();
+
+    [Pure]
+    public ImmutableArray<SyntaxNode> WithLast(Func<TSyntax, TSyntax> update)
+    {
+        var trimmed = Children[..^1];
+        var last = Children[^1] as TSyntax
+            ?? throw new InvalidCastException($"Last child is of the type {Children[..^1].GetType()}, and not of the type {typeof(TSyntax)}.");
+        var updated = update(last);
+        return trimmed.Add(updated);
+    }
+
+    [Pure]
+    public ImmutableArray<SyntaxNode> Add(TSyntax node) => Children.Add(node);
+
+    /// <inheritdoc />
+    [Pure]
+    public IEnumerator<TSyntax> GetEnumerator() => Children.OfType<TSyntax>().GetEnumerator();
+
+    /// <inheritdoc />
+    [Pure]
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/DotNetProjectFile.Analyzers/Syntax/SyntaxNodeResolver.cs
+++ b/src/DotNetProjectFile.Analyzers/Syntax/SyntaxNodeResolver.cs
@@ -1,0 +1,15 @@
+﻿using DotNetProjectFile.Parsing;
+
+namespace DotNetProjectFile.Syntax;
+
+internal static class SyntaxNodeResolver
+{
+    [Pure]
+    public static TSyntax Resolve<TSyntax>(this Parser parser, SyntaxTree tree) where TSyntax : SyntaxNode
+    {
+        var syntax = parser.Syntax;
+        syntax.SetParent(new RootSyntax(tree.With(parser.Tokens)));
+        return syntax as TSyntax
+            ?? throw new InvalidOperationException($"Unexpected syntax of type {syntax.GetType().FullName}.");
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Syntax/SyntaxTree.cs
+++ b/src/DotNetProjectFile.Analyzers/Syntax/SyntaxTree.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.CodeAnalysis.Text;
+using System.IO;
+using System.Text;
+
+namespace DotNetProjectFile.Syntax;
+
+[DebuggerDisplay("{DebuggerDisplay}")]
+public sealed class SyntaxTree
+{
+    public IOFile Path { get; init; }
+
+    public SourceText SourceText { get; init; } = SourceText.From(string.Empty);
+
+    public Encoding? Encoding => SourceText.Encoding;
+
+    public IReadOnlyList<SourceSpanToken> Tokens { get; init; } = [];
+
+    public SourceSpan SourceSpan => new(SourceText, new(0, SourceText.Length));
+
+    public SyntaxTree With(IReadOnlyList<SourceSpanToken> tokens) => new()
+    {
+        Path = Path,
+        SourceText = SourceText,
+        Tokens = tokens,
+    };
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string DebuggerDisplay => Path.HasValue
+        ? $"Size = {SourceText.Length}, Tokens = {Tokens.Count}, Path = {Path}"
+        : $"Size = {SourceText.Length}, Tokens = {Tokens.Count}";
+
+    [Pure]
+    public static SyntaxTree From(Stream stream) => new()
+    {
+        Path = stream is FileStream file ? IOFile.Parse(file.Name) : default,
+        SourceText = SourceText.From(stream),
+    };
+
+    [Pure]
+    public static SyntaxTree Parse(string text) => new()
+    {
+        SourceText = SourceText.From(text),
+    };
+}


### PR DESCRIPTION
Support unparsable tokens to always parse the full INI file, even if some lines can not be parsed. Also improved on how to create the syntax tree.