### PR TITLE
Implement glob expressions

### DIFF
--- a/specs/Benchmarks/Globs.cs
+++ b/specs/Benchmarks/Globs.cs
@@ -1,0 +1,13 @@
+﻿using DotNetProjectFile.IO;
+
+namespace Benchmarks;
+
+public class Globs
+{
+    [Params("*.cs", "*{.vbpoj,*.csproj}", "**/[ab].??proj")]
+    public string Expression { get; set; } = string.Empty;
+
+    [Benchmark]
+    public Glob? Parse()
+        => Glob.TryParse(Expression);
+}

--- a/specs/Benchmarks/README.md
+++ b/specs/Benchmarks/README.md
@@ -13,3 +13,10 @@ To monitor performance.
 |   27 LoC |    49.71 us |   1.84 us/LoC |
 |   36 LoC |    54.55 us |   1.52 us/LoC |
 | 1220 LoC | 7,819.40 us |   6.41 us/LoC |
+
+# Parsing globs
+| Expression         | Mean     |
+|------------------- |---------:|
+| *.cs               | 1.794 us |
+| *{.vbpoj,*.csproj} | 1.391 us |
+| **/[ab].??proj     | 4.121 us |

--- a/specs/DotNetProjectFile.Analyzers.Specs/IO/Glob_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/IO/Glob_specs.cs
@@ -1,0 +1,38 @@
+﻿using DotNetProjectFile.IO;
+
+namespace IO.Glob_specs;
+
+public class Parses
+{
+    [TestCase(".", "\\.")]
+    [TestCase("?", ".")]
+    [TestCase("*", "[^/]*")]
+    [TestCase("**", ".*")]
+    [TestCase("hello world", "hello world")]
+    [TestCase("*.cs", "[^/]*\\.cs")]
+    [TestCase("[^a]", "[\\^a]")]
+    [TestCase("test[ab].cs", "test[ab]\\.cs")]
+    [TestCase("test[.ab].cs", "test[\\.ab]\\.cs")]
+    [TestCase("test[a.b].cs", "test[a\\.b]\\.cs")]
+    [TestCase("test[!ab].cs", "test[^ab]\\.cs")]
+    [TestCase("**.{cs,vb}", ".*\\.(cs|vb)")]
+    public void expressions(string expression, string pattern)
+    {
+        var glob = Glob.TryParse(expression)!;
+        glob.Should().NotBeNull();
+        glob.Pattern.ToString().Should().Be(pattern);
+    }
+}
+
+public class Does_not_parse
+{
+    [TestCase("test\\file.gif", "Only forward slashes can be used.")]
+    [TestCase("***", "Not more then 2 starts in a row")]
+    [TestCase("[]", "Sequence should contain at least on character")]
+    [TestCase("[!]", "Not sequence should contain at least on character")]
+    public void expressions(string expression, string because)
+    {
+        var glob = Glob.TryParse(expression)!;
+        glob.Should().BeNull(because);
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/IO/Glob.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Glob.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.CodeAnalysis.Text;
+using System.Text.RegularExpressions;
+
+namespace DotNetProjectFile.IO;
+
+/// <summary>Represents a glob expression.</summary>
+/// <remarks>
+/// See: https://spec.editorconfig.org/index.html#glob-expressions.
+/// </remarks>
+public sealed class Glob
+{
+    private Glob(string expression, string pattern)
+    {
+        Expression = expression;
+        Pattern = new(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+    }
+
+    /// <summary>The expression.</summary>
+    public string Expression { get; }
+
+    /// <summary>The <see cref="Regex"/> equivalent to the expression.</summary>
+    public Regex Pattern { get; }
+
+    /// <inheritdoc />
+    [Pure]
+    public override string ToString() => Expression;
+
+    /// <summary>Tries to parse the glob expression.</summary>
+    /// <param name="expression">
+    /// The expression to parse.
+    /// </param>
+    /// <returns>
+    /// A <see cref="Glob"/> if the expression could be parsed, otherwise null.
+    /// </returns>
+    [Pure]
+    public static Glob? TryParse(string? expression)
+    {
+        if (expression is not { Length: > 0 }) return null;
+
+        var parser = GlobGrammar.glob.Parse(SourceText.From(expression));
+
+        return parser.State == Parsing.Matching.EoF
+            ? new(expression, parser.Syntax.ToString())
+            : null;
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/IO/GlobSyntax.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/GlobSyntax.cs
@@ -14,7 +14,7 @@ internal sealed class GlobGrammar : Grm
     static readonly Grm literal /*.*/ = regex(@"[^\\!?*[\]{,}]+") /*..............*/ + GlobSyntax.Literal;
     static readonly Grm seq /*.....*/ = ch('[') & ch('!').Option & literal & ch(']') + GlobSyntax.Literal;
 
-    static readonly Grm or_part /*.*/ = Lazy(() => part);
+    static readonly Grm or_part /*.*/ = Lazy(() => part!);
 
     static readonly Grm or =
         ch('{') + GlobSyntax.StartOr

--- a/src/DotNetProjectFile.Analyzers/IO/GlobSyntax.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/GlobSyntax.cs
@@ -1,0 +1,85 @@
+﻿#pragma warning disable SA1400 // Access modifier should be declared, but we want short lines.
+
+using DotNetProjectFile.Parsing;
+using DotNetProjectFile.Syntax;
+using Grm = DotNetProjectFile.Parsing.Grammar;
+
+namespace DotNetProjectFile.IO;
+
+internal sealed class GlobGrammar : Grm
+{
+    static readonly Grm single /*..*/ = ch('?') /*................................*/ + GlobSyntax.Simple(".");
+    static readonly Grm stars /*...*/ = (str("**") & ~ch('*')) /*.................*/ + GlobSyntax.Simple(".*");
+    static readonly Grm star /*....*/ = (ch('*') & ~ch('*')) /*...................*/ + GlobSyntax.Simple("[^/]*");
+    static readonly Grm literal /*.*/ = regex(@"[^\\!?*[\]{,}]+") /*..............*/ + GlobSyntax.Literal;
+    static readonly Grm seq /*.....*/ = ch('[') & ch('!').Option & literal & ch(']') + GlobSyntax.Literal;
+
+    static readonly Grm or_part /*.*/ = Lazy(() => part);
+
+    static readonly Grm or =
+        ch('{') + GlobSyntax.StartOr
+        & or_part
+        & (ch(',') + GlobSyntax.Comma
+        & or_part).Star
+        & ch('}') + GlobSyntax.EndOr;
+
+    static readonly Grm part =
+        single
+        | stars
+        | star
+        | seq
+        | or
+        | literal;
+
+    public static readonly Grm glob = part.Plus;
+}
+
+[Inheritable]
+internal record GlobSyntax : Syntax.SyntaxNode
+{
+    public override string ToString() => string.Concat(Children);
+
+    public static CreateSyntaxNode Simple([StringSyntax(StringSyntaxAttribute.Regex)] string expression) => parser =>
+    {
+        var simple = new GlobExpressionSimpleSyntax(expression);
+        var root = parser.Syntax as GlobSyntax ?? new GlobSyntax();
+        return root with { Children = root.Children.Add(simple) };
+    };
+
+    public static GlobSyntax Literal(Parser parser)
+    {
+        var text = parser.CurrentText
+            .Replace(".", @"\.")
+            .Replace("^", @"\^")
+            .Replace('!', '^');
+
+        var literal = new GlobExpressionSimpleSyntax(text);
+        var root = parser.Syntax as GlobSyntax ?? new GlobSyntax();
+        return root with { Children = root.Children.Add(literal) };
+    }
+
+    public static GlobSyntax StartOr(Parser parser)
+    {
+        var root = new GlobOrExpression();
+        root.SetParent(parser.Syntax);
+        return root;
+    }
+
+    public static Syntax.SyntaxNode Comma(Parser parser) => parser.Syntax;
+
+    public static Syntax.SyntaxNode EndOr(Parser parser)
+    {
+        var root = parser.Syntax.Parent!;
+        return root with { Children = root.Children.Add(parser.Syntax) };
+    }
+
+    private sealed record GlobOrExpression : GlobSyntax
+    {
+        public override string ToString() => $"({string.Join("|", Children)})";
+    }
+
+    private sealed record GlobExpressionSimpleSyntax(string Regex) : GlobSyntax
+    {
+        public override string ToString() => Regex;
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Parsing/Parser.cs
+++ b/src/DotNetProjectFile.Analyzers/Parsing/Parser.cs
@@ -35,6 +35,18 @@ public readonly struct Parser
 
     public SliceSpan Span => new(Cursor, Tokens.Count - Cursor);
 
+    /// <summary>Gets the text currently active.</summary>
+    public string CurrentText
+    {
+        get
+        {
+            var start = Tokens[Cursor].Span.Start;
+            var end = Tokens[^1].Span.End;
+            var span = new TextSpan(start, end - start);
+            return Tokens[Cursor].SourceSpan.SourceText.ToString(span);
+        }
+    }
+
     /// <summary>The result of <see cref="Matching.NoMatch"/>.</summary>
     /// <returns>
     /// A new parser with an updated state.


### PR DESCRIPTION
To support `.editorconfig` files we need to support glob expressions (see #201). This implementation converts to `Regex`'s (for simplicity). There is at least one dedicated [.NET implementation](https://github.com/kthompson/glob) but the downside would be to have an external dependency on that implementation, or to have to include/duplicate a lot of code, compared to what was needed to have a working implementation.