### PR TITLE
Fix TUnit related false positives

### DIFF
--- a/projects/TUnitTestProject/TUnitTestProject.csproj
+++ b/projects/TUnitTestProject/TUnitTestProject.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+
+  <ItemGroup Label="Build tools">
+    <PackageReference Include="TUnit" Version="0.6.100" PrivateAssets="all" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
@@ -19,14 +19,10 @@ public class Reports
 
 public class Guards
 {
-    [Test]
-    public void non_publishable_test_project()
-        => new TestProjectsRequireSdk()
-        .ForProject("TestProject.cs")
-        .HasNoIssues();
-
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
+    [TestCase("TestProject.cs")]
+    [TestCase("TUnitTestProject.cs")]
     public void non_test_project(string project)
          => new TestProjectsRequireSdk()
         .ForProject(project)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
@@ -11,12 +11,17 @@ public sealed class TestProjectsRequireSdk() : MsBuildProjectFileAnalyzer(
         var hasSdk = context.File
             .Walk().OfType<PackageReference>()
             .Any(r => r.Include == NuGet.Packages.Microsoft_NET_Test_Sdk.Name);
+        var hasTUnit = context.File
+            .Walk().OfType<PackageReference>()
+            .Any(r => r.Include == NuGet.Packages.TUnit.Name);
 
-        if (isTest && !hasSdk)
+        var hasSdkOrTUnit = hasSdk || hasTUnit;
+
+        if (isTest && !hasSdkOrTUnit)
         {
             context.ReportDiagnostic(Rule.TestProjectsRequireSdk, context.File);
         }
-        else if (!isTest && hasSdk)
+        else if (!isTest && hasSdkOrTUnit)
         {
             context.ReportDiagnostic(Rule.UsingMicrosoftNetTestSdkImpliesTestProject, context.File);
         }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -34,6 +34,8 @@ ToBeReleased:
 - Proj0244: Generate documentation file. (NEW RULE)
 - Proj0245: Don't mix Version and VersionPrefix/VersionSuffix. (NEW RULE)
 - Proj0246: Define VersionPrefix if VersionSuffix is defined. (NEW RULE)
+- Proj0452: No longer require test SDK for TUnit projects. (FP)
+- Proj1001: Fix for deprecated packages TUnit.Analyzers and TUnit.Assertions.Analyzers. (FP)
 - Proj1011: Now reports on PackageVersion node if present, instead of PackageReference.
 - Added AppendOnlyCollection to improve performance of parsing.
 - Introduction of XmlLocations to create Location based on XmlPositions.

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
@@ -4,6 +4,7 @@ public sealed class Packages : IReadOnlyCollection<Package>
 {
     public static readonly BuildExtension Microsoft_NET_Test_Sdk = new("Microsoft.NET.Test.Sdk");
     public static readonly BuildExtension Microsoft_Sbom_Targets = new("Microsoft.Sbom.Targets");
+    public static readonly BuildExtension TUnit = new("TUnit");
 
     public static readonly Packages All = new(
 
@@ -74,8 +75,6 @@ public sealed class Packages : IReadOnlyCollection<Package>
         new Analyzer("NUnit.Analyzers", "NUnit"),
         new Analyzer("RuntimeContracts.Analyzer", "RuntimeContracts"),
         new Analyzer("SerilogAnalyzer", "Serilog"),
-        new Analyzer("TUnit.Analyzers", "TUnit"),
-        new Analyzer("TUnit.Assertions.Analyzers", "TUnit.Assertions"),
         new Analyzer("xunit.analyzers", "xunit"),
         new Analyzer("ZeroFormatter.Analyzer", "ZeroFormatter"),
 
@@ -120,6 +119,7 @@ public sealed class Packages : IReadOnlyCollection<Package>
         new BuildExtension("MinVer"),
         new BuildExtension("NUnit3TestAdapter"),
         new BuildExtension("Nullable"),
+        TUnit,
         new BuildExtension("xunit.runner.visualstudio"));
 
     private readonly Dictionary<string, Package> items;


### PR DESCRIPTION
- TUnit.Analyzer and TUnit.Assertions.Analyzer are deprecated, so they shouldn't be recommended anymore (the analyzers are now included in the main packages).
- TUnit doesn't use VSTest and therefore doesn't require the test SDK (it even breaks if the test SDK is loaded).