### PR TITLE
Proj0501: Rely on compliant licenses only

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Rely_on_compliant_licenses_only.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Rely_on_compliant_licenses_only.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rules.MS_Build.Rely_on_compliant_licenses_only;
+
+public class Reports
+{
+    [Test]
+    public void Faulty_indented() => new RelyOnCompliantLicensesOnly()
+        .ForProject("FaultyIndenting.cs")
+        .HasIssues(
+            new Issue("Proj1700", "The element <PropertyGroup> has not been properly indented." /*...*/).WithSpan(04, 04, 04, 18),
+            new Issue("Proj1700", "The element <TargetFramework> has not been properly indented." /*.*/).WithSpan(05, 02, 05, 18),
+            new Issue("Proj1700", "The element </PropertyGroup> has not been properly indented." /*..*/).WithSpan(06, 05, 06, 21),
+            new Issue("Proj1700", "The element <Compile> has not been properly indented." /*.........*/).WithSpan(09, 04, 09, 43),
+            new Issue("Proj1700", "The element <Folder> has not been properly indented." /*..........*/).WithSpan(12, 13, 12, 21));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new RelyOnCompliantLicensesOnly()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RelyOnCompliantLicensesOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RelyOnCompliantLicensesOnly.cs
@@ -1,0 +1,36 @@
+using NuGet.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class RelyOnCompliantLicensesOnly() : MsBuildProjectFileAnalyzer(Rule.RelyOnCompliantLicensesOnly)
+{
+    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        var settings = global::NuGet.Configuration.Settings.LoadDefaultSettings(context.File.Path.Directory.ToString());
+        var packageFolder = IODirectory.Parse(SettingsUtility.GetGlobalPackagesFolder(settings));
+
+        foreach (var package in context.File.Walk().OfType<PackageReference>())
+        {
+            try
+            {
+                var path = packageFolder.SubDirectory(package.Include?.ToLowerInvariant(), package.Version?.ToLowerInvariant());
+
+                if (path.Files("*.nuspec").FirstOrDefault() is { HasValue: true } nuspec)
+                {
+
+                    using var stream = nuspec.OpenRead();
+                    var reader = new global::NuGet.Packaging.NuspecReader(stream);
+                    var license = reader.GetLicenseMetadata();
+
+                    context.ReportDiagnostic(Descriptor, package, package.Include, license.License);
+                }
+            }
+            catch (Exception) { }
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
@@ -9,6 +9,7 @@ public enum Category
     Configuration,
     CPM,
     Formatting,
+    Legal,
     Noise,
     Reliability,
     Obsolete,

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -44,6 +44,8 @@
 
   <ItemGroup Label="Roslyn dependencies">
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.Configuration" Version="6.13.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.13.1" />
   </ItemGroup>
 
   <ItemGroup Label="Analyzers">

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -723,6 +723,14 @@ public static partial class Rule
         tags: ["Unit Testing"],
         category: Category.Bug);
 
+    public static DiagnosticDescriptor RelyOnCompliantLicensesOnly => New(
+        id: 0500,
+        title: "Rely on compliant licenses only",
+        message: @"{0} has {1} license.",
+        description: "Including the Microsoft.NET.Test.Sdk is only useful for test projects.",
+        tags: ["License"],
+        category: Category.Legal);
+
     public static DiagnosticDescriptor AvoidGeneratePackageOnBuildWhenNotPackable => New(
         id: 0600,
         title: "Avoid generating packages on build if not packable",


### PR DESCRIPTION
As a result of #314 , I thought should also be possible to check for the used licenses. We have to tackle the dependency with NuGet, but once we have, we can do a lot of nice things.

Closes #322 