### PR TITLE
Prevent NU1504 from being raised when Directory.Packages.props is used

### DIFF
--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -28,6 +28,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased
+- Prevent NU1504 from being raised when Directory.Packages.props is used. (BUG)
 v1.5.3
 - Disable INI based rules by default. (BUG)
 v1.5.2

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
@@ -39,8 +39,14 @@
     <None Include="**/TestResults/**" />
   </ItemGroup>
 
+
   <!-- Ensure our analyzers are available -->
   <ItemGroup>
+    <!--
+      Remove first to ensure we do not get a NU1504. This can happen because
+      Directory.Packages.props has been used.
+    -->
+    <PackageReference Remove="DotNetProjectFile.Analyzers" />
     <PackageReference Include="DotNetProjectFile.Analyzers" Version="1.5.3" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
This happened because 

``` XML
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">

  <!-- Ensure our analyzers are available -->
  <ItemGroup>
    <PackageReference Include="DotNetProjectFile.Analyzers" Version="1.5.3" PrivateAssets="all" />
  </ItemGroup>

</Project>
```

always adds the `DotNetProjectFile.Analyzers` (as it should). Be removing it first, this should not longer occur.