### PR TITLE
Proj0029: Use C# specific properties only when applicable

### DIFF
--- a/dictionary.dic
+++ b/dictionary.dic
@@ -3,6 +3,7 @@ CPM
 fallback
 INI
 MOQ
+nullable
 pragma
 pragmas
 README

--- a/projects/CSharpOnlyProperties/CSharpOnlyProperties.csproj
+++ b/projects/CSharpOnlyProperties/CSharpOnlyProperties.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsPackable>false</IsPackable>
+    <FrameworkPathOverride />
+    <NoVBRuntimeReference>true</NoVBRuntimeReference>
+    <OptionExplicit>On</OptionExplicit>
+    <OptionInfer>On</OptionInfer>
+    <OptionStrict>On</OptionStrict>
+    <RemoveIntegerChecks>true</RemoveIntegerChecks>
+    <VbcVerbosity>Verbose</VbcVerbosity>
+    <VbcToolPath />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="*.props" />
+  </ItemGroup>
+
+</Project>

--- a/projects/CSharpOnlyProperties/Directory.Build.props
+++ b/projects/CSharpOnlyProperties/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  
+  <PropertyGroup>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/projects/CSharpOnlyPropertiesVB/CSharpOnlyPropertiesVB.vbproj
+++ b/projects/CSharpOnlyPropertiesVB/CSharpOnlyPropertiesVB.vbproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.vb" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="*.props" />
+  </ItemGroup>
+
+</Project>

