### PR TITLE
Cache test projects & Execute in parallel

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Properties/AssemblyInfo.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: Parallelizable(ParallelScope.All)]

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Generic/Only_use_UTF-8_without_BOM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Generic/Only_use_UTF-8_without_BOM.cs
@@ -22,6 +22,7 @@ public class Reports
 public class Does_not_crash
 {
     [Test]
+    [NonParallelizable] // Required due to file lock
     public void scanning_locked_files()
     {
         using var _ = new FileInfo("../../../../../projects/MultipleEncodings/utf8-bom.css").Lock();

--- a/specs/DotNetProjectFile.Analyzers.Specs/TestTools/CachedProjectLoader.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/TestTools/CachedProjectLoader.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+
+namespace Specs.TestTools;
+
+internal static class CachedProjectLoader
+{
+    private static readonly ConcurrentDictionary<string, Entry> projectCache = new();
+    private static readonly Lock projectCacheLock = new();
+
+    private sealed class Entry(FileInfo file)
+    {
+        private readonly Lock locker = new();
+        private Project? value;
+
+        public Project Value
+        {
+            get
+            {
+                if (value is { })
+                {
+                    return value;
+                }
+
+                lock (locker)
+                {
+                    if (value is not { })
+                    {
+                        value = ProjectLoader.Load(file);
+                    }
+
+                    return value;
+                }
+            }
+        }
+    }
+
+    public static Project Load(FileInfo file)
+    {
+        var key = file.FullName;
+
+        if (projectCache.TryGetValue(key, out var project))
+        {
+            return project.Value;
+        }
+
+        lock (projectCacheLock)
+        {
+            if (!projectCache.TryGetValue(key, out project))
+            {
+                project = new Entry(file);
+                projectCache[key] = project;
+            }
+        }
+
+        return project.Value;
+    }
+}


### PR DESCRIPTION
Caches loaded projects to speed up the tests. This reduced the time to run all tests on the machine where I wrote the changes by roughly 60% (10 min -> 4 min). Perhaps this change should be moved to your roslyn test tools package, but for now this was some low hanging fruit for this project, since this doesn't properly deal with the scenario where the cache gets too crowded and runs into potential memory issues.

Edit: also made the tests run in parallel, which reduced the time further to only 1 minute (for a total of 90% reduction in execution time).

Edit 2: this also makes the pipeline run in 2.5 minutes instead of 8.5 minutes.