### PR TITLE
Do not automatically include DotNetProjectFile.Analyzers

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
@@ -99,22 +99,6 @@ public partial class Rules
     private static partial Regex AmountPattern();
 }
 
-
-public class SDK
-{
-    [Test]
-    public void references_latest_version()
-    {
-        var proj = ProjectFiles.Global.MsBuildProject(IOFile.Parse("../../../../../src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj"));
-        var prop = ProjectFiles.Global.MsBuildProject(IOFile.Parse("../../../../../src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props"));
-
-        var vers = proj!.PropertyGroups.SelectMany(p => p.Version).Last().Value;
-        var reff = prop!.ItemGroups.SelectMany(p => p.PackageReferences).Single(p => p.Include == "DotNetProjectFile.Analyzers").Version;
-        vers.Should().NotBeEmpty();
-        reff.Should().Be(vers);
-    }
-}
-
 /// <remarks>Wrapper for better display of test resources in IDE.</remarks>
 public sealed record Rule(DiagnosticDescriptor Descriptor)
 {

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -28,6 +28,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased
+- Do not longer automatically include DotNetProjectFile.Analyzers
 v1.5.4
 - Prevent NU1504 from being raised when Directory.Packages.props is used. (BUG)
 v1.5.3

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <!-- The TargetFramework may be overridden, but has a fine default. -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <!-- We do not want to enable default items here -->
@@ -37,17 +36,6 @@
 
   <ItemGroup>
     <None Include="**/TestResults/**" />
-  </ItemGroup>
-
-
-  <!-- Ensure our analyzers are available -->
-  <ItemGroup>
-    <!--
-      Remove first to ensure we do not get a NU1504. This can happen because
-      Directory.Packages.props has been used.
-    -->
-    <PackageReference Remove="DotNetProjectFile.Analyzers" />
-    <PackageReference Include="DotNetProjectFile.Analyzers" Version="1.5.4" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
By automatically including `DotNetProjectFile.Analyzers` via a package reference, multiple issues can occur. With #259 we successfully prevented NU1504 from happening, but with `<ManagePackageVersionsCentrally>` enabled, we also have to deal with setting versions or not. It is a mess. Long story short, the SDK will not longer automatically include the analyzer, and should be added manually.

In most cases, this will not change a thing, as the the analyzer was already included for all projects via `Directory.Build.props`.