### PR TITLE
Proj0031: Adopt preferred casing of nodes

### DIFF
--- a/dictionary.dic
+++ b/dictionary.dic
@@ -1,3 +1,4 @@
+BOM
 CDATA
 CPM
 fallback

--- a/projects/CaseInsensitive/CaseInsensitive.csproj
+++ b/projects/CaseInsensitive/CaseInsensitive.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\props\simple.props" />
+  
+  <PropertyGroup>
+    <TARGETFRAMEWORK>net8.0</TARGETFRAMEWORK>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ComPile Include="../common/Code.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <packagereference Include="Qowaiv" Version="7.1.3" />
+  </ItemGroup>
+  
+</Project>

--- a/projects/CaseInsensitive/CaseInsensitive.csproj
+++ b/projects/CaseInsensitive/CaseInsensitive.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\props\simple.props" />
+  <Import Project="../props/simple.props" />
   
   <PropertyGroup>
     <TARGETFRAMEWORK>net8.0</TARGETFRAMEWORK>

--- a/projects/CaseInsensitive/Extra.cs
+++ b/projects/CaseInsensitive/Extra.cs
@@ -1,0 +1,9 @@
+using Qowaiv;
+
+namespace CaseInsensitive;
+
+public static class Extra
+{
+    // Proofs that the reference is included.
+    public static Uuid Next() => Uuid.NewUuid();
+}

