### PR TITLE
Report on RESX files that are not added as additional files

### DIFF
--- a/projects/CompliantCSharp/Messages.nl.resx
+++ b/projects/CompliantCSharp/Messages.nl.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
- <resheader name="resmimetype">
+  <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">

--- a/projects/CompliantCSharp/Messages.resx
+++ b/projects/CompliantCSharp/Messages.resx
@@ -3,7 +3,7 @@
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
-   <resheader name="reader">
+  <resheader name="reader">
     <value>System.Resources.ResXResourceReader</value>
   </resheader>
   <resheader name="writer">

--- a/projects/CompliantCSharpPackage/Messages.nl.resx
+++ b/projects/CompliantCSharpPackage/Messages.nl.resx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
- <resheader name="resmimetype">
+  <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">

--- a/projects/CompliantCSharpPackage/Messages.resx
+++ b/projects/CompliantCSharpPackage/Messages.resx
@@ -3,7 +3,7 @@
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
-   <resheader name="reader">
+  <resheader name="reader">
     <value>System.Resources.ResXResourceReader</value>
   </resheader>
   <resheader name="writer">

--- a/projects/ResxUnsorted/ResxUnsorted.csproj
+++ b/projects/ResxUnsorted/ResxUnsorted.csproj
@@ -5,8 +5,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
-  </PropertyGroup>
-
 </Project>

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
@@ -80,6 +80,11 @@ public sealed partial class ProjectFiles
             : null;
     }
 
+    public Resource? UpdateResourceFile(IOFile file)
+         => Is.Resource(file)
+            ? ResourceFiles.TryGetOrUpdate(file, _ => Resource.Load(file, this))
+            : null;
+
     private static GitIgnoreSyntax Create_GitIgnoreFile(IOFile file)
         => GitIgnoreSyntax.Parse(Syntax.SyntaxTree.Load(file.OpenRead()));
 

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -61,6 +61,7 @@
       <![CDATA[
 ToBeReleased:
 - Proj1102: Use Coverlet Collector or MSBuild. (NEW RULE)
+- Proj2???: Report on RESX files that are not added as additional files. (FN)
 v1.5.6
 - Proj0033: Project reference includes should exist. (NEW RULE)
 - Proj0201: VersionPrefix is now allowed as alternative to Version. (FP)

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
@@ -55,11 +55,29 @@ internal static class AnalysisContextExtensions
 
     /// <summary>Registers an action on <see cref="ProjectFileAnalysisContext"/>.</summary>
     public static void RegisterResourceFileAction(this AnalysisContext context, Action<ResourceFileAnalysisContext> action)
-        => context.RegisterAdditionalFileAction(c =>
+    {
+        context.RegisterAdditionalFileAction(c =>
         {
             if (ProjectFiles.Global.UpdateResourceFile(c) is { IsXml: true } resource)
             {
                 action.Invoke(new(resource, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
             }
         });
+
+        // Fallback for detecting files that not have been added as additional files.
+        context.RegisterCompilationAction(c =>
+        {
+            if (ProjectFiles.Global.UpdateMsBuildProject(c) is { } msbuild)
+            {
+                foreach (var file in msbuild.Path.Directory.Files("**/*.resx") ?? [])
+                {
+                    if (ProjectFiles.Global.UpdateResourceFile(file) is { IsXml: true } resource
+                        && !resource.IsAdditional(c.Options.AdditionalFiles))
+                    {
+                        action.Invoke(new(resource, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
+                    }
+                }
+            }
+        });
+    }
 }


### PR DESCRIPTION
I was under the impression for some time that embedded resources where added as additional files by default, and that the only reason our test tools did pick add them to the additional files was due to an issue with those tools (Buildalyzer). I apparently never tested this assumption correctly, or the behavior did change (way less likely).

Long story short, with this fix, all resource files that are not added as additional files are also analyzed.