### PR TITLE
Fix error reporting in wrong files

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_package_references_once.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_package_references_once.cs
@@ -8,7 +8,6 @@ public class Reports
        .ForProject("DoublePackageReferences.cs")
        .HasIssues(
             new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(04, 04, 04, 57).WithPath("DoublePackageReferences.props"),
-            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(04, 04, 04, 57).WithPath("DoublePackageReferences.csproj"),
             new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(10, 04, 10, 57).WithPath("DoublePackageReferences.csproj"),
             new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(11, 04, 11, 57).WithPath("DoublePackageReferences.csproj"));
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Track_TODO_tags.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Track_TODO_tags.cs
@@ -6,17 +6,17 @@ public class Reports
     public void TODOs_and_FIXMEs_in_MS_BUILD() => new DotNetProjectFile.Analyzers.MsBuild.TrackToDoTags()
         .ForProject("ToDo.cs")
         .HasIssues(
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""Fixme"" comment.").WithSpan(08, 54, 10, 02),
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""FIX ME"" comment.").WithSpan(12, 06, 14, 02),
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment.").WithSpan(06, 06, 06, 34),
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""to-do"" comment.").WithSpan(16, 56, 18, 02));
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""Fixme"" comment.").WithSpan(08, 54, 10, 02).WithPath("ToDo.csproj"),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""FIX ME"" comment.").WithSpan(12, 06, 14, 02).WithPath("ToDo.csproj"),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment.").WithSpan(06, 06, 06, 34).WithPath("ToDo.csproj"),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""to-do"" comment.").WithSpan(16, 56, 18, 02).WithPath("ToDo.csproj"));
 
     [Test]
     public void TODOs_and_FIXMEs_in_RESX() => new DotNetProjectFile.Analyzers.Resx.TrackToDoTags()
         .ForProject("ToDo.cs")
         .HasIssues(
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment.").WithSpan(14, 06, 14, 36),
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""TO-DOs"" comment.").WithSpan(20, 09, 20, 52));
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment.").WithSpan(14, 06, 14, 36).WithPath("Resources.resx"),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TO-DOs"" comment.").WithSpan(20, 09, 20, 52).WithPath("Resources.resx"));
 }
 
 public class Has_no_issues

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -24,11 +24,11 @@
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers SDK</Description>
     <PackageTags>SDK;Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
-    <Version>1.5.4</Version>
+    <Version>1.5.5</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
-ToBeReleased
+v1.5.5
 - No longer automatically include DotNetProjectFile.Analyzers
 v1.5.4
 - Prevent NU1504 from being raised when Directory.Packages.props is used. (BUG)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/EditorConfig/HeaderMustBeGlob.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/EditorConfig/HeaderMustBeGlob.cs
