### PR TITLE
XML nodes within resource values should be escaped

### DIFF
--- a/projects/ResxWithHtmlContent/Messages.resx
+++ b/projects/ResxWithHtmlContent/Messages.resx
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+   <resheader name="reader">
+    <value>System.Resources.ResXResourceReader</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter</value>
+  </resheader>
+  <data name="Html" xml:space="preserve">
+    <value><b>King</b></value>
+  </data>
+  <data name="Escaped" xml:space="preserve">
+    <value>&lt;b&gt;King&lt;/b&gt;</value>
+  </data>
+  <data name="Cdata" xml:space="preserve">
+     <value><![CDATA[<b>King</b>]]></value>
+  </data>
+</root>

--- a/projects/ResxWithHtmlContent/ResxWithHtmlContent.csproj
+++ b/projects/ResxWithHtmlContent/ResxWithHtmlContent.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
+  </PropertyGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Escape_XML_nodes_resource_values.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Escape_XML_nodes_resource_values.cs
@@ -1,0 +1,20 @@
+using System.Resources;
+
+namespace Rules.RESX.Escape_XML_nodes_resource_values;
+
+public class Reports
+{
+    [Test]
+    public void on_value_with_HTML() => new Resx.EscapeXmlNodesResourceValues()
+        .ForProject("ResxWithHtmlContent.cs")
+        .HasIssue(new Issue("Proj2005", "Escape the XML node in 'Html'.").WithSpan(12, 04, 12, 30));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new Resx.EscapeXmlNodesResourceValues()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Resx/EscapeXmlNodesResourceValues.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Resx/EscapeXmlNodesResourceValues.cs
@@ -1,0 +1,16 @@
+namespace DotNetProjectFile.Analyzers.Resx;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class EscapeXmlNodesResourceValues() : ResourceFileAnalyzer(Rule.EscapeXmlNodesResourceValues)
+{
+    protected override void Register(ResourceFileAnalysisContext context)
+    {
+        foreach (var data in context.File.Data)
+        {
+            if (data.Value is { } value && value.Element.Elements().OfType<XElement>().Any())
+            {
+                context.ReportDiagnostic(Descriptor, value, data.Name);
+            }
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -23,11 +23,12 @@
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
-    <Version>1.4.6</Version>
+    <Version>1.4.7</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
-ToBeReleased
+v1.4.7
+- Proj2005: Escape XML nodes of resource values. (NEW RULE)
 - Proj2100: Children of <value> should be excluded. (FP)
 v1.4.6
 - Proj3000: Don't crash on non-existing files. (BUG)

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -94,6 +94,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj2002** Sort resource file values alphabetically](https://dotnet-project-file-analyzers.github.io/rules/Proj2002.html)
 * [**Proj2003** Add invariant fallback resources](https://dotnet-project-file-analyzers.github.io/rules/Proj2003.html)
 * [**Proj2004** Add invariant fallback values](https://dotnet-project-file-analyzers.github.io/rules/Proj2004.html)
+* [**Proj2005** Escape XML nodes of resource values](https://dotnet-project-file-analyzers.github.io/rules/Proj2005.html)
 * [**Proj2100** Indent RESX](https://dotnet-project-file-analyzers.github.io/rules/Proj2100.html)
 
 ## Generic

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -757,6 +757,14 @@ public static class Rule
        tags: ["resx", "resources", "invariant", "localization"],
        category: Category.Bug);
 
+    public static DiagnosticDescriptor EscapeXmlNodesResourceValues => New(
+      id: 2005,
+      title: "Escape XML nodes of resource values",
+      message: "Escape the XML node in '{0}'.",
+      description: "To ensure correct handling, XML nodes within resource values should be escaped.",
+      tags: ["resx", "resources", "XML", "escaping"],
+      category: Category.Bug);
+
     public static DiagnosticDescriptor IndentResx => New(
       id: 2100,
       title: "Indent XML files",


### PR DESCRIPTION
To ensure correct handling, XML nodes within resource values should be escaped.

Closes #215 

Documentation PR: https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers.github.io/pull/42