--- a/projects/CaseInsensitive/Extra.cs
+++ b/projects/CaseInsensitive/Extra.cs
@@ -4,6 +4,6 @@ namespace CaseInsensitive;
 
 public static class Extra
 {
-    // Proofs that the reference is included.
+    // Proves that the reference is included.
     public static Uuid Next() => Uuid.NewUuid();
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Adopt_preferred_casing.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Adopt_preferred_casing.cs
@@ -6,9 +6,9 @@ public class Reports
     public void on_alternative_casing() => new AdoptPreferredCasing()
         .ForProject("CaseInsensitive.cs")
         .HasIssues(
-            new Issue("Proj0031", "The node <TARGETFRAMEWORK> is has a different casing than the preferred one <TargetFramework>."/*...*/).WithSpan(05, 04, 05, 45),
-            new Issue("Proj0031", "The node <ComPile> is has a different casing than the preferred one <Compile>."/*...................*/).WithSpan(09, 04, 09, 43),
-            new Issue("Proj0031", "The node <packagereference> is has a different casing than the preferred one <PackageReference>."/*.*/).WithSpan(13, 04, 13, 57));
+            new Issue("Proj0031", "The node <TARGETFRAMEWORK> has a different casing than the preferred one <TargetFramework>."/*...*/).WithSpan(05, 04, 05, 45),
+            new Issue("Proj0031", "The node <ComPile> has a different casing than the preferred one <Compile>."/*...................*/).WithSpan(09, 04, 09, 43),
+            new Issue("Proj0031", "The node <packagereference> has a different casing than the preferred one <PackageReference>."/*.*/).WithSpan(13, 04, 13, 57));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Adopt_preferred_casing.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Adopt_preferred_casing.cs
@@ -1,0 +1,23 @@
+namespace Rules.MS_Build.Adopt_preferred_casing;
+
+public class Reports
+{
+    [Test]
+    public void on_alternative_casing() => new AdoptPreferredCasing()
+        .ForProject("CaseInsensitive.cs")
+        .HasIssues(
+            new Issue("Proj0031", "The node <TARGETFRAMEWORK> is has a different casing than the preferred one <TargetFramework>."/*...*/).WithSpan(05, 04, 05, 45),
+            new Issue("Proj0031", "The node <ComPile> is has a different casing than the preferred one <Compile>."/*...................*/).WithSpan(09, 04, 09, 43),
+            new Issue("Proj0031", "The node <packagereference> is has a different casing than the preferred one <PackageReference>."/*.*/).WithSpan(13, 04, 13, 57));
+}
+
+public class Guards
+{
+    [TestCase("PackagesWithAnalyzers.cs")]
+    [TestCase("PackagesWithoutAnalyzers.cs")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new AdoptPreferredCasing()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AdoptPreferredCasing.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AdoptPreferredCasing.cs
@@ -1,0 +1,20 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class AdoptPreferredCasing() : MsBuildProjectFileAnalyzer(Rule.AdoptPreferredCasing)
+{
+    protected override void Register(ProjectFileAnalysisContext context) => Walk(context.File, context);
+
+    private void Walk(Node node, ProjectFileAnalysisContext context)
+    {
+        if (node is not Unknown && node.LocalName != node.Element.Name.LocalName)
+        {
+            context.ReportDiagnostic(Descriptor, node, node.Element.Name.LocalName, node.LocalName);
+        }
+
+        foreach (var child in node.Children)
+        {
+            Walk(child, context);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -30,6 +30,7 @@
 ToBeReleased
 - Proj0029: Use C# specific properties only when applicable. (NEW RULE)
 - Proj0030: Use VB.NET specific properties only when applicable. (NEW RULE)
+- Proj0031: Adopt preferred casing of nodes. (NEW RULE)
 - Proj0216: Define the product name explictly. (NEW RULE)
 v1.4.7
 - Proj2005: Escape XML nodes of resource values. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.Linq.XElement.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Xml.Linq.XElement.cs
@@ -2,6 +2,20 @@ namespace System.Xml.Linq;
 
 internal static class XElementExtensions
 {
+    [Pure]
+    public static int Depth(this XElement element)
+    {
+        var depth = 0;
+        var parent = element.Parent;
+        while (parent is { })
+        {
+            depth++;
+            parent = parent.Parent;
+        }
+        return depth;
+    }
+
+    [Pure]
     public static bool PreservesSpace(this XElement element) => element
         .AncestorsAndSelf()
         .Select(e => e.Attribute(XmlSpace))

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -20,7 +20,7 @@ public abstract class Node : XmlAnalysisNode
         Project = project ?? (this as Project) ?? throw new ArgumentNullException(nameof(project));
         Children = element.Elements().Select(Create).ToArray();
         Positions = XmlPositions.New(element);
-        Depth = AncestorsAndSelf().Count() - 1;
+        Depth = element.Depth();
     }
 
     internal readonly Project Project;

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -7,6 +7,8 @@ namespace DotNetProjectFile.MsBuild;
 /// <summary>Represents node in a MS Build project file.</summary>
 public abstract class Node : XmlAnalysisNode
 {
+    private static readonly NodeFactory Factory = new();
+
     /// <summary>Semi-colon separator char(s).</summary>
     protected static readonly char[] SemicolonSeparated = [';'];
 
@@ -16,7 +18,7 @@ public abstract class Node : XmlAnalysisNode
         Element = element;
         Parent = parent;
         Project = project ?? (this as Project) ?? throw new ArgumentNullException(nameof(project));
-        Children = element.Elements().Select(Create).OfType<Node>().ToArray();
+        Children = element.Elements().Select(Create).ToArray();
         Positions = XmlPositions.New(element);
         Depth = AncestorsAndSelf().Count() - 1;
     }
@@ -89,7 +91,7 @@ public abstract class Node : XmlAnalysisNode
     public string? Child([CallerMemberName] string? propertyName = null)
         => Element.Element(propertyName)?.Value;
 
-    internal Node? Create(XElement element) => NodeFactory.Create(element, this, Project);
+    internal Node Create(XElement element) => Factory.Create(element, this, Project);
 
     protected T? Convert<T>(string? value, [CallerMemberName] string? propertyName = null)
         => Converters.TryConvert<T>(value, GetType(), propertyName!);

--- a/src/DotNetProjectFile.Analyzers/MsBuild/NodeFactory.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/NodeFactory.cs
@@ -8,43 +8,50 @@ namespace DotNetProjectFile.MsBuild;
 /// Used for creating instances of the <see cref="Node"/> class
 /// based on given <see cref="XElement"/> instances.
 /// </summary>
-internal static class NodeFactory
+internal sealed class NodeFactory
 {
-    private static readonly Type[] ctorArgumentTypes = GetCtorParameterTypes();
-    private static readonly ParameterExpression[] ctorArgumentExpressions = ctorArgumentTypes.Select(x => Expression.Parameter(x)).ToArray();
-    private static readonly IReadOnlyDictionary<string, CtorFunc> map = BuildCtorMap();
+    public NodeFactory()
+    {
+        CtorArgumentTypes = GetCtorParameterTypes();
+        CtorArgumentExpressions = CtorArgumentTypes.Select(x => Expression.Parameter(x)).ToArray();
+        Map = BuildCtorMap();
+    }
 
-    public static Node? Create(XElement element, Node parent, MsBuildProject project)
-        => element.Name.LocalName switch
-        {
-            null /*.......................................*/ => null,
-            var n when map.TryGetValue(n, out var con) /*.*/ => con(element, parent, project),
-            _ /*..........................................*/ => new Unknown(element, parent, project),
-        };
+    private readonly Type[] CtorArgumentTypes;
+    private readonly ParameterExpression[] CtorArgumentExpressions;
+    private readonly IReadOnlyDictionary<string, CtorFunc> Map;
 
+    [Pure]
+    public Node Create(XElement element, Node parent, MsBuildProject project)
+        => Map.TryGetValue(element.Name.LocalName, out var con)
+        ? con(element, parent, project)
+        : new Unknown(element, parent, project);
+
+    [Pure]
     private static Type[] GetCtorParameterTypes()
     {
         var all = typeof(CtorFunc).GenericTypeArguments;
-        var result = new Type[all.Length - 1];
-        Array.Copy(all, result, result.Length);
-        return result;
+        return all.Take(all.Length - 1).ToArray();
     }
 
-    private static Dictionary<string, CtorFunc> BuildCtorMap()
+    [Pure]
+    private IReadOnlyDictionary<string, CtorFunc> BuildCtorMap()
         => typeof(Node).Assembly
         .GetTypes()
         .Select(GetValidNodeCtor)
         .OfType<ConstructorInfo>()
         .ToDictionary(ci => ci.DeclaringType.Name, GenerateCtor);
 
-    private static ConstructorInfo? GetValidNodeCtor(Type type)
+    [Pure]
+    private ConstructorInfo? GetValidNodeCtor(Type type)
         => type.IsAbstract || !typeof(Node).IsAssignableFrom(type)
             ? null
-            : type.GetConstructor(ctorArgumentTypes);
+            : type.GetConstructor(CtorArgumentTypes);
 
-    private static CtorFunc GenerateCtor(ConstructorInfo ci)
+    [Pure]
+    private CtorFunc GenerateCtor(ConstructorInfo ci)
     {
-        var args = ctorArgumentExpressions;
+        var args = CtorArgumentExpressions;
         var create = Expression.New(ci, args);
         var lambda = Expression.Lambda(create, args);
         return (CtorFunc)lambda.Compile();

--- a/src/DotNetProjectFile.Analyzers/MsBuild/NodeFactory.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/NodeFactory.cs
@@ -14,14 +14,14 @@ internal sealed class NodeFactory
     {
         CtorArgumentTypes = GetCtorParameterTypes();
         CtorArgumentExpressions = CtorArgumentTypes.Select(x => Expression.Parameter(x)).ToArray();
-        CaseSensitve = BuildCtorMap();
-        CaseInsensitve = new Dictionary<string, CtorFunc>(CaseSensitve, StringComparer.OrdinalIgnoreCase);
+        CaseSensitive = BuildCtorMap();
+        CaseInsensitive = new Dictionary<string, CtorFunc>(CaseSensitive, StringComparer.OrdinalIgnoreCase);
     }
 
     private readonly Type[] CtorArgumentTypes;
     private readonly ParameterExpression[] CtorArgumentExpressions;
-    private readonly Dictionary<string, CtorFunc> CaseSensitve;
-    private readonly Dictionary<string, CtorFunc> CaseInsensitve;
+    private readonly Dictionary<string, CtorFunc> CaseSensitive;
+    private readonly Dictionary<string, CtorFunc> CaseInsensitive;
 
     [Pure]
     public Node Create(XElement element, Node parent, MsBuildProject project)
@@ -32,8 +32,8 @@ internal sealed class NodeFactory
     [Pure]
     private Dictionary<string, CtorFunc> Lookup(XElement element)
         => element.Depth() >= 2
-        ? CaseInsensitve
-        : CaseSensitve;
+        ? CaseInsensitive
+        : CaseSensitive;
 
     [Pure]
     private static Type[] GetCtorParameterTypes()

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -32,6 +32,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0028** Define conditions on level 1](https://dotnet-project-file-analyzers.github.io/rules/Proj0028.html)
 * [**Proj0029** Use C# specific properties only when applicable](https://dotnet-project-file-analyzers.github.io/rules/Proj0029.html)
 * [**Proj0030** Use VB.NET specific properties only when applicable](https://dotnet-project-file-analyzers.github.io/rules/Proj0030.html)
+* [**Proj0031** Adopt preferred casing of nodes](https://dotnet-project-file-analyzers.github.io/rules/Proj0031.html)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](https://dotnet-project-file-analyzers.github.io/rules/Proj0200.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -274,6 +274,16 @@ public static class Rule
         tags: ["noise"],
         category: Category.Noise);
 
+    public static DiagnosticDescriptor AdoptPreferredCasing => New(
+        id: 0031,
+        title: "Adopt preferred casing of nodes",
+        message: "The node <{0}> is has a different casing than the preferred one <{1}>.",
+        description:
+            "MS Build is (mostly) case insensitive. To prevent issues, however " +
+            "it is  preferred to use the same casing consistently.",
+        tags: ["clarity", "casing"],
+        category: Category.Clarity);
+
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,
         title: "Define the project packability explicitly",

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -277,7 +277,7 @@ public static class Rule
     public static DiagnosticDescriptor AdoptPreferredCasing => New(
         id: 0031,
         title: "Adopt preferred casing of nodes",
-        message: "The node <{0}> is has a different casing than the preferred one <{1}>.",
+        message: "The node <{0}> has a different casing than the preferred one <{1}>.",
         description:
             "MS Build is (mostly) case insensitive. To prevent issues, however " +
             "it is  preferred to use the same casing consistently.",

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -279,8 +279,8 @@ public static class Rule
         title: "Adopt preferred casing of nodes",
         message: "The node <{0}> has a different casing than the preferred one <{1}>.",
         description:
-            "MS Build is (mostly) case insensitive. To prevent issues, however " +
-            "it is  preferred to use the same casing consistently.",
+            "MS Build is (mostly) case insensitive. To prevent issues, however, " +
+            "it is preferred to use the same casing consistently.",
         tags: ["clarity", "casing"],
         category: Category.Clarity);
 


### PR DESCRIPTION
After some consideration, I think it is better to first release a rule just checking for consistent casing, instead of also checking for potential spelling issues (#221). This should not (hardly) lead to any FP's, where the other might bring more harm then good (hopefully not).