### PR TITLE
Automatically add the project file to the additional files

### DIFF
--- a/projects/WithPackageProps/WithPackageProps.csproj
+++ b/projects/WithPackageProps/WithPackageProps.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.props" />
+  
+  <PropertyGroup>
+    <TargetFrameWork>net8.0</TargetFrameWork>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+  <ItemGroup Label="Analyzer">
+    <ProjectReference
+      Include="../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj"
+      PrivateAssets="all"
+      ReferenceOutputAssembly="false"
+      OutputItemType="Analyzer"
+      SetTargetFramework="TargetFramework=netstandard2.0" />
+  </ItemGroup>
+  
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
@@ -3,8 +3,7 @@ namespace Rules.MS_Build.Add_additional_files;
 public class Reports
 {
     [Test]
-    public void project_files_not_additional()
-        => new AddAdditionalFile()
+    public void project_files_not_additional() => new AddAdditionalFile()
         .ForProject("EmptyProject.cs")
         .HasIssue(
             new Issue("Proj0006", "Add 'EmptyProject.csproj' to the additional files."));
@@ -12,16 +11,21 @@ public class Reports
 
 public class Guards
 {
+    /// <remarks>The imported file is reported, but that is not relevant here. </remarks>
+    [Test]
+    public void project_files_not_additional() => new AddAdditionalFile()
+        .ForProject("WithPackageProps.cs")
+        .HasIssue(
+            new Issue("Proj0006", "Add 'DotNetProjectFile.Analyzers.props' to the additional files."));
+
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
-    public void project_files_as_additional(string project)
-         => new AddAdditionalFile()
+    public void project_files_as_additional(string project) => new AddAdditionalFile()
         .ForProject(project)
         .HasNoIssues();
 
     [Test]
-    public void Directory_Build_props_not_being_added()
-        => new AddAdditionalFile()
+    public void Directory_Build_props_not_being_added() => new AddAdditionalFile()
         .ForProject("WithDirectoryBuildProps.cs")
         .HasNoIssues();
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -23,16 +23,17 @@
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
-    <Version>1.4.7</Version>
+    <Version>1.4.8</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
-ToBeReleased
+v1.4.8
 - Proj0029: Use C# specific properties only when applicable. (NEW RULE)
 - Proj0030: Use VB.NET specific properties only when applicable. (NEW RULE)
 - Proj0031: Adopt preferred casing of nodes. (NEW RULE)
 - Proj0216: Define the product name explictly. (NEW RULE)
 - Support Directory.Build.targets.
+- Automatically add the project file to the additional files.
 v1.4.7
 - Proj2005: Escape XML nodes of resource values. (NEW RULE)
 - Proj2100: Children of <value> should be excluded. (FP)
@@ -188,6 +189,7 @@ v1.0.0
   </PropertyGroup>
 
   <ItemGroup Label="Package files">
+    <None Include="DotNetProjectFile.Analyzers.props" Pack="true" PackagePath="/build/" />
     <None Update="tools/*.ps1" Pack="true" PackagePath="/" />
     <None Include="$(OutputPath)/DotNetProjectFile.Analyzers.dll" Pack="true" PackagePath="analyzers" Visible="false" />
     <None Include="../../design/logo_128x128.png" Pack="true" PackagePath="/" />

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.props
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.props
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Automatically add the project file to the additional files -->
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildProjectFile)" Visible="false" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
To make life easier when using the analyzers, the instruction to add the project file to additional files is added automatically, because the package now comes with its own `*.props` file. I hope users will like this feature.