### PR TITLE
Introduction of XML Locations

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Configure_CPM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Configure_CPM.cs
@@ -3,8 +3,7 @@ namespace Rules.MS_Build.Configure_CPM;
 public class Reports
 {
     [Test]
-    public void project_without_CPM()
-        => new ConfigureCentralPackageVersionManagement()
+    public void project_without_CPM() => new ConfigureCentralPackageVersionManagement()
         .ForProject("NoCPM.cs")
         .HasIssue(new Issue("Proj0800", "Define the <ManagePackageVersionsCentrally> node with the value 'true', or 'false'.")
         .WithSpan(00, 00, 00, 32));
@@ -13,15 +12,13 @@ public class Reports
 public class Guards
 {
     [Test]
-    public void Projects_with_CPM_file()
-        => new ConfigureCentralPackageVersionManagement()
+    public void Projects_with_CPM_file() => new ConfigureCentralPackageVersionManagement()
        .ForProject("UseCPM.cs")
        .HasNoIssues();
 
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
-    public void Projects_explicitly_without_CPM(string project)
-         => new ConfigureCentralPackageVersionManagement()
+    public void Projects_explicitly_without_CPM(string project) => new ConfigureCentralPackageVersionManagement()
         .ForProject(project)
         .HasNoIssues();
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Include_Directory_Packages_props.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Include_Directory_Packages_props.cs
@@ -3,8 +3,7 @@ namespace Rules.MS_Build.Include_Directory_Packages_props;
 public class Reports
 {
     [Test]
-    public void project_without_file()
-        => new IncludeDirectoryPackagesProps()
+    public void project_without_file() => new IncludeDirectoryPackagesProps()
         .ForProject("NoDirectoryPackagesProps.cs")
         .HasIssue(new Issue("Proj0801", "The file 'Directory.Packages.props' could not be located.")
         .WithSpan(00, 00, 00, 32));
@@ -13,15 +12,13 @@ public class Reports
 public class Guards
 {
     [Test]
-    public void Projects_with_CPM_file()
-        => new IncludeDirectoryPackagesProps()
+    public void Projects_with_CPM_file() => new IncludeDirectoryPackagesProps()
        .ForProject("UseCPM.cs")
        .HasNoIssues();
 
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
-    public void Projects_explicitly_without_CPM(string project)
-         => new IncludeDirectoryPackagesProps()
+    public void Projects_explicitly_without_CPM(string project) => new IncludeDirectoryPackagesProps()
         .ForProject(project)
         .HasNoIssues();
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Ommit_XML_declaration.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Ommit_XML_declaration.cs
@@ -3,19 +3,17 @@ namespace Rules.MS_Build.Omit_XML_declaration;
 public class Reports
 {
     [Test]
-    public void on_double_imports()
-       => new OmitXmlDeclarations()
+    public void on_double_imports() => new OmitXmlDeclarations()
        .ForProject("XmlDeclaration.cs")
        .HasIssue(new Issue("Proj1702", "Remove the XML declaration as it is redundant.")
-       .WithSpan(00, 00, 01, 00));
+       .WithSpan(01, 00, 01, 32));
 }
 
 public class Guards
 {
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
-    public void Projects_without_issues(string project)
-         => new OmitXmlDeclarations()
+    public void Projects_without_issues(string project) => new OmitXmlDeclarations()
         .ForProject(project)
         .HasNoIssues();
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_CDATA_for_large_texts.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_CDATA_for_large_texts.cs
@@ -3,8 +3,7 @@ namespace Rules.MS_Build.Use_CDATA_for_large_texts;
 public class Reports
 {
     [Test]
-    public void missing_CDATA()
-        => new UseCDATAForLargeTexts()
+    public void missing_CDATA() => new UseCDATAForLargeTexts()
         .ForProject("MissingCDATA.cs")
         .HasIssue(new Issue("Proj1701", "Add <![CDATA[ and ]]> around this text.")
         .WithSpan(17, 24, 23, 04));
@@ -13,15 +12,13 @@ public class Reports
 public class Guards
 {
     [Test]
-    public void missing_CDATA()
-        => new UseCDATAForLargeTexts()
+    public void missing_CDATA() => new UseCDATAForLargeTexts()
         .ForProject("PackageDescription.cs")
         .HasNoIssues();
 
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
-    public void Projects_without_issues(string project)
-         => new StaticAliasUsingNotSupported()
+    public void Projects_without_issues(string project) => new UseCDATAForLargeTexts()
         .ForProject(project)
         .HasNoIssues();
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/IdentationChecker.cs
@@ -32,17 +32,19 @@ internal sealed class IdentationChecker<TFile>(
 
     private void Report(XmlAnalysisNode node, SourceText text, ProjectFileAnalysisContext<TFile> context, bool start)
     {
-        var checkSelfClosingEnd = !start && node.Positions.IsSelfClosing;
-        var startAndEndOnSameLine = !start && node.Positions.StartElement.End.Line == node.Positions.EndElement.Start.Line;
+        var positions = node.Locations.Positions;
+
+        var checkSelfClosingEnd = !start && positions.IsSelfClosing;
+        var startAndEndOnSameLine = !start && positions.StartElement.End.Line == positions.EndElement.Start.Line;
 
         if (checkSelfClosingEnd || startAndEndOnSameLine) { return; }
 
-        var element = start ? node.Positions.StartElement : node.Positions.EndElement;
+        var element = start ? positions.StartElement : positions.EndElement;
 
         if (!ProperlyIndented(element) && !ClosingTagAfterTextWithSpacePreservation(node.Element))
         {
             var name = start ? node.LocalName : '/' + node.LocalName;
-            context.ReportDiagnostic(Descriptor, node.Project, element, name);
+            context.ReportDiagnostic(Descriptor, start ? node.Locations.StartElement : node.Locations.EndElement, name);
         }
 
         bool ProperlyIndented(LinePositionSpan element)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/ToDoChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/ToDoChecker.cs
@@ -24,7 +24,7 @@ internal sealed class ToDoChecker<TFile>(
         {
             if (ToDoChecker.IsIssue(comment.Text) is { } issue)
             {
-                context.ReportDiagnostic(Descriptor, comment.Project, comment.Positions.InnerSpan, issue);
+                context.ReportDiagnostic(Descriptor, comment.Locations.InnerSpan, issue);
             }
         }
 
@@ -38,7 +38,7 @@ internal sealed class ToDoChecker<TFile>(
     {
         if (GetText(node) is { Length: >= 4 } txt && ToDoChecker.IsIssue(txt) is { } issue)
         {
-            context.ReportDiagnostic(Descriptor, node.Project, node.Positions.InnerSpan, issue);
+            context.ReportDiagnostic(Descriptor, node.Locations.InnerSpan, issue);
         }
 
         foreach (var child in node.Children())

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ConfigureCentralPackageVersionManagement.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ConfigureCentralPackageVersionManagement.cs
@@ -10,7 +10,7 @@ public sealed class ConfigureCentralPackageVersionManagement() : MsBuildProjectF
     {
         if (context.File.ManagePackageVersionsCentrally() is null)
         {
-            context.ReportDiagnostic(Descriptor, context.File, context.File.Positions.StartElement);
+            context.ReportDiagnostic(Descriptor, context.File, context.File.Locations.StartElement);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ConfigureCentralPackageVersionManagement.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ConfigureCentralPackageVersionManagement.cs
@@ -1,16 +1,18 @@
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
+/// <summary>Implements <see cref="Rule.ConfigureCentralPackageVersionManagement"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class ConfigureCentralPackageVersionManagement() : MsBuildProjectFileAnalyzer(Rule.ConfigureCentralPackageVersionManagement)
 {
     /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile_DirectoryPackages;
 
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         if (context.File.ManagePackageVersionsCentrally() is null)
         {
-            context.ReportDiagnostic(Descriptor, context.File, context.File.Locations.StartElement);
+            context.ReportDiagnostic(Descriptor, context.File.Locations.StartElement);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GuardUnsupported.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GuardUnsupported.cs
@@ -20,7 +20,7 @@ public sealed class GuardUnsupported() : MsBuildProjectFileAnalyzer(
         }
         else if (project.IsLegacy)
         {
-            context.ReportDiagnostic(Diagnostic.Create(Rule.UpdateLegacyProjects, project.GetLocation(project.Positions.FullSpan)));
+            context.ReportDiagnostic(Diagnostic.Create(Rule.UpdateLegacyProjects,project.Locations.FullSpan));
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IncludeDirectoryPackagesProps.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IncludeDirectoryPackagesProps.cs
@@ -1,17 +1,19 @@
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
+/// <summary>Implements <see cref="Rule.IncludeDirectoryPackagesProps"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class IncludeDirectoryPackagesProps() : MsBuildProjectFileAnalyzer(Rule.IncludeDirectoryPackagesProps)
 {
     /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
 
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         if (context.File.ManagePackageVersionsCentrally().GetValueOrDefault()
             && context.File.DirectoryPackagesProps is null)
         {
-            context.ReportDiagnostic(Descriptor, context.File, context.File.Locations.StartElement);
+            context.ReportDiagnostic(Descriptor, context.File.Locations.StartElement);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IncludeDirectoryPackagesProps.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IncludeDirectoryPackagesProps.cs
@@ -11,7 +11,7 @@ public sealed class IncludeDirectoryPackagesProps() : MsBuildProjectFileAnalyzer
         if (context.File.ManagePackageVersionsCentrally().GetValueOrDefault()
             && context.File.DirectoryPackagesProps is null)
         {
-            context.ReportDiagnostic(Descriptor, context.File, context.File.Positions.StartElement);
+            context.ReportDiagnostic(Descriptor, context.File, context.File.Locations.StartElement);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OmitXmlDeclarations.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OmitXmlDeclarations.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis.Text;
-
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
@@ -9,8 +7,7 @@ public sealed class OmitXmlDeclarations() : MsBuildProjectFileAnalyzer(Rule.Omit
     {
         if (context.File.Element.Document.Declaration is { })
         {
-            var span = new LinePositionSpan(default, context.File.Positions.StartElement.Start);
-            context.ReportDiagnostic(Descriptor, context.File, span);
+            context.ReportDiagnostic(Descriptor, context.File.Locations.StartElement);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCDATAForLargeTexts.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCDATAForLargeTexts.cs
@@ -11,7 +11,7 @@ public sealed class UseCDATAForLargeTexts() : MsBuildProjectFileAnalyzer(Rule.Us
         {
             if (node is PackageReleaseNotes && !node.Element.ContainsCDATA())
             {
-                context.ReportDiagnostic(Descriptor, context.File, node.Positions.InnerSpan);
+                context.ReportDiagnostic(Descriptor, context.File, node.Locations.InnerSpan);
             }
 
             foreach (var child in node.Children)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCDATAForLargeTexts.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCDATAForLargeTexts.cs
@@ -1,8 +1,10 @@
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
+/// <summary>Implements <see cref="Rule.UseCDATAForLargeTexts"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class UseCDATAForLargeTexts() : MsBuildProjectFileAnalyzer(Rule.UseCDATAForLargeTexts)
 {
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         Walk(context.File);
@@ -11,7 +13,7 @@ public sealed class UseCDATAForLargeTexts() : MsBuildProjectFileAnalyzer(Rule.Us
         {
             if (node is PackageReleaseNotes && !node.Element.ContainsCDATA())
             {
-                context.ReportDiagnostic(Descriptor, context.File, node.Locations.InnerSpan);
+                context.ReportDiagnostic(Descriptor, node.Locations.InnerSpan);
             }
 
             foreach (var child in node.Children)

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -31,7 +31,7 @@ public readonly struct ProjectFileAnalysisContext<TFile>(
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, XmlAnalysisNode node, params object?[]? messageArgs)
-        => ReportDiagnostic(descriptor, node.Project, node.Positions.FullSpan, messageArgs);
+        => ReportDiagnostic(descriptor, node.Locations.FullSpan, messageArgs);
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, ProjectFile file, LinePositionSpan span, params object?[]? messageArgs)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -28,9 +28,11 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased:
+- Introduction of XmlLocations to create Location based on XmlPositions.
 v1.5.5
-- Fix some warnings being reported in the wrong files.
-- Fix crashes related to errors being reported in the wrong files.
+- Fix some warnings being reported in the wrong files. (BUG)
+- Fix crashes related to errors being reported in the wrong files. (BUG)
 v1.5.4
 - Proj0009: Take conditionals into account. (FP)
 - Proj0032: Migarate away from BinaryFormatter. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -19,13 +19,11 @@ public abstract class Node : XmlAnalysisNode
         Parent = parent;
         Project = project ?? (this as Project) ?? throw new ArgumentNullException(nameof(project));
         Children = element.Elements().Select(Create).ToArray();
-        Positions = XmlPositions.New(element);
+        Locations = XmlPositions.New(element).Locations(Project);
         Depth = element.Depth();
     }
 
     public Project Project { get; }
-
-    ProjectFile XmlAnalysisNode.Project => Project;
 
     public XElement Element { get; }
 
@@ -33,7 +31,7 @@ public abstract class Node : XmlAnalysisNode
 
     public int Depth { get; }
 
-    public XmlPositions Positions { get; }
+    public XmlLocations Locations { get; }
 
     public virtual object? Val => Element.Value;
 

--- a/src/DotNetProjectFile.Analyzers/Resx/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Node.cs
@@ -7,7 +7,7 @@ public partial class Node : XmlAnalysisNode
     {
         Element = element;
         Resource = resource ?? (this as Resource) ?? throw new ArgumentNullException(nameof(resource));
-        Positions = XmlPositions.New(element);
+        Locations = XmlPositions.New(element).Locations(Resource);
         Depth = element.Ancestors().Count();
         Children = Element.Elements().Select(Create).OfType<Node>().ToArray();
     }
@@ -18,13 +18,11 @@ public partial class Node : XmlAnalysisNode
 
     public int Depth { get; }
 
-    public XmlPositions Positions { get; }
+    public XmlLocations Locations { get; }
 
     public string LocalName => Element.Name.LocalName;
 
     public IReadOnlyList<Node> Children { get; }
-
-    ProjectFile XmlAnalysisNode.Project => Resource;
 
     IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlAnalysisNode.cs
@@ -4,13 +4,11 @@ public interface XmlAnalysisNode
 {
     XElement Element { get; }
 
-    XmlPositions Positions { get; }
+    XmlLocations Locations { get; }
 
     string LocalName { get; }
 
     int Depth { get; }
-
-    ProjectFile Project { get; }
 
     IEnumerable<XmlAnalysisNode> Children();
 }

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlComment.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlComment.cs
@@ -10,7 +10,7 @@ public sealed class XmlComment(XComment comment, ProjectFile project) : XmlAnaly
     public ProjectFile Project { get; } = project;
 
     /// <inheritdoc />
-    public XmlPositions Positions { get; } = XmlPositions.New(comment);
+    public XmlLocations Locations { get; } = XmlPositions.New(comment).Locations(project);
 
     /// <inheritdoc cref="XComment.Value" />
     public string Text => Comment.Value;

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlLocations.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlLocations.cs
@@ -1,0 +1,18 @@
+using Microsoft.CodeAnalysis.Text;
+
+namespace DotNetProjectFile.Xml;
+
+public sealed record XmlLocations
+{
+    public Location FullSpan => File.GetLocation(Positions.FullSpan);
+
+    public Location InnerSpan => File.GetLocation(Positions.InnerSpan);
+
+    public Location StartElement => File.GetLocation(Positions.StartElement);
+
+    public Location EndElement => File.GetLocation(Positions.EndElement);
+
+    public required ProjectFile File { get; init; }
+
+    public required XmlPositions Positions { get; init; }
+}

--- a/src/DotNetProjectFile.Analyzers/Xml/XmlPositions.cs
+++ b/src/DotNetProjectFile.Analyzers/Xml/XmlPositions.cs
@@ -15,6 +15,9 @@ public sealed record XmlPositions
 
     public bool IsSelfClosing => StartElement == EndElement;
 
+    [Pure]
+    public XmlLocations Locations(ProjectFile file) => new() { File = file, Positions = this };
+
     public static XmlPositions New(XElement element)
     {
         LinePosition? start = null;


### PR DESCRIPTION
`XmlLocations` is an object that combines the `XmlPositions` with the `ProjectFile`. It allows the `XmlPositions` to be created without having the knowledge of the `ProjectFile` and the reporting not to have to specify the `ProjectFile` being reported on.

Closes #269 