### PR TITLE
Add packages to be included as private assets

### DIFF
--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -28,6 +28,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
+- Proj1200: Add packages that should be included as private assets. (FN)
 - Proj3000: Inaccessible files should not lead to a crash. (BUG)
 V1.5.0
 - Proj0700: Avoid defining <Compile> items in SDK project. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
@@ -83,6 +83,7 @@ public sealed class Packages : IReadOnlyCollection<Package>
         new SourceGenerator("OneOf.SourceGenerator"),
         new SourceGenerator("Polyfill"),
         new SourceGenerator("PolySharp"),
+        new SourceGenerator("Qowaiv.Diagnostics.Contracts"),
         new SourceGenerator("PropertyChanged.SourceGenerator"),
         new SourceGenerator("ReactiveMarbles.ObservableEvents.SourceGenerator"),
         new SourceGenerator("Realm.SourceGenerator"),
@@ -99,6 +100,7 @@ public sealed class Packages : IReadOnlyCollection<Package>
         // Private assets
         new Package("coverlet.collector", isPrivateAsset: true),
         new Package("coverlet.msbuild", isPrivateAsset: true),
+        new Package("DotNetProjectFile.Analyzers.Sdk", isPrivateAsset: true),
         Microsoft_NET_Test_Sdk,
         new Package("NUnit3TestAdapter", isPrivateAsset: true));
 


### PR DESCRIPTION
Both `DotNetProjectFile.Analyzers.Sdk` as `Qowaiv.Diagnostics.Contracts` should be added as private assets too.