### PR TITLE
Move argument of IdentationChecker

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -29,11 +29,11 @@
 
   <ItemGroup Label="Test tools">
     <PackageReference Include="CodeAnalysis.TestTools" Version="3.0.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="NuGet.Common" Version="6.12.1" />
     <PackageReference Include="NuGet.Frameworks" Version="6.12.1" />
     <PackageReference Include="NuGet.Packaging" Version="6.12.1" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup Label="Build tools">

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -53,7 +53,7 @@ v1.5.0
   </ItemGroup>
 
   <ItemGroup Label="Props and targets">
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.1" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
@@ -2,27 +2,31 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace DotNetProjectFile.Analyzers.Helpers;
 
-internal sealed class IdentationChecker<TFile>(char ch, int repeat, DiagnosticDescriptor descriptor)
+internal sealed class IdentationChecker<TFile>(
+    char ch,
+    int repeat,
+    DiagnosticDescriptor descriptor,
+    Predicate<XmlAnalysisNode>? exclude = null)
     where TFile : class, ProjectFile, XmlAnalysisNode
 {
     private readonly char Char = ch;
     private readonly int Repeat = repeat;
     private readonly DiagnosticDescriptor Descriptor = descriptor;
+    private readonly Predicate<XmlAnalysisNode> Exclude = exclude ?? (_ => false);
 
     public void Walk(
         XmlAnalysisNode node,
         SourceText text,
-        ProjectFileAnalysisContext<TFile> context,
-        Predicate<XmlAnalysisNode> exclude)
+        ProjectFileAnalysisContext<TFile> context)
     {
-        if (!exclude(node))
+        if (!Exclude(node))
         {
             Report(node, text, context, true);
             Report(node, text, context, false);
         }
         foreach (var child in node.Children())
         {
-            Walk(child, text, context, exclude);
+            Walk(child, text, context);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IndentXml.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IndentXml.cs
@@ -11,5 +11,5 @@ public sealed class IndentXml : MsBuildProjectFileAnalyzer
         => Checker = new(ch, repeat, Descriptor);
 
     protected override void Register(ProjectFileAnalysisContext context)
-        => Checker.Walk(context.File, context.File.Text, context, _ => false);
+        => Checker.Walk(context.File, context.File.Text, context);
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Resx/IndentResx.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Resx/IndentResx.cs
@@ -10,10 +10,10 @@ public sealed class IndentResx : ResourceFileAnalyzer
     public IndentResx() : this(' ', 2) { }
 
     public IndentResx(char ch, int repeat) : base(Rule.IndentResx)
-        => Checker = new(ch, repeat, Descriptor);
+        => Checker = new(ch, repeat, Descriptor, Exclude);
 
     protected override void Register(ResourceFileAnalysisContext context)
-        => Checker.Walk(context.File, context.File.Text, context, Exclude);
+        => Checker.Walk(context.File, context.File.Text, context);
 
     /// <remarks>
     /// Excludes children of value.

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -218,7 +218,7 @@ v1.0.0
   </ItemGroup>
 
   <ItemGroup Label="Props and targets">
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="Roslyn dependencies">
@@ -231,7 +231,7 @@ v1.0.0
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -537,7 +537,6 @@ public static partial class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
-
     public static DiagnosticDescriptor GenerateSbom => New(
        id: 0243,
        title: "Generate software bill of materials",


### PR DESCRIPTION
Additional logic is past through the constructor, instead of the `Walk` method.