### PR TITLE
Publish packages in pipeline

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -47,22 +47,16 @@ jobs:
           dotnet-version: "9.0.x"
       - name: Download artifacts
         uses: actions/download-artifact@v4
-      # - name: Push NuGet package
-      #   shell: bash +e {0} # prevents console from exit on error
-      #   working-directory: ./artifacts
-      #   env:
-      #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-      #     SOURCE: https://api.nuget.org/v3/index.json
-      #   run: |
-      #     dotnet nuget push "${{ env.PackageId }}*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
-      #     echo "PackagePushed=$?" >> $GITHUB_ENV
-      #     dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }} --skip-duplicate
       - name: Push NuGet package
         shell: bash +e {0} # prevents console from exit on error
         working-directory: ./artifacts
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          SOURCE: https://api.nuget.org/v3/index.json
         run: |
-          ls -lrt
-          echo "PackagePushed=0" >> $GITHUB_ENV
+          dotnet nuget push "${{ env.PackageId }}*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
+          echo "PackagePushed=$?" >> $GITHUB_ENV
+          dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }} --skip-duplicate
       - name: Get version number # Note this requires the package filename to be of the form [PackageId].[Version].nupkg
         working-directory: ./artifacts
         run: echo "Version=$(ls -1 | (sed -En 's/${{ env.PackageId }}\.([0-9]+\.[0-9]+\.[0-9]+)\.nupkg/\1/p'))" >> $GITHUB_ENV

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,16 +4,56 @@ on: [push]
 
 jobs:
   build:
- 
     runs-on: ubuntu-latest
- 
     steps:
