### PR TITLE
Proj0009: Take conditionals into account

### DIFF
--- a/projects/TargetFrameworkOverridesConditional/TargetFrameworkOverridesConditional.csproj
+++ b/projects/TargetFrameworkOverridesConditional/TargetFrameworkOverridesConditional.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net8.0;net9.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Override_TargetFrameworks_with_TargetFrameworks.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Override_TargetFrameworks_with_TargetFrameworks.cs
@@ -4,8 +4,7 @@ public class Reports
 {
     [Test]
     [Ignore("Buildalizer does not output any artifacts, hence nothing is analyzed.")]
-    public void TFM_overriding_TFMs()
-        => new OverrideTargetFrameworksWithTargetFrameworks()
+    public void TFM_overriding_TFMs() => new OverrideTargetFrameworksWithTargetFrameworks()
         .ForProject("TfmsMixed.cs")
         .HasIssue(new Issue("Proj0027", "This <TargetFramework> will be ignored due to the earlier use of <TargetFrameworks>.")
         .WithSpan(06, 04, 06, 46));
@@ -14,22 +13,24 @@ public class Reports
 public class Guards
 {
     [Test]
-    public void projects_with_TFM_only()
-        => new OverrideTargetFrameworksWithTargetFrameworks()
+    public void projects_with_TFM_only() => new OverrideTargetFrameworksWithTargetFrameworks()
         .ForProject("TargetFramework.cs")
         .HasNoIssues();
 
     [Test]
-    public void projects_with_TFMs_only()
-        => new OverrideTargetFrameworksWithTargetFrameworks()
+    public void Single_TFM_and_conditional_TFMs() => new OverrideTargetFrameworksWithTargetFrameworks()
+        .ForProject("TargetFrameworkOverridesConditional.cs")
+        .HasNoIssues();
+
+    [Test]
+    public void projects_with_TFMs_only() => new OverrideTargetFrameworksWithTargetFrameworks()
         .ForProject("TargetFrameworksMultiple.cs")
         .HasNoIssues();
 
 
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
-    public void Projects_without_issues(string project)
-         => new OverrideTargetFrameworksWithTargetFrameworks()
+    public void Projects_without_issues(string project) => new OverrideTargetFrameworksWithTargetFrameworks()
         .ForProject(project)
         .HasNoIssues();
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OverrideTargetFrameworksWithTargetFrameworks.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OverrideTargetFrameworksWithTargetFrameworks.cs
@@ -6,9 +6,9 @@ public sealed class OverrideTargetFrameworksWithTargetFrameworks()
 {
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.File.Property<TargetFrameworks>() is null) return;
-
-        foreach (var tfm in context.File.PropertyGroups.SelectMany(g => g.TargetFramework))
+        foreach (var tfm in context.File.PropertyGroups.
+            SelectMany(g => g.TargetFramework)
+            .Where(tfm => context.File.PropertyGroups.SelectMany(g => g.TargetFrameworks).Any(x => x.Condition is null || x.Condition == tfm.Condition)))
         {
             context.ReportDiagnostic(Descriptor, tfm);
         }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OverrideTargetFrameworksWithTargetFrameworks.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OverrideTargetFrameworksWithTargetFrameworks.cs
@@ -10,7 +10,7 @@ public sealed class OverrideTargetFrameworksWithTargetFrameworks()
             SelectMany(g => g.TargetFramework)
             .Where(tfm => context.File.PropertyGroups
                 .SelectMany(g => g.TargetFrameworks)
-                .Any(tmfs => tmfs.Condition is null || tmfs.Condition == tfm.Condition)))
+                .Any(tfms => tfms.Condition is null || tfms.Condition == tfm.Condition)))
         {
             context.ReportDiagnostic(Descriptor, tfm);
         }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OverrideTargetFrameworksWithTargetFrameworks.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OverrideTargetFrameworksWithTargetFrameworks.cs
@@ -8,7 +8,9 @@ public sealed class OverrideTargetFrameworksWithTargetFrameworks()
     {
         foreach (var tfm in context.File.PropertyGroups.
             SelectMany(g => g.TargetFramework)
-            .Where(tfm => context.File.PropertyGroups.SelectMany(g => g.TargetFrameworks).Any(x => x.Condition is null || x.Condition == tfm.Condition)))
+            .Where(tfm => context.File.PropertyGroups
+                .SelectMany(g => g.TargetFrameworks)
+                .Any(tmfs => tmfs.Condition is null || tmfs.Condition == tfm.Condition)))
         {
             context.ReportDiagnostic(Descriptor, tfm);
         }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -29,6 +29,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 To be released:
+- Proj0009: Take conditionals into account. (FP)
 - Proj0032: Migarate away from BinaryFormatter. (NEW RULE)
 v1.5.3
 - Disable INI based rules by default. (BUG)


### PR DESCRIPTION
If the `<TargetFrameworks>` has a different conditional constraint (not being none/null) using it beside `<TargetFramework>` is fine.

Closes #258 