--- a/projects/CSharpOnlyPropertiesVB/Directory.Build.props
+++ b/projects/CSharpOnlyPropertiesVB/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  
+  <PropertyGroup>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_CSharp_specific_only_in_CSharp_context.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_CSharp_specific_only_in_CSharp_context.cs
@@ -1,0 +1,28 @@
+namespace Rules.Use_CSharp_specific_only_in_CSharp_context;
+
+public class Reports
+{
+    [Test]
+    public void VB_NET_only_context()
+        => new UseInCSharpContextOnly()
+        .ForProject("CSharpOnlyPropertiesVB.vb")
+        .HasIssues(
+            new Issue("Proj0029", "The property <AllowUnsafeBlocks> is only applicable when using C# and can therefor be removed." /*...*/).WithSpan(03, 4, 03, 48).WithPath("Directory.Build.props"),
+            new Issue("Proj0029", "The property <AllowUnsafeBlocks> is only applicable when using C# and can therefor be removed." /*...*/).WithSpan(05, 4, 05, 48).WithPath("CSharpOnlyPropertiesVB.vbproj"),
+            new Issue("Proj0029", "The property <CheckForOverflowUnderflow> is only applicable when using C# and can therefor be removed.").WithSpan(04, 4, 04, 63).WithPath("Directory.Build.props"),
+            new Issue("Proj0029", "The property <CheckForOverflowUnderflow> is only applicable when using C# and can therefor be removed.").WithSpan(06, 4, 06, 63).WithPath("CSharpOnlyPropertiesVB.vbproj"),
+            new Issue("Proj0029", "The property <Nullable> is only applicable when using C# and can therefor be removed." /*............*/).WithSpan(05, 4, 05, 31).WithPath("Directory.Build.props"),
+            new Issue("Proj0029", "The property <Nullable> is only applicable when using C# and can therefor be removed." /*............*/).WithSpan(07, 4, 07, 31).WithPath("CSharpOnlyPropertiesVB.vbproj"));
+}
+
+public class Guards
+{
+    [TestCase("CSharpOnlyProperties.cs")]
+    [TestCase("CompliantVB.vb")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_with_analyzers(string project)
+         => new UseInCSharpContextOnly()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_VB_specific_only_in_VB_context.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_VB_specific_only_in_VB_context.cs
@@ -3,7 +3,7 @@ namespace Rules.Use_VB_specific_only_in_VB_context;
 public class Reports
 {
     [Test]
-    public void C_sharp_only_context()
+    public void CSharp_only_context()
         => new UseInVBContextOnly()
         .ForProject("VBOnlyPropertiesCSharp.cs")
         .HasIssues(

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseInCSharpContextOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseInCSharpContextOnly.cs
@@ -1,0 +1,42 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class UseInCSharpContextOnly() : MsBuildProjectFileAnalyzer(Rule.UseInCSharpContextOnly)
+{
+    private static readonly Type[] CSharpOnly =
+    [
+        typeof(DotNetProjectFile.MsBuild.CSharp.AllowUnsafeBlocks),
+        typeof(DotNetProjectFile.MsBuild.CSharp.CheckForOverflowUnderflow),
+        typeof(DotNetProjectFile.MsBuild.CSharp.Nullable),
+    ];
+
+    protected override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile_DirectoryBuild;
+
+    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        if (!InCSharpContext(context.File))
+        {
+            Walk(context.File, context);
+        }
+    }
+
+    private static bool InCSharpContext(MsBuildProject project) => project.FileType switch
+    {
+        ProjectFileType.ProjectFile => project.Path.Extension.IsMatch(".csproj"),
+        ProjectFileType.DirectoryBuild => !project.Path.Directory.Files("*.vbproj").Any(),
+        _ => false,
+    };
+
+    private void Walk(Node node, ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        if (CSharpOnly.Contains(node.GetType()))
+        {
+            context.ReportDiagnostic(Descriptor, node, node.LocalName);
+        }
+
+        foreach (var child in node.Children)
+        {
+            Walk(child, context);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseInCSharpContextOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseInCSharpContextOnly.cs
@@ -23,7 +23,7 @@ public sealed class UseInCSharpContextOnly() : MsBuildProjectFileAnalyzer(Rule.U
     private static bool InCSharpContext(MsBuildProject project) => project.FileType switch
     {
         ProjectFileType.ProjectFile => project.Path.Extension.IsMatch(".csproj"),
-        ProjectFileType.DirectoryBuild => !project.Path.Directory.Files("*.vbproj").Any(),
+        ProjectFileType.DirectoryBuild => project.Path.Directory.Files("*.vbproj")!.None(),
         _ => false,
     };
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseInVBContextOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseInVBContextOnly.cs
@@ -3,8 +3,7 @@ using DotNetProjectFile.MsBuild.VisualBasic;
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-public sealed class UseInVBContextOnly()
-    : MsBuildProjectFileAnalyzer(Rule.UseInVBContextOnly)
+public sealed class UseInVBContextOnly() : MsBuildProjectFileAnalyzer(Rule.UseInVBContextOnly)
 {
     private static readonly Type[] VBOnly =
     [

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -28,6 +28,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased
+- Proj0029: Use C# specific properties only when applicable. (NEW RULE)
 - Proj0030: Use VB.NET specific properties only when applicable. (NEW RULE)
 - Proj0216: Define the product name explictly. (NEW RULE)
 v1.4.7

--- a/src/DotNetProjectFile.Analyzers/MsBuild/CSharp/AllowUnsafeBlocks.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/CSharp/AllowUnsafeBlocks.cs
@@ -1,0 +1,10 @@
+namespace DotNetProjectFile.MsBuild.CSharp;
+
+/// <summary>
+/// The AllowUnsafeBlocks compiler option allows code that uses the unsafe
+/// keyword to compile. The default value for this option is false, meaning
+/// unsafe code isn't allowed.
+/// </summary>
+/// <remarks>C# only.</remarks>
+public sealed class AllowUnsafeBlocks(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/CSharp/CheckForOverflowUnderflow.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/CSharp/CheckForOverflowUnderflow.cs
@@ -1,0 +1,9 @@
+namespace DotNetProjectFile.MsBuild.CSharp;
+
+/// <summary>
+/// The CheckForOverflowUnderflow option controls the default overflow-checking
+/// context that defines the program behavior if integer arithmetic overflows.
+/// </summary>
+/// <remarks>C# only.</remarks>
+public sealed class CheckForOverflowUnderflow(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/CSharp/Nullable.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/CSharp/Nullable.cs
@@ -1,0 +1,8 @@
+namespace DotNetProjectFile.MsBuild.CSharp;
+
+/// <summary>
+/// Enable nullable context, or nullable warnings.
+/// </summary>
+/// <remarks>C# only.</remarks>
+public sealed class Nullable(XElement element, Node parent, MsBuildProject project)
+    : Node(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -30,6 +30,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0026** Remove IncludeAssets when redundant](https://dotnet-project-file-analyzers.github.io/rules/Proj0026.html)
 * [**Proj0027** Override &lt;TargetFrameworks&gt; with &lt;TargetFrameworks&gt;](https://dotnet-project-file-analyzers.github.io/rules/Proj0027.html)
 * [**Proj0028** Define conditions on level 1](https://dotnet-project-file-analyzers.github.io/rules/Proj0028.html)
+* [**Proj0029** Use C# specific properties only when applicable](https://dotnet-project-file-analyzers.github.io/rules/Proj0029.html)
 * [**Proj0030** Use VB.NET specific properties only when applicable](https://dotnet-project-file-analyzers.github.io/rules/Proj0030.html)
 
 ### Packaging

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -259,8 +259,8 @@ public static class Rule
         title: "Use C# specific properties only when applicable",
         message: "The property <{0}> is only applicable when using C# and can therefor be removed.",
         description:
-            "Properties only applicable to VB.NET are noise when none of " +
-            "the involved targets is a VB.NET target.",
+            "Properties only applicable to C# are noise when none of " +
+            "the involved targets is a C# target.",
         tags: ["noise"],
         category: Category.Noise);
 

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -254,6 +254,16 @@ public static class Rule
         tags: ["conditions"],
         category: Category.Reliability);
 
+    public static DiagnosticDescriptor UseInCSharpContextOnly => New(
+        id: 0029,
+        title: "Use C# specific properties only when applicable",
+        message: "The property <{0}> is only applicable when using C# and can therefor be removed.",
+        description:
+            "Properties only applicable to VB.NET are noise when none of " +
+            "the involved targets is a VB.NET target.",
+        tags: ["noise"],
+        category: Category.Noise);
+
     public static DiagnosticDescriptor UseInVBContextOnly => New(
         id: 0030,
         title: "Use VB.NET specific properties only when applicable",
@@ -263,7 +273,6 @@ public static class Rule
             "the involved targets is a VB.NET target.",
         tags: ["noise"],
         category: Category.Noise);
-
 
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,


### PR DESCRIPTION
Equivalent to #223, but for C#. Currently, only 3 properties are involved.