### PR TITLE
Use source text's lines for parsing

### DIFF
--- a/specs/Benchmarks/Program.cs
+++ b/specs/Benchmarks/Program.cs
@@ -6,6 +6,6 @@ public static class Program
 {
     public static void Main(string[] args)
     {
-        BenchmarkRunner.Run<Globs>();
+        BenchmarkRunner.Run<IniFile>();
     }
 }

--- a/specs/Benchmarks/README.md
+++ b/specs/Benchmarks/README.md
@@ -12,11 +12,11 @@ analyzers.
 | .NET analyzers | 73.621 ms | 73.621 ms | 0.586 ms |
 
 # Parsing INI files
-|     File |        Mean |       per LoC |
-|---------:|------------:|--------------:|
-|   27 LoC |    49.71 us |   1.84 us/LoC |
-|   36 LoC |    54.55 us |   1.52 us/LoC |
-| 1220 LoC | 7,819.40 us |   6.41 us/LoC |
+|     File |        Mean |        Speed |
+|---------:|------------:|-------------:|
+|   27 LoC |    41.41 us |   1,5 µs/LoC |
+|   36 LoC |    44.52 us |   1,2 µs/LoC |
+| 1220 LoC | 4,828.15 us |   4,0 µs/LoC |
 
 # Parsing Globs
 The purpose was never speed, 

--- a/src/DotNetProjectFile.Analyzers/Ini/_grammar.cs
+++ b/src/DotNetProjectFile.Analyzers/Ini/_grammar.cs
@@ -7,7 +7,7 @@ internal sealed class IniGrammar : Grammar
 {
     public static readonly Grammar eol = eof | str("\r\n", EoLToken) | ch('\n', EoLToken);
 
-    public static readonly Grammar ws = line(@"\s*", WhitespaceToken);
+    public static readonly Grammar ws = match(c => c == ' ' || c == 't', WhitespaceToken).Option;
 
     public static readonly Grammar ws_only = line(@"$\s*^", WhitespaceToken);
 

--- a/src/DotNetProjectFile.Analyzers/Syntax/SourceSpan.cs
+++ b/src/DotNetProjectFile.Analyzers/Syntax/SourceSpan.cs
@@ -77,20 +77,9 @@ public readonly struct SourceSpan(SourceText sourceText, TextSpan textSpan) : IE
     [Pure]
     public TextSpan Line()
     {
-        var len = -1;
-        var i = Span.Start;
-
-        while (++len < Span.Length)
-        {
-            if (SourceText[i++] == '\n')
-            {
-                return len != 0 && SourceText[i - 2] == '\r'
-                    ? new(Span.Start, len - 1)
-                    : new(Span.Start, len);
-            }
-        }
-
-        return Span;
+        var line = SourceText.Lines.GetLineFromPosition(Start);
+        var span = line.Span;
+        return new TextSpan(Start, span.Length - (Start - span.Start));
     }
 
     /// <summary>Matches the regular expression.</summary>


### PR DESCRIPTION
Microsoft's `SourceText` has (lazy created) fixed collection of lines. Specially for bigger files, this reduces the parsing times. It also reduces the amount of code needed. Hence, an improvement I'd like to keep.

|     File |         Old |         New |
|---------:|------------:|------------:|
|   27 LoC |    49.71 us |    41.41 us |
|   36 LoC |    54.55 us |    44.52 us |
| 1220 LoC | 7,819.40 us | 4,828.15 us |
