### PR TITLE
Use .NET 8.0 target framework by default for SDK

### DIFF
--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -28,6 +28,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased:
+- Use .NET 8.0 target framework by default. 
 v1.5.3
 - Disable INI based rules by default. (BUG)
 v1.5.2

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- The TargetFramework may be overridden, but has a fine default. -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>


### PR DESCRIPTION
It turns out that .NET 8.0 gives a better experience than netstandard2.0 does.