-    - uses: actions/checkout@v1
-    - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '9.0.x'
-    - name: Build with dotnet
-      run: dotnet build dotnet-project-file-analyzers.sln --configuration Release
-    - name: Run unit tests
-      run: dotnet test dotnet-project-file-analyzers.sln --no-build --configuration Release
+      - uses: actions/checkout@v1
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "9.0.x"
+      - name: Build with dotnet
+        run: dotnet build dotnet-project-file-analyzers.sln --configuration Release
+      - name: Run unit tests
+        run: dotnet test dotnet-project-file-analyzers.sln --no-build --configuration Release
+      - name: Publish artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts
+          path: ./src/Tools/bin/Release/*.nupkg
+          if-no-files-found: ignore
+
+  push:
+    name: Push and Tag
+    runs-on: ubuntu-latest
+    if: true || github.ref == 'refs/heads/main' # TODO: remove true
+    needs: build
+    env:
+      PackageId: DotNetProjectFile.Analyzers # The package version will be extracted from the package filename as [PackageId].[Version].nupkg
+      PackagePushed: 1 # Will only tag branch on successfull package push with exit code 0
+      Version: ""
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "9.0.x"
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - name: Push NuGet package
+        shell: bash +e {0} # prevents console from exit on error
+        working-directory: ./artifacts
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          SOURCE: https://api.nuget.org/v3/index.json
+        run: |
+          dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
+          echo "PackagePushed=$?" >> $GITHUB_ENV
+      - name: Get version number # Note this requires the package filename to be of the form [PackageId].[Version].nupkg
+        working-directory: ./artifacts
+        run: echo "Version=$(ls -1 | (sed -En 's/${{ env.PackageId }}\.([0-9]+\.[0-9]+\.[0-9]+)\.nupkg/\1/p'))" >> $GITHUB_ENV
+      - name: Tag version
+        if: env.Version != ''
+        run: |
+          git tag v${{ env.Version }}
+          git push origin v${{ env.Version }}
+

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -47,7 +47,7 @@ jobs:
           dotnet-version: "9.0.x"
       - name: Download artifacts
         uses: actions/download-artifact@v4
-      - name: Push NuGet package
+      - name: Try push NuGet package
         shell: bash +e {0} # prevents console from exit on error
         working-directory: ./artifacts
         env:
@@ -59,10 +59,11 @@ jobs:
           echo "PackagePushed=$?" >> $GITHUB_ENV
           dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }} --skip-duplicate
       - name: Get version number # Note this requires the package filename to be of the form [PackageId].[Version].nupkg
+        if: env.PackagePushed == 0
         working-directory: ./artifacts
         run: echo "Version=$(ls -1 | (sed -En 's/${{ env.PackageId }}\.([0-9]+\.[0-9]+\.[0-9]+)\.nupkg/\1/p'))" >> $GITHUB_ENV
       - name: Tag version
-        if: env.Version != ''
+        if: env.PackagePushed == 0 && env.Version != ''
         run: |
           git tag v${{ env.Version }}
           git push origin v${{ env.Version }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -39,15 +39,21 @@ jobs:
           dotnet-version: "9.0.x"
       - name: Download artifacts
         uses: actions/download-artifact@v4
+      # - name: Push NuGet package
+      #   shell: bash +e {0} # prevents console from exit on error
+      #   working-directory: ./artifacts
+      #   env:
+      #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      #     SOURCE: https://api.nuget.org/v3/index.json
+      #   run: |
+      #     dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
+      #     echo "PackagePushed=$?" >> $GITHUB_ENV
       - name: Push NuGet package
         shell: bash +e {0} # prevents console from exit on error
         working-directory: ./artifacts
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-          SOURCE: https://api.nuget.org/v3/index.json
         run: |
-          dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
-          echo "PackagePushed=$?" >> $GITHUB_ENV
+          ls -lrt
+          echo "PackagePushed=0" >> $GITHUB_ENV
       - name: Get version number # Note this requires the package filename to be of the form [PackageId].[Version].nupkg
         working-directory: ./artifacts
         run: echo "Version=$(ls -1 | (sed -En 's/${{ env.PackageId }}\.([0-9]+\.[0-9]+\.[0-9]+)\.nupkg/\1/p'))" >> $GITHUB_ENV

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -46,8 +46,9 @@ jobs:
       #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       #     SOURCE: https://api.nuget.org/v3/index.json
       #   run: |
-      #     dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
+      #     dotnet nuget push "${{ env.PackageId }}.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
       #     echo "PackagePushed=$?" >> $GITHUB_ENV
+      #     dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }} --skip-duplicate
       - name: Push NuGet package
         shell: bash +e {0} # prevents console from exit on error
         working-directory: ./artifacts

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,7 +20,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts
-          path: ./src/DotNetProjectFile.Analyzers/bin/Release/*.nupkg
+          path: |
+            ./src/DotNetProjectFile.Analyzers/bin/Release/*.nupkg
+            ./src/DotNetProjectFile.Analyzers.Sdk/bin/Release/*.nupkg
           if-no-files-found: ignore
 
   push:
@@ -28,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     if: true || github.ref == 'refs/heads/main' # TODO: remove true
     needs: build
+    permissions:
+      contents: write
     env:
       PackageId: DotNetProjectFile.Analyzers # The package version will be extracted from the package filename as [PackageId].[Version].nupkg
       PackagePushed: 1 # Will only tag branch on successfull package push with exit code 0
@@ -47,7 +51,7 @@ jobs:
       #     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       #     SOURCE: https://api.nuget.org/v3/index.json
       #   run: |
-      #     dotnet nuget push "${{ env.PackageId }}.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
+      #     dotnet nuget push "${{ env.PackageId }}*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
       #     echo "PackagePushed=$?" >> $GITHUB_ENV
       #     dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }} --skip-duplicate
       - name: Push NuGet package

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -31,7 +31,7 @@ jobs:
   push:
     name: Push and Tag
     runs-on: ubuntu-latest
-    if: true || github.ref == 'refs/heads/main' # TODO: remove true
+    if: github.ref == 'refs/heads/main'
     needs: build
     permissions:
       contents: write

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+    name: Build and Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -19,7 +20,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts
-          path: ./src/Tools/bin/Release/*.nupkg
+          path: ./src/DotNetProjectFile.Analyzer/bin/Release/*.nupkg
           if-no-files-found: ignore
 
   push:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts
-          path: ./src/DotNetProjectFile.Analyzer/bin/Release/*.nupkg
+          path: ./src/DotNetProjectFile.Analyzers/bin/Release/*.nupkg
           if-no-files-found: ignore
 
   push:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -54,7 +54,8 @@ jobs:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           SOURCE: https://api.nuget.org/v3/index.json
         run: |
-          dotnet nuget push "${{ env.PackageId }}*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
+          packageName=$(ls -1 | (sed -En 's/(${{ env.PackageId }}\.[0-9]+\.[0-9]+\.[0-9]+\.nupkg)/\1/p'))
+          dotnet nuget push $packageName --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }}
           echo "PackagePushed=$?" >> $GITHUB_ENV
           dotnet nuget push "*.nupkg" --api-key ${{ env.NUGET_API_KEY }} --source ${{ env.SOURCE }} --skip-duplicate
       - name: Get version number # Note this requires the package filename to be of the form [PackageId].[Version].nupkg

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,13 +16,16 @@ jobs:
         run: dotnet build dotnet-project-file-analyzers.sln --configuration Release
       - name: Run unit tests
         run: dotnet test dotnet-project-file-analyzers.sln --no-build --configuration Release
+      - name: Copy .nupkg files to nuget_packges folder
+        run: |
+          mkdir nuget_packges
+          cp ./src/DotNetProjectFile.Analyzers/bin/Release/*.nupkg ./nuget_packges/
+          cp ./src/DotNetProjectFile.Analyzers.Sdk/bin/Release/*.nupkg ./nuget_packges/
       - name: Publish artifacts
         uses: actions/upload-artifact@v4
         with:
           name: artifacts
-          path: |
-            ./src/DotNetProjectFile.Analyzers/bin/Release/*.nupkg
-            ./src/DotNetProjectFile.Analyzers.Sdk/bin/Release/*.nupkg
+          path: nuget_packges
           if-no-files-found: ignore
 
   push:


### PR DESCRIPTION
Closes #249 

Automatically push the `DotNetProjectFile.Analyzers` and `DotNetProjectFile.Analyzers.Sdk` packages in the pipeline. It is straight forward to push to nuget, but tagging the branch seems to require alot of custom steps. To tag the branch we:
- check if the push of `DotNetProjectFile.Analyzers` was successful (through the exit code),
- use the package name to extract the version Id,
- tag the branch.

So while the automatic tagging is nice, all the custom scripts could make it fragile. Potential other ways could be:
- Trigger the workflow instead when a `vx.x.x` tag is manually pushed.
- Remove the automatic tagging process and keep it a manual process, while the build & push pipeline still runs automatically.

Suggestions or preferences are welcome.  