### PR TITLE
Proj0006: Report on RESX files that are not added as additional files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To use the SDK, follow the instructions [here](https://dotnet-project-file-analy
 
 ## Additional files
 To fully benefit from these analyzers it is recommended to add the project file
-(and imported projects/props) as additional files.
+(and RESX, and imported projects/props) as additional files.
 
 To add a project file:
 
@@ -47,6 +47,7 @@ To add a project file:
 
   <ItemGroup>
     <AdditionalFiles Include="*.??proj" Visible="false" />
+	<AdditionalFiles Include="*.resx" />
   </ItemGroup>
 
 </Project>
@@ -55,11 +56,11 @@ To add a project file:
 To add a props file:
 
 ``` XML
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
 
   <ItemGroup>
     <AdditionalFiles Include="../props/{file_name}" Link="Properties/{file_name}" />
+	<AdditionalFiles Include="*.resx" />
   </ItemGroup>
 
 </Project>

--- a/projects/CompliantCSharp/CompliantCSharp.csproj
+++ b/projects/CompliantCSharp/CompliantCSharp.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <AdditionalFiles Include="*.csproj" Visible="false" />
+    <AdditionalFiles Include="*.resx" />
   </ItemGroup>
 
   <!-- #pragma warning disable Proj0008 -->

--- a/projects/CompliantCSharpPackage/CompliantCSharpPackage.csproj
+++ b/projects/CompliantCSharpPackage/CompliantCSharpPackage.csproj
@@ -52,7 +52,7 @@ v1.0.0
 
   <ItemGroup>
     <AdditionalFiles Include="*.csproj" Visible="false" />
-	<AdditionalFiles Include="*.resx" />
+    <AdditionalFiles Include="*.resx" />
   </ItemGroup>
 
   <ItemGroup>

--- a/projects/CompliantCSharpPackage/CompliantCSharpPackage.csproj
+++ b/projects/CompliantCSharpPackage/CompliantCSharpPackage.csproj
@@ -52,6 +52,7 @@ v1.0.0
 
   <ItemGroup>
     <AdditionalFiles Include="*.csproj" Visible="false" />
+	<AdditionalFiles Include="*.resx" />
   </ItemGroup>
 
   <ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_additional_files.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_additional_files.cs
@@ -1,0 +1,24 @@
+namespace Rules.RESX.Add_additional_files;
+
+public class Reports
+{
+    [Test]
+    public void project_files_not_additional() => new Resx.AddAdditionalFile()
+        .ForProject("ResxUnsorted.cs")
+        .HasIssue(
+            Issue.WRN("Proj0006", "Add 'Resources.resx' to the additional files.").WithPath("Resources.resx"));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void project_files_as_additional(string project) => new Resx.AddAdditionalFile()
+        .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void Directory_Build_props_not_being_added() => new Resx.AddAdditionalFile()
+        .ForProject("WithDirectoryBuildProps.cs")
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Resx/AddAdditionalFile.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Resx/AddAdditionalFile.cs
@@ -1,0 +1,15 @@
+namespace DotNetProjectFile.Analyzers.Resx;
+
+/// <summary>Implements <see cref="Rule.AddAdditionalFile"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class AddAdditionalFile() : ResourceFileAnalyzer(Rule.AddAdditionalFile)
+{
+    /// <inheritdoc />
+    protected override void Register(ResourceFileAnalysisContext context)
+    {
+        if (!context.File.IsAdditional(context.Options.AdditionalFiles))
+        {
+            context.ReportDiagnostic(Descriptor, context.File, ((ProjectFile)context.File).Path.Name);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -60,6 +60,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
+- Proj0006: Report on RESX files that are not added as additional files. (FN)
 - Proj1102: Use Coverlet Collector or MSBuild. (NEW RULE)
 - Proj2???: Report on RESX files that are not added as additional files. (FN)
 v1.5.6


### PR DESCRIPTION
See #305 . So Proj0006 should be extended. This also means that the documentation should be extended. Not only that, but the rule now becomes a generic rule (applies both to RESX, and MS Build files), we could to introduce a new rule ID for it (and mark the old one as obsolete, of drop it).