### PR TITLE
Fix RS1038 warning

### DIFF
--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -189,8 +189,7 @@ v1.0.0
   </ItemGroup>
 
   <ItemGroup Label="Roslyn dependencies">
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">


### PR DESCRIPTION
Rule [RS1038](https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1038.md) states that `Microsoft.CodeAnalysis.Workspaces.Common` should not be referenced, but `Microsoft.CodeAnalysis.Common` instead. So, that is what I did.

Note that I only solved this issue for the analyzer assembly. The unit test assembly reports on this too, but I'd like to fix those issues in another PR.