### PR TITLE
Proj1102: Use Coverlet Collector or MSBuild

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -37,7 +37,6 @@
 
   <ItemGroup Label="Build tools">
     <PackageReference Include="coverlet.collector" Version="*" PrivateAssets="all" />
-    <PackageReference Include="coverlet.msbuild" Version="*" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" PrivateAssets="all" />
     <PackageReference Include="NUnit3TestAdapter" Version="*" PrivateAssets="all" />
   </ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_coverlet_collector_or_msbuild.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_coverlet_collector_or_msbuild.cs
@@ -1,0 +1,56 @@
+namespace Rules.MS_Build.Use_coverlet_collector_or_msbuild;
+
+public class Reports
+{
+    [Test]
+    public void empty_nodes() => new UseCoverletCollectorOrMsBuild()
+        .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""coverlet.collector"" Version=""6.0.0"" PrivateAssets=""all"" />
+    <PackageReference Include=""coverlet.msbuild"" Version=""6.0.0"" PrivateAssets=""all"" />
+  </ItemGroup>
+</Project>")
+        .HasIssue(
+           Issue.WRN("Proj1102", "Choose either coverlet.collector or coverlet.msbuild.")
+            .WithSpan(5, 04, 5, 89));
+}
+
+public class Guards
+{
+    [TestCase]
+    public void Project_with_collector() => new UseCoverletCollectorOrMsBuild()
+        .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""coverlet.collector"" Version=""6.0.0"" PrivateAssets=""all"" />
+  </ItemGroup>
+</Project>")
+        .HasNoIssues();
+
+    [TestCase]
+    public void Project_with_msbuild() => new UseCoverletCollectorOrMsBuild()
+    .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""coverlet.msbuild"" Version=""6.0.0"" PrivateAssets=""all"" />
+  </ItemGroup>
+</Project>")
+    .HasNoIssues();
+
+
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_with_analyzers(string project) => new UseCoverletCollectorOrMsBuild()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
@@ -1,3 +1,4 @@
+
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
@@ -5,6 +6,8 @@ public sealed class TestProjectsRequireSdk() : MsBuildProjectFileAnalyzer(
     Rule.TestProjectsRequireSdk,
     Rule.UsingMicrosoftNetTestSdkImpliesTestProject)
 {
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
         var isTest = context.File.IsTestProject();

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCoverletCollectorOrMsBuild.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCoverletCollectorOrMsBuild.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+/// <summary>Implements  <see cref="Rule.UseCoverletCollectorOrMsBuild"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class UseCoverletCollectorOrMsBuild()
+    : MsBuildProjectFileAnalyzer(Rule.UseCoverletCollectorOrMsBuild)
+{
+    /// <inheritdoc />
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    /// <inheritdoc />
+    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        var collector = context.File
+            .Walk()
+            .OfType<PackageReference>()
+            .LastOrDefault(r => r.Include == NuGet.Packages.coverlet_collector.Name);
+        var msBuild = context.File
+            .Walk()
+            .OfType<PackageReference>()
+            .LastOrDefault(r => r.Include == NuGet.Packages.coverlet_msbuild.Name);
+        
+        if (collector is { } && msBuild is { })
+        {
+            if (collector.Project == context.File)
+            {
+                context.ReportDiagnostic(Descriptor, collector);
+            }
+            else if (msBuild.Project == context.File)
+            {
+                context.ReportDiagnostic(Descriptor, msBuild);
+            }
+            else
+            {
+                context.ReportDiagnostic(Descriptor, context.File);
+            }
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -59,6 +59,8 @@
     <Version>1.5.6</Version>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased:
+- Proj1102: Use Coverlet Collector or MSBuild. (NEW RULE)
 v1.5.6
 - Proj0033: Project reference includes should exist. (NEW RULE)
 - Proj0201: VersionPrefix is now allowed as alternative to Version. (FP)

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
@@ -2,6 +2,8 @@ namespace DotNetProjectFile.NuGet;
 
 public sealed class Packages : IReadOnlyCollection<Package>
 {
+    public static readonly BuildExtension coverlet_collector = new("coverlet.collector");
+    public static readonly BuildExtension coverlet_msbuild = new("coverlet.msbuild");
     public static readonly BuildExtension Microsoft_NET_Test_Sdk = new("Microsoft.NET.Test.Sdk");
     public static readonly BuildExtension Microsoft_Sbom_Targets = new("Microsoft.Sbom.Targets");
     public static readonly BuildExtension TUnit = new("TUnit");
@@ -100,8 +102,8 @@ public sealed class Packages : IReadOnlyCollection<Package>
         new SourceGenerator("Vogen"),
 
         // Build extensions
-        new BuildExtension("coverlet.collector"),
-        new BuildExtension("coverlet.msbuild"),
+        coverlet_collector,
+        coverlet_msbuild,
         new BuildExtension("DotNetProjectFile.Analyzers.Sdk"),
         new BuildExtension("Grpc.Tools"),
         new BuildExtension("JetBrains.Annotations"),

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -105,6 +105,7 @@ The package contains analyzers that analyze .NET project files.
 ### Other
 * [**Proj1100** Avoid using Moq](https://dotnet-project-file-analyzers.github.io/rules/Proj1100.html)
 * [**Proj1101** Package references should have stable versions](https://dotnet-project-file-analyzers.github.io/rules/Proj1101.html)
+* [**Proj1102** Use Coverlet Collector or MSBuild](https://dotnet-project-file-analyzers.github.io/rules/Proj1102.html)
 * [**Proj1200** Exclude private assets as project file dependency](https://dotnet-project-file-analyzers.github.io/rules/Proj1200.html)
 
 ## Resource file rules

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -880,7 +880,9 @@ public static partial class Rule
         id: 1102,
         title: "Use Coverlet Collector or MSBuild",
         message: "Choose either coverlet.collector or coverlet.msbuild.",
-        description: "",
+        description:
+            "The packages coverlet.collector and coverlet.msbuild have the " +
+            "same purpose but should not be used together. ",
         tags: ["coverlet", "code", "coverage"],
         category: Category.Bug);
 

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -876,6 +876,14 @@ public static partial class Rule
         tags: ["NuGet", "Versioning"],
         category: Category.Reliability);
 
+    public static DiagnosticDescriptor UseCoverletCollectorOrMsBuild => New(
+        id: 1102,
+        title: "Use Coverlet Collector or MSBuild",
+        message: "Choose either coverlet.collector or coverlet.msbuild.",
+        description: "",
+        tags: ["coverlet", "code", "coverage"],
+        category: Category.Bug);
+
     public static DiagnosticDescriptor ExcludePrivateAssetDependencies => New(
         id: 1200,
         title: "Exclude private assets as project file dependency",


### PR DESCRIPTION
[Coverlet](https://github.com/coverlet-coverage/coverlet) is a cross-platform code coverage framework for .NET, with support for line, branch and method coverage. The packages `coverlet.collector` and `coverlet.msbuild` have the same purpose but should not be used together. Note that `coverlet.collector` is preferred over the `coverlet.msbuild`.

Documentation: https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers.github.io/pull/85