@@ -15,7 +15,7 @@ public sealed class HeaderMustBeGlob() : IniFileAnalyzer(Rule.Ini.HeaderMustBeGl
             .Where(h => h.Text is { Length: > 0 } && Glob.TryParse(h.Text) is null))
         {
             var span = header.Tokens.First(t => t.Kind == TokenKind.HeaderTextToken);
-            context.ReportDiagnostic(Descriptor, span.LinePositionSpan, header.Text);
+            context.ReportDiagnostic(Descriptor, context.File, span.LinePositionSpan, header.Text);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/EditorConfig/UseEqualsAssign.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/EditorConfig/UseEqualsAssign.cs
@@ -11,7 +11,7 @@ public sealed class UseEqualsAssign() : IniFileAnalyzer(Rule.Ini.UseEqualsAssign
 
         foreach (var colon in context.File.Syntax.Tokens.Where(t => t.Kind == TokenKind.ColonToken))
         {
-            context.ReportDiagnostic(Descriptor, colon.LinePositionSpan);
+            context.ReportDiagnostic(Descriptor, context.File, colon.LinePositionSpan);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
@@ -42,7 +42,7 @@ internal sealed class IdentationChecker<TFile>(
         if (!ProperlyIndented(element) && !ClosingTagAfterTextWithSpacePreservation(node.Element))
         {
             var name = start ? node.LocalName : '/' + node.LocalName;
-            context.ReportDiagnostic(Descriptor, element, name);
+            context.ReportDiagnostic(Descriptor, node.Project, element, name);
         }
 
         bool ProperlyIndented(LinePositionSpan element)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/ToDoChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/ToDoChecker.cs
@@ -20,11 +20,11 @@ internal sealed class ToDoChecker<TFile>(
         foreach (var comment in node.Element
             .DescendantNodes()
             .OfType<XComment>()
-            .Select(x => new XmlComment(x)))
+            .Select(x => new XmlComment(x, context.File)))
         {
             if (ToDoChecker.IsIssue(comment.Text) is { } issue)
             {
-                context.ReportDiagnostic(Descriptor, comment.Positions.InnerSpan, issue);
+                context.ReportDiagnostic(Descriptor, comment, issue);
             }
         }
 
@@ -38,7 +38,7 @@ internal sealed class ToDoChecker<TFile>(
     {
         if (GetText(node) is { Length: >= 4 } txt && ToDoChecker.IsIssue(txt) is { } issue)
         {
-            context.ReportDiagnostic(Descriptor, node.Positions.InnerSpan, issue);
+            context.ReportDiagnostic(Descriptor, node, issue);
         }
 
         foreach (var child in node.Children())

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/ToDoChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/ToDoChecker.cs
@@ -24,7 +24,7 @@ internal sealed class ToDoChecker<TFile>(
         {
             if (ToDoChecker.IsIssue(comment.Text) is { } issue)
             {
-                context.ReportDiagnostic(Descriptor, comment, issue);
+                context.ReportDiagnostic(Descriptor, comment.Project, comment.Positions.InnerSpan, issue);
             }
         }
 
@@ -38,7 +38,7 @@ internal sealed class ToDoChecker<TFile>(
     {
         if (GetText(node) is { Length: >= 4 } txt && ToDoChecker.IsIssue(txt) is { } issue)
         {
-            context.ReportDiagnostic(Descriptor, node, issue);
+            context.ReportDiagnostic(Descriptor, node.Project, node.Positions.InnerSpan, issue);
         }
 
         foreach (var child in node.Children())

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Ini/EmptySection.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Ini/EmptySection.cs
@@ -9,7 +9,7 @@ public sealed class EmptySection() : IniFileAnalyzer(Rule.Ini.EmptySection)
             .Where(s => s.KeyValuePairs.None())
             .Select(s => s.Header!))
         {
-            context.ReportDiagnostic(Descriptor, header.LinePositionSpan, header.Text);
+            context.ReportDiagnostic(Descriptor, context.File, header.LinePositionSpan, header.Text);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ConfigureCentralPackageVersionManagement.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ConfigureCentralPackageVersionManagement.cs
@@ -10,7 +10,7 @@ public sealed class ConfigureCentralPackageVersionManagement() : MsBuildProjectF
     {
         if (context.File.ManagePackageVersionsCentrally() is null)
         {
-            context.ReportDiagnostic(Descriptor, context.File.Positions.StartElement);
+            context.ReportDiagnostic(Descriptor, context.File, context.File.Positions.StartElement);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IncludeDirectoryPackagesProps.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IncludeDirectoryPackagesProps.cs
@@ -11,7 +11,7 @@ public sealed class IncludeDirectoryPackagesProps() : MsBuildProjectFileAnalyzer
         if (context.File.ManagePackageVersionsCentrally().GetValueOrDefault()
             && context.File.DirectoryPackagesProps is null)
         {
-            context.ReportDiagnostic(Descriptor, context.File.Positions.StartElement);
+            context.ReportDiagnostic(Descriptor, context.File, context.File.Positions.StartElement);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OmitXmlDeclarations.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OmitXmlDeclarations.cs
@@ -10,7 +10,7 @@ public sealed class OmitXmlDeclarations() : MsBuildProjectFileAnalyzer(Rule.Omit
         if (context.File.Element.Document.Declaration is { })
         {
             var span = new LinePositionSpan(default, context.File.Positions.StartElement.Start);
-            context.ReportDiagnostic(Descriptor, span);
+            context.ReportDiagnostic(Descriptor, context.File, span);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCDATAForLargeTexts.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCDATAForLargeTexts.cs
@@ -11,7 +11,7 @@ public sealed class UseCDATAForLargeTexts() : MsBuildProjectFileAnalyzer(Rule.Us
         {
             if (node is PackageReleaseNotes && !node.Element.ContainsCDATA())
             {
-                context.ReportDiagnostic(Descriptor, node.Positions.InnerSpan);
+                context.ReportDiagnostic(Descriptor, context.File, node.Positions.InnerSpan);
             }
 
             foreach (var child in node.Children)

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -31,7 +31,7 @@ public readonly struct ProjectFileAnalysisContext<TFile>(
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, XmlAnalysisNode node, params object?[]? messageArgs)
-        => ReportDiagnostic(descriptor, node.Project.GetLocation(node.Positions.FullSpan), messageArgs);
+        => ReportDiagnostic(descriptor, node.Project, node.Positions.FullSpan, messageArgs);
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, ProjectFile file, LinePositionSpan span, params object?[]? messageArgs)

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -35,7 +35,7 @@ public readonly struct ProjectFileAnalysisContext<TFile>(
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, ProjectFile file, LinePositionSpan span, params object?[]? messageArgs)
-        => ReportDiagnostic(descriptor, File.GetLocation(span), messageArgs);
+        => ReportDiagnostic(descriptor, file.GetLocation(span), messageArgs);
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, Location location, params object?[]? messageArgs)

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -30,15 +30,11 @@ public readonly struct ProjectFileAnalysisContext<TFile>(
     public CancellationToken CancellationToken { get; } = cancellationToken;
 
     /// <summary>Reports a diagnostic about the project file.</summary>
-    public void ReportDiagnostic(DiagnosticDescriptor descriptor, Node node, params object?[]? messageArgs)
-        => ReportDiagnostic(descriptor, node.Positions.FullSpan, messageArgs);
-
-    /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, XmlAnalysisNode node, params object?[]? messageArgs)
-        => ReportDiagnostic(descriptor, node.Positions.FullSpan, messageArgs);
+        => ReportDiagnostic(descriptor, node.Project.GetLocation(node.Positions.FullSpan), messageArgs);
 
     /// <summary>Reports a diagnostic about the project file.</summary>
-    public void ReportDiagnostic(DiagnosticDescriptor descriptor, LinePositionSpan span, params object?[]? messageArgs)
+    public void ReportDiagnostic(DiagnosticDescriptor descriptor, ProjectFile file, LinePositionSpan span, params object?[]? messageArgs)
         => ReportDiagnostic(descriptor, File.GetLocation(span), messageArgs);
 
     /// <summary>Reports a diagnostic about the project file.</summary>

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -24,11 +24,11 @@
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
-    <Version>1.5.4</Version>
+    <Version>1.5.5</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
-ToBeReleased
+v1.5.5
 - Fix some warnings being reported in the wrong files.
 - Fix crashes related to errors being reported in the wrong files.
 v1.5.4

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -24,11 +24,11 @@
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
-    <Version>1.5.5</Version>
+    <Version>1.5.4</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
-v1.5.5
+ToBeReleased
 - Fix some warnings being reported in the wrong files.
 - Fix crashes related to errors being reported in the wrong files.
 v1.5.4

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -24,10 +24,13 @@
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
-    <Version>1.5.4</Version>
+    <Version>1.5.5</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+v1.5.5
+- Fix some warnings being reported in the wrong files.
+- Fix crashes related to errors being reported in the wrong files.
 v1.5.4
 - Proj0009: Take conditionals into account. (FP)
 - Proj0032: Migarate away from BinaryFormatter. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -23,7 +23,9 @@ public abstract class Node : XmlAnalysisNode
         Depth = element.Depth();
     }
 
-    internal readonly Project Project;
+    public Project Project { get; }
+
+    ProjectFile XmlAnalysisNode.Project => Project;
 
     public XElement Element { get; }
 

--- a/src/DotNetProjectFile.Analyzers/Resx/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Node.cs
@@ -1,3 +1,4 @@
+
 namespace DotNetProjectFile.Resx;
 
 public partial class Node : XmlAnalysisNode
@@ -22,6 +23,8 @@ public partial class Node : XmlAnalysisNode
     public string LocalName => Element.Name.LocalName;
 
     public IReadOnlyList<Node> Children { get; }
+
+    ProjectFile XmlAnalysisNode.Project => Resource;
 
     IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
@@ -10,5 +10,7 @@ public interface XmlAnalysisNode
 
     int Depth { get; }
 
+    ProjectFile Project { get; }
+
     IEnumerable<XmlAnalysisNode> Children();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlComment.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlComment.cs
@@ -1,11 +1,13 @@
 namespace DotNetProjectFile.Xml;
 
-public sealed class XmlComment(XComment comment) : XmlAnalysisNode
+public sealed class XmlComment(XComment comment, ProjectFile project) : XmlAnalysisNode
 {
     /// <inheritdoc />
     public XElement Element { get; } = comment.Parent;
 
     public XComment Comment { get; } = comment;
+
+    public ProjectFile Project { get; } = project;
 
     /// <inheritdoc />
     public XmlPositions Positions { get; } = XmlPositions.New(comment);


### PR DESCRIPTION
Closes #266 

It turned out that in many cases we assumed that the `.ReportDiagnostic` was called on the context of the file we were reporting an error in, which didn't always turn out to be a correct assumption.

I solved this by:
- hoisting the `ProjectFile` `Project` property to the `XmlAnalysisNode` interface.
- Updating `XmlAnalysisNode` implementations to match the new interface.
- Use the `ProjectFile` from the `XmlAnalysisNode` we are reporting on, rather than the one from the context.
- Added a mandatory `ProjectFile` argument to the `.ReportDiagnostic` method that takes a linespan, in order to prevent accidental incorrect usage.