### PR TITLE
More package validation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![.NET project file analyzers logo](design/logo_128x128.png)
 # .NET project file analyzers
-Contains 90+ [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
+Contains 100+ [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 (static code) [diagnostic analyzers](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.diagnostics.diagnosticanalyzer)
 that report issues on .NET project files.
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
@@ -1,16 +1,18 @@
 using CodeAnalysis.TestTools.Contexts;
 using Specs.TestTools;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Security.Cryptography;
-using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal static class DiagnosticAnalyzerExtensions
 {
     [Pure]
-    public static ProjectAnalyzerVerifyContext ForInlineCsproj(this DiagnosticAnalyzer analyzer, string content)
+    public static ProjectAnalyzerVerifyContext ForInlineCsproj(
+        this DiagnosticAnalyzer analyzer,
+        [StringSyntax(StringSyntaxAttribute.Xml)] string content)
     {
         content = content.Trim();
 #pragma warning disable RS1035 // FP: Not an analyzer.

--- a/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
@@ -12,6 +12,7 @@ internal static class DiagnosticAnalyzerExtensions
     [Pure]
     public static ProjectAnalyzerVerifyContext ForInlineCsproj(this DiagnosticAnalyzer analyzer, string content)
     {
+        content = content.Trim();
 #pragma warning disable RS1035 // FP: Not an analyzer.
         var tempDir = Path.Combine(Path.GetTempPath(), "dotnet-project-file-analyzer/tests");
         var hash = GetHash(content);

--- a/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Extensions/Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer.cs
@@ -1,10 +1,48 @@
 using CodeAnalysis.TestTools.Contexts;
 using System.IO;
+using System.Security.Cryptography;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
 internal static class DiagnosticAnalyzerExtensions
 {
+    [Pure]
+    public static ProjectAnalyzerVerifyContext ForInlineCsproj(this DiagnosticAnalyzer analyzer, string content)
+    {
+#pragma warning disable RS1035 // FP: Not an analyzer.
+        var tempDir = Path.Combine(Path.GetTempPath(), "dotnet-project-file-analyzer/tests");
+        var hash = GetHash(content);
+        var dir = Path.Combine(tempDir, hash);
+        Directory.CreateDirectory(dir);
+        var fileName = Path.Combine(dir, $"{hash}.csproj");
+        var file = new FileInfo(fileName);
+
+        if (File.Exists(fileName))
+        {
+            var fileContent = File.ReadAllText(fileName);
+            var fileHash = GetHash(fileContent);
+
+            if (hash == fileHash)
+            {
+                return ForTestProject(analyzer, file);
+            }
+        }
+
+        File.WriteAllText(fileName, content);
+        return ForTestProject(analyzer, file);
+
+#pragma warning restore RS1035
+    }
+
+    private static string GetHash(string content)
+    {
+        var input = Encoding.UTF8.GetBytes(content);
+        using var md5 = MD5.Create();
+        var output = md5.ComputeHash(input);
+        var str = Convert.ToHexString(output);
+        return str;
+    }
+
     [Pure]
     public static ProjectAnalyzerVerifyContext ForProject(this DiagnosticAnalyzer analyzer, string fileName)
     {

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_attribute_checks.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_attribute_checks.cs
@@ -1,0 +1,72 @@
+namespace Rules.MS_Build.Enable_api_compatibility_attribute_checks;
+
+public class Reports
+{
+    [Test]
+    public void on_missing_property() => new EnableApiCompatibilityAttributeChecks()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0251", "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 07, 22));
+
+    [Test]
+    public void on_disabled_property() => new EnableApiCompatibilityAttributeChecks()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <ApiCompatEnableRuleAttributesMustMatch>false</ApiCompatEnableRuleAttributesMustMatch>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0251", "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 102));
+}
+
+public class Guards
+{
+    [TestCase("TestProject.cs")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new EnableApiCompatibilityAttributeChecks()
+        .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void on_enabled_property() => new EnableApiCompatibilityAttributeChecks()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <ApiCompatEnableRuleAttributesMustMatch>true</ApiCompatEnableRuleAttributesMustMatch>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+
+    [Test]
+    public void on_validation_disabled() => new EnableApiCompatibilityAttributeChecks()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <ApiCompatEnableRuleAttributesMustMatch>false</ApiCompatEnableRuleAttributesMustMatch>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_parameter_name_checks.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_parameter_name_checks.cs
@@ -1,0 +1,72 @@
+namespace Rules.MS_Build.Enable_api_compatibility_parameter_name_checks;
+
+public class Reports
+{
+    [Test]
+    public void on_missing_property() => new EnableApiCompatibilityParameterNameChecks()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0252", "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 07, 22));
+
+    [Test]
+    public void on_disabled_property() => new EnableApiCompatibilityParameterNameChecks()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <ApiCompatEnableRuleCannotChangeParameterName>false</ApiCompatEnableRuleCannotChangeParameterName>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0252", "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 114));
+}
+
+public class Guards
+{
+    [TestCase("TestProject.cs")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new EnableApiCompatibilityParameterNameChecks()
+        .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void on_enabled_property() => new EnableApiCompatibilityParameterNameChecks()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <ApiCompatEnableRuleCannotChangeParameterName>true</ApiCompatEnableRuleCannotChangeParameterName>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+
+    [Test]
+    public void on_validation_disabled() => new EnableApiCompatibilityParameterNameChecks()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <ApiCompatEnableRuleCannotChangeParameterName>false</ApiCompatEnableRuleCannotChangeParameterName>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_baseline_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_baseline_validation.cs
@@ -1,0 +1,80 @@
+namespace Rules.MS_Build.Enable_strict_mode_for_package_baseline_validation;
+
+public class Reports
+{
+    [Test]
+    public void on_missing_property() => new EnableStrictModeForPackageBaselineValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <PackageValidationBaselineName>DotNetProjectFile.Analyzers</PackageValidationBaselineName>
+                <PackageValidationBaselineVersion>1.5.0</PackageValidationBaselineVersion>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0247", "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 09, 22));
+
+    [Test]
+    public void on_disabled_property() => new EnableStrictModeForPackageBaselineValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <PackageValidationBaselineName>DotNetProjectFile.Analyzers</PackageValidationBaselineName>
+                <PackageValidationBaselineVersion>1.5.0</PackageValidationBaselineVersion>
+                <EnableStrictModeForBaselineValidation>false</EnableStrictModeForBaselineValidation>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0247", "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(07, 16, 07, 100));
+}
+
+public class Guards
+{
+    [TestCase("TestProject.cs")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new EnableStrictModeForPackageBaselineValidation()
+        .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void on_enabled_property() => new EnableStrictModeForPackageBaselineValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <PackageValidationBaselineName>DotNetProjectFile.Analyzers</PackageValidationBaselineName>
+                <PackageValidationBaselineVersion>1.5.0</PackageValidationBaselineVersion>
+                <EnableStrictModeForBaselineValidation>true</EnableStrictModeForBaselineValidation>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+
+    [Test]
+    public void on_validation_disabled() => new EnableStrictModeForPackageBaselineValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <PackageValidationBaselineName>DotNetProjectFile.Analyzers</PackageValidationBaselineName>
+                <PackageValidationBaselineVersion>1.5.0</PackageValidationBaselineVersion>
+                <EnableStrictModeForBaselineValidation>false</EnableStrictModeForBaselineValidation>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_framework_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_framework_validation.cs
@@ -1,0 +1,72 @@
+namespace Rules.MS_Build.Enable_strict_mode_for_package_framework_validation;
+
+public class Reports
+{
+    [Test]
+    public void on_missing_property() => new EnableStrictModeForPackageFrameworkCompatibilityValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 07, 22));
+
+    [Test]
+    public void on_disabled_property() => new EnableStrictModeForPackageFrameworkCompatibilityValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <EnableStrictModeForCompatibleFrameworksInPackage>false</EnableStrictModeForCompatibleFrameworksInPackage>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 122));
+}
+
+public class Guards
+{
+    [TestCase("TestProject.cs")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new EnableStrictModeForPackageFrameworkCompatibilityValidation()
+        .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void on_enabled_property() => new EnableStrictModeForPackageFrameworkCompatibilityValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <EnableStrictModeForCompatibleFrameworksInPackage>true</EnableStrictModeForCompatibleFrameworksInPackage>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+
+    [Test]
+    public void on_validation_disabled() => new EnableStrictModeForPackageFrameworkCompatibilityValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnableStrictModeForCompatibleFrameworksInPackage>false</EnableStrictModeForCompatibleFrameworksInPackage>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_runtime_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_runtime_validation.cs
@@ -1,0 +1,57 @@
+namespace Rules.MS_Build.Enable_strict_mode_for_package_runtime_validation;
+
+public class Reports
+{
+    [Test]
+    public void on_disabled_property() => new EnableStrictModeForPackageRuntimeCompatibilityValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <EnableStrictModeForCompatibleTfms>false</EnableStrictModeForCompatibleTfms>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0248", "Define the <EnableStrictModeForCompatibleTfms> node with value 'true' or remove the <EnableStrictModeForCompatibleTfms> node with value 'false' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 92));
+}
+
+public class Guards
+{
+    [TestCase("TestProject.cs")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new EnableStrictModeForPackageRuntimeCompatibilityValidation()
+        .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void on_missing_property() => new EnableStrictModeForPackageRuntimeCompatibilityValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+
+    [Test]
+    public void on_validation_disabled() => new EnableStrictModeForPackageBaselineValidation()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnableStrictModeForCompatibleTfms>false</EnableStrictModeForCompatibleTfms>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_api_compatibility_suppression_file.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_api_compatibility_suppression_file.cs
@@ -1,0 +1,72 @@
+namespace Rules.MS_Build.Generate_api_compatibility_suppression_file;
+
+public class Reports
+{
+    [Test]
+    public void on_missing_property() => new GenerateApiCompatibilitySuppressionFile()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0250", "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 07, 22));
+
+    [Test]
+    public void on_disabled_property() => new GenerateApiCompatibilitySuppressionFile()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <ApiCompatGenerateSuppressionFile>false</ApiCompatGenerateSuppressionFile>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasIssues(Issue.WRN("Proj0250", "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 90));
+}
+
+public class Guards
+{
+    [TestCase("TestProject.cs")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new GenerateApiCompatibilitySuppressionFile()
+        .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void on_enabled_property() => new GenerateApiCompatibilitySuppressionFile()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <EnablePackageValidation>true</EnablePackageValidation>
+                <ApiCompatGenerateSuppressionFile>true</ApiCompatGenerateSuppressionFile>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+
+    [Test]
+    public void on_validation_disabled() => new GenerateApiCompatibilitySuppressionFile()
+        .ForInlineCsproj(@"
+            <Project Sdk=""Microsoft.NET.Sdk"">
+
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <ApiCompatGenerateSuppressionFile>false</ApiCompatGenerateSuppressionFile>
+              </PropertyGroup>
+
+            </Project>
+        ")
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableApiCompatibilityAttributeChecks.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableApiCompatibilityAttributeChecks.cs
@@ -1,0 +1,26 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class EnableApiCompatibilityAttributeChecks()
+    : MsBuildProjectFileAnalyzer(Rule.EnableApiCompatibilityAttributeChecks)
+{
+    /// <inheritdoc />
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (!context.File.PackageValidationEnabled())
+        {
+            return;
+        }
+
+        if (context.File.Property<ApiCompatEnableRuleAttributesMustMatch>() is { } node && node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
+        }
+        else
+        {
+            context.ReportDiagnostic(Descriptor, context.File);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableApiCompatibilityAttributeChecks.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableApiCompatibilityAttributeChecks.cs
@@ -14,13 +14,13 @@ public sealed class EnableApiCompatibilityAttributeChecks()
             return;
         }
 
-        if (context.File.Property<ApiCompatEnableRuleAttributesMustMatch>() is { } node && node.Value is not true)
-        {
-            context.ReportDiagnostic(Descriptor, node);
-        }
-        else
+        if (context.File.Property<ApiCompatEnableRuleAttributesMustMatch>() is not { } node)
         {
             context.ReportDiagnostic(Descriptor, context.File);
+        }
+        else if (node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableApiCompatibilityParameterNameChecks.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableApiCompatibilityParameterNameChecks.cs
@@ -14,13 +14,13 @@ public sealed class EnableApiCompatibilityParameterNameChecks()
             return;
         }
 
-        if (context.File.Property<ApiCompatEnableRuleCannotChangeParameterName>() is { } node && node.Value is not true)
-        {
-            context.ReportDiagnostic(Descriptor, node);
-        }
-        else
+        if (context.File.Property<ApiCompatEnableRuleCannotChangeParameterName>() is not { } node)
         {
             context.ReportDiagnostic(Descriptor, context.File);
+        }
+        else if (node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableApiCompatibilityParameterNameChecks.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableApiCompatibilityParameterNameChecks.cs
@@ -1,0 +1,26 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class EnableApiCompatibilityParameterNameChecks()
+    : MsBuildProjectFileAnalyzer(Rule.EnableApiCompatibilityParameterNameChecks)
+{
+    /// <inheritdoc />
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (!context.File.PackageValidationEnabled())
+        {
+            return;
+        }
+
+        if (context.File.Property<ApiCompatEnableRuleCannotChangeParameterName>() is { } node && node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
+        }
+        else
+        {
+            context.ReportDiagnostic(Descriptor, context.File);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageBaselineValidation.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageBaselineValidation.cs
@@ -15,13 +15,13 @@ public sealed class EnableStrictModeForPackageBaselineValidation()
             return;
         }
 
-        if (context.File.Property<EnableStrictModeForBaselineValidation>() is { } node && node.Value is not true)
-        {
-            context.ReportDiagnostic(Descriptor, node);
-        }
-        else
+        if (context.File.Property<EnableStrictModeForBaselineValidation>() is not { } node)
         {
             context.ReportDiagnostic(Descriptor, context.File);
+        }
+        else if (node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageBaselineValidation.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageBaselineValidation.cs
@@ -1,0 +1,27 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class EnableStrictModeForPackageBaselineValidation()
+    : MsBuildProjectFileAnalyzer(Rule.EnableStrictModeForPackageBaselineValidation)
+{
+    /// <inheritdoc />
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (!context.File.PackageValidationEnabled()
+         || context.File.Property<PackageValidationBaselineVersion>() is null)
+        {
+            return;
+        }
+
+        if (context.File.Property<EnableStrictModeForBaselineValidation>() is { } node && node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
+        }
+        else
+        {
+            context.ReportDiagnostic(Descriptor, context.File);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageFrameworkCompatibilityValidation.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageFrameworkCompatibilityValidation.cs
@@ -1,0 +1,26 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class EnableStrictModeForPackageFrameworkCompatibilityValidation()
+    : MsBuildProjectFileAnalyzer(Rule.EnableStrictModeForPackageFrameworkCompatibilityValidation)
+{
+    /// <inheritdoc />
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (!context.File.PackageValidationEnabled())
+        {
+            return;
+        }
+
+        if (context.File.Property<EnableStrictModeForCompatibleFrameworksInPackage>() is { } node && node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
+        }
+        else
+        {
+            context.ReportDiagnostic(Descriptor, context.File);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageFrameworkCompatibilityValidation.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageFrameworkCompatibilityValidation.cs
@@ -14,13 +14,13 @@ public sealed class EnableStrictModeForPackageFrameworkCompatibilityValidation()
             return;
         }
 
-        if (context.File.Property<EnableStrictModeForCompatibleFrameworksInPackage>() is { } node && node.Value is not true)
-        {
-            context.ReportDiagnostic(Descriptor, node);
-        }
-        else
+        if (context.File.Property<EnableStrictModeForCompatibleFrameworksInPackage>() is not { } node)
         {
             context.ReportDiagnostic(Descriptor, context.File);
+        }
+        else if (node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageRuntimeCompatibilityValidation.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/EnableStrictModeForPackageRuntimeCompatibilityValidation.cs
@@ -1,0 +1,18 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class EnableStrictModeForPackageRuntimeCompatibilityValidation()
+    : MsBuildProjectFileAnalyzer(Rule.EnableStrictModeForPackageRuntimeCompatibilityValidation)
+{
+    /// <inheritdoc />
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (context.File.PackageValidationEnabled()
+         && context.File.Property<EnableStrictModeForCompatibleTfms>() is { } node && node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GenerateApiCompatibilitySuppressionFile.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GenerateApiCompatibilitySuppressionFile.cs
@@ -14,13 +14,13 @@ public sealed class GenerateApiCompatibilitySuppressionFile()
             return;
         }
 
-        if (context.File.Property<ApiCompatGenerateSuppressionFile>() is { } node && node.Value is not true)
-        {
-            context.ReportDiagnostic(Descriptor, node);
-        }
-        else
+        if (context.File.Property<ApiCompatGenerateSuppressionFile>() is not { } node)
         {
             context.ReportDiagnostic(Descriptor, context.File);
+        }
+        else if (node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GenerateApiCompatibilitySuppressionFile.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GenerateApiCompatibilitySuppressionFile.cs
@@ -1,0 +1,26 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class GenerateApiCompatibilitySuppressionFile()
+    : MsBuildProjectFileAnalyzer(Rule.GenerateApiCompatibilitySuppressionFile)
+{
+    /// <inheritdoc />
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        if (!context.File.PackageValidationEnabled())
+        {
+            return;
+        }
+
+        if (context.File.Property<ApiCompatGenerateSuppressionFile>() is { } node && node.Value is not true)
+        {
+            context.ReportDiagnostic(Descriptor, node);
+        }
+        else
+        {
+            context.ReportDiagnostic(Descriptor, context.File);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -65,6 +65,12 @@ ToBeReleased:
 - Proj0244: Generate documentation file. (NEW RULE)
 - Proj0245: Don't mix Version and VersionPrefix/VersionSuffix. (NEW RULE)
 - Proj0246: Define VersionPrefix if VersionSuffix is defined. (NEW RULE)
+- Proj0247: Enable strict mode for package baseline validation. (NEW RULE)
+- Proj0248: Enable strict mode for package runtime compatibility validation. (NEW RULE)
+- Proj0249: Enable strict mode for package framework compatibility validation. (NEW RULE)
+- Proj0250: Generate API compatibility suppression file. (NEW RULE)
+- Proj0251: Enable API compatibility attribute checks. (NEW RULE)
+- Proj0252: Enable API compatibility parameter name checks. (NEW RULE)
 - Proj0452: No longer require test SDK for TUnit projects. (FP)
 - Proj1001: Fix for deprecated packages TUnit.Analyzers and TUnit.Assertions.Analyzers. (FP)
 - Proj1011: Now reports on PackageVersion node if present, instead of PackageReference.

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ApiCompatEnableRuleAttributesMustMatch.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ApiCompatEnableRuleAttributesMustMatch.cs
@@ -1,0 +1,4 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class ApiCompatEnableRuleAttributesMustMatch(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ApiCompatEnableRuleCannotChangeParameterName.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ApiCompatEnableRuleCannotChangeParameterName.cs
@@ -1,0 +1,4 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class ApiCompatEnableRuleCannotChangeParameterName(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ApiCompatGenerateSuppressionFile.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ApiCompatGenerateSuppressionFile.cs
@@ -1,0 +1,4 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class ApiCompatGenerateSuppressionFile(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/EnableStrictModeForBaselineValidation.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/EnableStrictModeForBaselineValidation.cs
@@ -1,0 +1,4 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class EnableStrictModeForBaselineValidation(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/EnableStrictModeForCompatibleFrameworksInPackage.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/EnableStrictModeForCompatibleFrameworksInPackage.cs
@@ -1,0 +1,4 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class EnableStrictModeForCompatibleFrameworksInPackage(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/EnableStrictModeForCompatibleTfms.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/EnableStrictModeForCompatibleTfms.cs
@@ -1,0 +1,4 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class EnableStrictModeForCompatibleTfms(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project) { }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
@@ -67,4 +67,16 @@ public sealed class PropertyGroup(XElement element, Node parent, MsBuildProject 
     public Nodes<PackageValidationBaselineVersion> PackageValidationBaselineVersion => new(Children);
 
     public Nodes<ManagePackageVersionsCentrally> ManagePackageVersionsCentrally => new(Children);
+
+    public Nodes<EnableStrictModeForBaselineValidation> EnableStrictModeForBaselineValidation => new(Children);
+
+    public Nodes<EnableStrictModeForCompatibleFrameworksInPackage> EnableStrictModeForCompatibleFrameworksInPackage => new(Children);
+
+    public Nodes<EnableStrictModeForCompatibleTfms> EnableStrictModeForCompatibleTfms => new(Children);
+
+    public Nodes<ApiCompatEnableRuleAttributesMustMatch> ApiCompatEnableRuleAttributesMustMatch => new(Children);
+
+    public Nodes<ApiCompatEnableRuleCannotChangeParameterName> ApiCompatEnableRuleCannotChangeParameterName => new(Children);
+
+    public Nodes<ApiCompatGenerateSuppressionFile> ApiCompatGenerateSuppressionFile => new(Children);
 }

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -61,12 +61,12 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0244** Generate documentation file](https://dotnet-project-file-analyzers.github.io/rules/Proj0244.html)
 * [**Proj0245** Don’t mix Version and VersionPrefix/VersionSuffix](https://dotnet-project-file-analyzers.github.io/rules/Proj0245.html)
 * [**Proj0246** Define VersionPrefix if VersionSuffix is defined](https://dotnet-project-file-analyzers.github.io/rules/Proj0246.html)
-* [**Proj0247** Enable strict mode for package baseline validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0247.md)
-* [**Proj0248** Enable strict mode for package runtime compatibility validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0248.md)
-* [**Proj0249** Enable strict mode for package framework compatibility validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0249.md)
-* [**Proj0250** Generate API compatibility suppression file](https://dotnet-project-file-analyzers.github.io/rules/Proj0250.md)
-* [**Proj0251** Enable API compatibility attribute checks](https://dotnet-project-file-analyzers.github.io/rules/Proj0251.md)
-* [**Proj0252** Enable API compatibility parameter name checks](https://dotnet-project-file-analyzers.github.io/rules/Proj0252.md)
+* [**Proj0247** Enable strict mode for package baseline validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0247.html)
+* [**Proj0248** Enable strict mode for package runtime compatibility validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0248.html)
+* [**Proj0249** Enable strict mode for package framework compatibility validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0249.html)
+* [**Proj0250** Generate API compatibility suppression file](https://dotnet-project-file-analyzers.github.io/rules/Proj0250.html)
+* [**Proj0251** Enable API compatibility attribute checks](https://dotnet-project-file-analyzers.github.io/rules/Proj0251.html)
+* [**Proj0252** Enable API compatibility parameter name checks](https://dotnet-project-file-analyzers.github.io/rules/Proj0252.html)
 * [**Proj0600** Avoid generating packages on build if not packable](https://dotnet-project-file-analyzers.github.io/rules/Proj0600.html)
 
 ### Publishing

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -61,6 +61,12 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0244** Generate documentation file](https://dotnet-project-file-analyzers.github.io/rules/Proj0244.html)
 * [**Proj0245** Don’t mix Version and VersionPrefix/VersionSuffix](https://dotnet-project-file-analyzers.github.io/rules/Proj0245.html)
 * [**Proj0246** Define VersionPrefix if VersionSuffix is defined](https://dotnet-project-file-analyzers.github.io/rules/Proj0246.html)
+* [**Proj0247** Enable strict mode for package baseline validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0247.md)
+* [**Proj0248** Enable strict mode for package runtime compatibility validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0248.md)
+* [**Proj0249** Enable strict mode for package framework compatibility validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0249.md)
+* [**Proj0250** Generate API compatibility suppression file](https://dotnet-project-file-analyzers.github.io/rules/Proj0250.md)
+* [**Proj0251** Enable API compatibility attribute checks](https://dotnet-project-file-analyzers.github.io/rules/Proj0251.md)
+* [**Proj0252** Enable API compatibility parameter name checks](https://dotnet-project-file-analyzers.github.io/rules/Proj0252.md)
 * [**Proj0600** Avoid generating packages on build if not packable](https://dotnet-project-file-analyzers.github.io/rules/Proj0600.html)
 
 ### Publishing

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -511,7 +511,7 @@ public static partial class Rule
         message: "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'.",
         description:
             "To ensure the (backwards) compatibility " +
-            "of the API surface of your package, it is adviced " +
+            "of the API surface of your package, it is advised " +
             "to enable package validation by defining the " +
             "<EnablePackageValidation> node with value 'true'.",
         tags: ["Configuration", "package", "compatibility"],
@@ -525,7 +525,7 @@ public static partial class Rule
         message: "Define the <PackageValidationBaselineVersion> node with a previously released stable version.",
         description:
             "To ensure the backwards compatibility " +
-            "of the API surface of your package, it is adviced " +
+            "of the API surface of your package, it is advised " +
             "to enable package baseline validation by defining the " +
             "<PackageValidationBaselineVersion> node with the version " +
             "of the previous stable release.",
@@ -604,7 +604,7 @@ public static partial class Rule
         message: "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'.",
         description:
             "When ensuring backwards compatibility of the API surface " +
-            "of your package, it is adviced to do this in strict mode. " +
+            "of your package, it is advised to do this in strict mode. " +
             "This helps preventing any unintentional API changes.",
         tags: ["Configuration", "package", "compatibility"],
         category: Category.Reliability,
@@ -617,7 +617,7 @@ public static partial class Rule
         message: "Define the <EnableStrictModeForCompatibleTfms> node with value 'true' or remove the <EnableStrictModeForCompatibleTfms> node with value 'false' or remove the <EnablePackageValidation> node with value 'true'.",
         description:
             "When building your package for multiple runtimes it " +
-            "is adviced to enable the strict mode of the runtime " +
+            "is advised to enable the strict mode of the runtime " +
             "compatibility validation.",
         tags: ["Configuration", "package", "compatibility"],
         category: Category.Reliability,
@@ -630,7 +630,7 @@ public static partial class Rule
         message: "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
         description:
             "When building your package for multiple runtimes it " +
-            "is adviced to enable the strict mode of the framework " +
+            "is advised to enable the strict mode of the framework " +
             "compatibility validation.",
         tags: ["Configuration", "package", "compatibility"],
         category: Category.Reliability,
@@ -643,7 +643,7 @@ public static partial class Rule
         message: "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
         description:
             "This suppression file can be created manually, or automatically generated " +
-            "by enabling the `GenerateCompatibilitySuppressionFile` property.It is adviced " +
+            "by enabling the `GenerateCompatibilitySuppressionFile` property.It is advised " +
             "to enable this property in the project file to ensure that file is kept " +
             "up-to-date automatically.",
         tags: ["Configuration", "package", "compatibility"],
@@ -656,7 +656,7 @@ public static partial class Rule
         title: "Enable API compatibility attribute checks",
         message: "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
         description:
-            "When package validation is enabled, it is adviced to opt-in " +
+            "When package validation is enabled, it is advised to opt-in " +
             "to the strict attribute compatibility checks.",
         tags: ["Configuration", "package", "compatibility"],
         category: Category.Reliability,
@@ -668,7 +668,7 @@ public static partial class Rule
         title: "Enable API compatibility parameter name checks",
         message: "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
         description:
-            "When package validation is enabled, it is adviced to opt-in " +
+            "When package validation is enabled, it is advised to opt-in " +
             "to the strict parameter name compatibility checks.",
         tags: ["Configuration", "package", "compatibility"],
         category: Category.Reliability,

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -547,56 +547,56 @@ public static partial class Rule
         isEnabled: true);
 
     public static DiagnosticDescriptor GenerateSbom => New(
-       id: 0243,
-       title: "Generate software bill of materials",
-       message: "{0} or define the <IsPackable> node with value 'false'.",
-       description:
+        id: 0243,
+        title: "Generate software bill of materials",
+        message: "{0} or define the <IsPackable> node with value 'false'.",
+        description:
            "To be compliant with USA legislation, a software bill of materials " +
            "should be included with a shipped package.",
-       tags: ["compliance", "package", "legislation"],
-       category: Category.CodeQuality,
-       severity: DiagnosticSeverity.Warning,
-       isEnabled: true);
+        tags: ["compliance", "package", "legislation"],
+        category: Category.CodeQuality,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
 
     public static DiagnosticDescriptor GenerateDocumentationFile => New(
-       id: 0244,
-       title: "Generate documentation file",
-       message: "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'.",
-       description:
+        id: 0244,
+        title: "Generate documentation file",
+        message: "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'.",
+        description:
            "In order for code documentation to be visible for package consumers " +
            "it is important that the documentation is generated.",
-       tags: ["Configuration", "package"],
-       category: Category.Clarity,
-       severity: DiagnosticSeverity.Warning,
-       isEnabled: true);
+        tags: ["Configuration", "package"],
+        category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
 
     public static DiagnosticDescriptor DontMixVersionAndVersionPrefixOrVersionSuffix => New(
-       id: 0245,
-       title: "Don't mix Version and VersionPrefix/VersionSuffix",
-       message: "Remove the <Version> node or remove the {0}.",
-       description:
+        id: 0245,
+        title: "Don't mix Version and VersionPrefix/VersionSuffix",
+        message: "Remove the <Version> node or remove the {0}.",
+        description:
             "Version node overrides VersionPrefix and VersionSuffix nodes " +
             ", therefore you should either remove the Version node " +
             "(if you want to use the VersionPrefix and VersionSuffix nodes) or " +
             "you should remove the VersionPrefix and VersionSuffix nodes " +
             "(if you want to use Version node).",
-       tags: ["Configuration", "NuGet", "package"],
-       category: Category.Configuration,
-       severity: DiagnosticSeverity.Warning,
-       isEnabled: true);
+        tags: ["Configuration", "NuGet", "package"],
+        category: Category.Configuration,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
 
     public static DiagnosticDescriptor DefineVersionPrefixIfVersionSuffixIsDefined => New(
-       id: 0246,
-       title: "Define VersionPrefix if VersionSuffix is defined",
-       message: "Define the <VersionPrefix> node or remove the <VersionSuffix> node.",
-       description:
+        id: 0246,
+        title: "Define VersionPrefix if VersionSuffix is defined",
+        message: "Define the <VersionPrefix> node or remove the <VersionSuffix> node.",
+        description:
             "VersionSuffix indicates the desire to use the VersionPrefix and VersionSuffix system " +
             ", but when only defining the VersionSuffix node, the default value of VersionPrefix (1.0.0) " +
             "is used, which is most likely an error.",
-       tags: ["Configuration", "NuGet", "package"],
-       category: Category.Configuration,
-       severity: DiagnosticSeverity.Warning,
-       isEnabled: true);
+        tags: ["Configuration", "NuGet", "package"],
+        category: Category.Configuration,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
 
     public static DiagnosticDescriptor DefineIsPublishable => New(
         id: 0400,

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -598,6 +598,83 @@ public static partial class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
+    public static DiagnosticDescriptor EnableStrictModeForPackageBaselineValidation => New(
+        id: 0247,
+        title: "Enable strict mode for package baseline validation",
+        message: "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'.",
+        description:
+            "When ensuring backwards compatibility of the API surface " +
+            "of your package, it is adviced to do this in strict mode. " +
+            "This helps preventing any unintentional API changes.",
+        tags: ["Configuration", "package", "compatibility"],
+        category: Category.Reliability,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
+    public static DiagnosticDescriptor EnableStrictModeForPackageRuntimeCompatibilityValidation => New(
+        id: 0248,
+        title: "Enable strict mode for package runtime compatibility validation",
+        message: "Define the <EnableStrictModeForCompatibleTfms> node with value 'true' or remove the <EnableStrictModeForCompatibleTfms> node with value 'false' or remove the <EnablePackageValidation> node with value 'true'.",
+        description:
+            "When building your package for multiple runtimes it " +
+            "is adviced to enable the strict mode of the runtime " +
+            "compatibility validation.",
+        tags: ["Configuration", "package", "compatibility"],
+        category: Category.Reliability,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
+    public static DiagnosticDescriptor EnableStrictModeForPackageFrameworkCompatibilityValidation => New(
+        id: 0249,
+        title: "Enable strict mode for package framework compatibility validation",
+        message: "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
+        description:
+            "When building your package for multiple runtimes it " +
+            "is adviced to enable the strict mode of the framework " +
+            "compatibility validation.",
+        tags: ["Configuration", "package", "compatibility"],
+        category: Category.Reliability,
+        severity: DiagnosticSeverity.Warning,
+    isEnabled: true);
+
+    public static DiagnosticDescriptor GenerateApiCompatibilitySuppressionFile => New(
+        id: 0250,
+        title: "Generate API compatibility suppression file",
+        message: "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
+        description:
+            "This suppression file can be created manually, or automatically generated " +
+            "by enabling the `GenerateCompatibilitySuppressionFile` property.It is adviced " +
+            "to enable this property in the project file to ensure that file is kept " +
+            "up-to-date automatically.",
+        tags: ["Configuration", "package", "compatibility"],
+        category: Category.Reliability,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
+    public static DiagnosticDescriptor EnableApiCompatibilityAttributeChecks => New(
+        id: 0251,
+        title: "Enable API compatibility attribute checks",
+        message: "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
+        description:
+            "When package validation is enabled, it is adviced to opt-in " +
+            "to the strict attribute compatibility checks.",
+        tags: ["Configuration", "package", "compatibility"],
+        category: Category.Reliability,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
+    public static DiagnosticDescriptor EnableApiCompatibilityParameterNameChecks => New(
+        id: 0252,
+        title: "Enable API compatibility parameter name checks",
+        message: "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
+        description:
+            "When package validation is enabled, it is adviced to opt-in " +
+            "to the strict parameter name compatibility checks.",
+        tags: ["Configuration", "package", "compatibility"],
+        category: Category.Reliability,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
     public static DiagnosticDescriptor DefineIsPublishable => New(
         id: 0400,
         title: "Define the project publishability explicitly",


### PR DESCRIPTION
Implementations of https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers.github.io/pull/83

Also introduced a system to define in-line project files, since creating the physical files on disk is becoming quite tiresome to me (and I believe this also makes it easier to understand what a test case is verifying without having to open additional files).