### PR TITLE
Implement Track TODO tags for RESX

### DIFF
--- a/projects/ToDo/Resources.resx
+++ b/projects/ToDo/Resources.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter</value>
+  </resheader>
+  <!-- TODO: search for translation -->
+  <data name="B" xml:space="preserve">
+    <value>B value</value>
+  </data>
+  <data name="A" xml:space="preserve">
+    <value>A value</value>
+	<comment>TO-DOs: translate to both French and Dutch</comment>
+  </data>
+
+</root>

--- a/projects/ToDo/ToDo.csproj
+++ b/projects/ToDo/ToDo.csproj
@@ -18,4 +18,8 @@
     <Compile Include="../common/Code.cs" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
+  </PropertyGroup>
+
 </Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Track_TODO_tags.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Track_TODO_tags.cs
@@ -3,13 +3,20 @@ namespace Rules.MS_Build.Track_TODO_tags;
 public class Reports
 {
     [Test]
-    public void TODOs_and_FIXMEs() => new TrackToDoTags()
+    public void TODOs_and_FIXMEs_in_MS_BUILD() => new DotNetProjectFile.Analyzers.MsBuild.TrackToDoTags()
         .ForProject("ToDo.cs")
         .HasIssues(
-            Issue.WRN("Proj0033", @"Complete the task associated to this ""Fixme"" comment.").WithSpan(08, 54, 10, 02),
-            Issue.WRN("Proj0033", @"Complete the task associated to this ""FIX ME"" comment.").WithSpan(12, 06, 14, 02),
-            Issue.WRN("Proj0033", @"Complete the task associated to this ""TODO"" comment.").WithSpan(06, 06, 06, 34),
-            Issue.WRN("Proj0033", @"Complete the task associated to this ""to-do"" comment.").WithSpan(16, 56, 18, 02));
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""Fixme"" comment.").WithSpan(08, 54, 10, 02),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""FIX ME"" comment.").WithSpan(12, 06, 14, 02),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment.").WithSpan(06, 06, 06, 34),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""to-do"" comment.").WithSpan(16, 56, 18, 02));
+
+    [Test]
+    public void TODOs_and_FIXMEs_in_RESX() => new DotNetProjectFile.Analyzers.Resx.TrackToDoTags()
+        .ForProject("ToDo.cs")
+        .HasIssues(
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment.").WithSpan(14, 06, 14, 36),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TO-DOs"" comment.").WithSpan(20, 09, 20, 52));
 }
 
 public class Has_no_issues

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Resx/TrackToDoTags.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Resx/TrackToDoTags.cs
@@ -1,0 +1,20 @@
+using DotNetProjectFile.Resx;
+
+namespace DotNetProjectFile.Analyzers.Resx;
+
+/// <summary>Implements <see cref="Rule.TrackToDoTags"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class TrackToDoTags() : ResourceFileAnalyzer(Rule.TrackToDoTags)
+{
+    private readonly ToDoChecker<Resource> Checker = new(Rule.TrackToDoTags, GetText);
+
+    /// <inheritdoc />
+    protected override void Register(ResourceFileAnalysisContext context)
+        => Checker.Check(context.File, context.File.Text, context);
+
+    private static string? GetText(XmlAnalysisNode node) => node switch
+    {
+        Comment c => c.Text,
+        _ => null,
+    };
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -31,7 +31,7 @@
 To be released:
 - Proj0009: Take conditionals into account. (FP)
 - Proj0032: Migarate away from BinaryFormatter. (NEW RULE)
-- Proj3001: Track uses of ""TODO"" tags (MS BUILD and RESX). (NEW RULE)
+- Proj3001: Track uses of "TODO" tags (MS BUILD and RESX). (NEW RULE)
 v1.5.3
 - Disable INI based rules by default. (BUG)
 v1.5.2

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -31,7 +31,7 @@
 To be released:
 - Proj0009: Take conditionals into account. (FP)
 - Proj0032: Migarate away from BinaryFormatter. (NEW RULE)
-- Proj0033: Track uses of ""TODO"" tags. (NEW RULE)
+- Proj3001: Track uses of ""TODO"" tags (MS BUILD and RESX). (NEW RULE)
 v1.5.3
 - Disable INI based rules by default. (BUG)
 v1.5.2

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -108,7 +108,7 @@ The package contains analyzers that analyze .NET project files.
 
 ## Generic
 * [**Proj3000** Only use UTF-8 without BOM](https://dotnet-project-file-analyzers.github.io/rules/Proj3000.html)
-* [**Proj3001** Track uses of ""TODO"" tags](https://dotnet-project-file-analyzers.github.io/rules/Proj3001.html)
+* [**Proj3001** Track uses of "TODO" tags](https://dotnet-project-file-analyzers.github.io/rules/Proj3001.html)
 
 ## INI
 * [**Proj4000** Invalid INI file](https://dotnet-project-file-analyzers.github.io/rules/Proj4000.html)

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -34,7 +34,6 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0030** Use VB.NET specific properties only when applicable](https://dotnet-project-file-analyzers.github.io/rules/Proj0030.html)
 * [**Proj0031** Adopt preferred casing of nodes](https://dotnet-project-file-analyzers.github.io/rules/Proj0031.html)
 * [**Proj0032** Migrate away from BinaryFormatter](https://dotnet-project-file-analyzers.github.io/rules/Proj0032.html)
-* [**Proj0033** Track uses of ""TODO"" tags](https://dotnet-project-file-analyzers.github.io/rules/Proj0033.html)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](https://dotnet-project-file-analyzers.github.io/rules/Proj0200.html)
@@ -109,6 +108,7 @@ The package contains analyzers that analyze .NET project files.
 
 ## Generic
 * [**Proj3000** Only use UTF-8 without BOM](https://dotnet-project-file-analyzers.github.io/rules/Proj3000.html)
+* [**Proj3001** Track uses of ""TODO"" tags](https://dotnet-project-file-analyzers.github.io/rules/Proj3001.html)
 
 ## INI
 * [**Proj4000** Invalid INI file](https://dotnet-project-file-analyzers.github.io/rules/Proj4000.html)

--- a/src/DotNetProjectFile.Analyzers/Resx/Comment.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Comment.cs
@@ -1,0 +1,6 @@
+namespace DotNetProjectFile.Resx;
+
+public sealed class Comment(XElement element, Resource resource) : Node(element, resource)
+{
+    public string? Text => Element.Value;
+}

--- a/src/DotNetProjectFile.Analyzers/Resx/Node.Create.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Node.Create.cs
@@ -2,13 +2,13 @@ namespace DotNetProjectFile.Resx;
 
 public partial class Node
 {
-    internal Node? Create(XElement element)
-        => element.Name.LocalName switch
-        {
-            null => null,
-            "resheader" /*.*/ => new ResHeader(element, Resource),
-            "data" /*......*/ => new Data(element, Resource),
-            "value" /*.....*/ => new Value(element, Resource),
-            _ => new Unknown(element, Resource),
-        };
+    internal Node? Create(XElement element) => element.Name.LocalName switch
+    {
+        null => null,
+        "resheader" /*.*/ => new ResHeader(element, Resource),
+        "comment" /*...*/ => new Comment(element, Resource),
+        "data" /*......*/ => new Data(element, Resource),
+        "value" /*.....*/ => new Value(element, Resource),
+        _ => new Unknown(element, Resource),
+    };
 }

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -294,17 +294,6 @@ public static partial class Rule
         tags: ["Bug", "Security", "Vulnerability"],
         category: Category.Security);
 
-    public static DiagnosticDescriptor TrackToDoTags => New(
-        id: 0033,
-        title: @"Track uses of ""TODO"" tags",
-        message: @"Complete the task associated to this ""{0}"" comment.",
-        description:
-            "Developers often use TODO tags to mark areas in the code where " +
-            "additional work or improvements are needed but are not implemented " +
-            "immediately.",
-        tags: ["Code smell"],
-        category: Category.CodeSmell);
-
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,
         title: "Define the project packability explicitly",
@@ -867,6 +856,17 @@ public static partial class Rule
             "includes multiple web based files such as Javascript and CSS.",
         tags: ["encoding", "UTF-8"],
         category: Category.Reliability);
+
+    public static DiagnosticDescriptor TrackToDoTags => New(
+        id: 3001,
+        title: @"Track uses of ""TODO"" tags",
+        message: @"Complete the task associated to this ""{0}"" comment.",
+        description:
+            "Developers often use TODO tags to mark areas in the code where " +
+            "additional work or improvements are needed but are not implemented " +
+            "immediately.",
+        tags: ["Code smell"],
+        category: Category.CodeSmell);
 
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.


### PR DESCRIPTION
After implementing it for MS BUILD (#262), also implement it for RESX files. Part of this is updating the diagnostics ID from 0033 (MS BUILD range) to 3001 (Generic range).

See #250 