### PR TITLE
Resolve project file from additional files if possible

### DIFF
--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
@@ -38,6 +38,14 @@ public sealed partial class ProjectFiles
 
         var file = name + extension;
 
+        // If it is amongst the additional files, do not look further.
+        if (context.Options.AdditionalFiles
+            .Select(a => IOFile.Parse(a.Path))
+            .FirstOrDefault(f => f.Name.IsMatch(file)) is { HasValue: true } additional)
+        {
+            return MsBuildProject(additional);
+        }
+
         return context.Compilation?.Assembly?.Locations
             .Select(l => IOFile.Parse(l.SourceTree?.FilePath))
             .Where(file => file.HasValue)


### PR DESCRIPTION
This reduces both the scans on disk required, and mitigates in cases where the assemblies are not deployed in a sub directory of the project file.