### PR TITLE
Use cache for dependency types

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/NuGet/Nuspec_file_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/NuGet/Nuspec_file_specs.cs
@@ -40,8 +40,8 @@ public class Loads
                 DevelopmentDependency = true,
             }
         });
-
     }
+
     [Test]
     public void v2013()
     {

--- a/specs/DotNetProjectFile.Analyzers.Specs/NuGet/Nuspec_file_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/NuGet/Nuspec_file_specs.cs
@@ -6,7 +6,44 @@ namespace NuGet.Nuspec_file_specs;
 public class Loads
 {
     [Test]
-    public void from_stream()
+    public void v2011()
+    {
+        using var stream = Streams.FromText(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+  <metadata>
+    <id>DotNetProjectFile.Analyzers</id>
+    <version>1.2.2</version>
+    <authors>Corniel Nobel,Wesley Baartman</authors>
+    <developmentDependency>true</developmentDependency>
+    <license type=""file"">license.txt</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <icon>logo_128x128.png</icon>
+    <readme>README.md</readme>
+    <projectUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/Corniel/dotnet-project-file-analyzers/main/design/logo_128x128.png</iconUrl>
+    <description>.NET project file analyzers</description>
+    <copyright>Copyright © Corniel Nobel 2023-current</copyright>
+    <tags>Code Analysis Project files csproj vbproj resx MS Build resources</tags>
+    <repository type=""git"" url=""https://www.github.com/Corniel/dotnet-project-file-analyzers"" commit=""cd0017da4a7eb2a2f765cbe821dcb14745e9aaeb"" />
+  </metadata>
+</package>");
+
+        var specs = NuSpecFile.Load(stream);
+
+        specs.Should().Be(new NuSpecFile
+        {
+            Metadata = new()
+            {
+                Id = "DotNetProjectFile.Analyzers",
+                Version = "1.2.2",
+                License = new() { Type = "file", Value = "license.txt" },
+                DevelopmentDependency = true,
+            }
+        });
+
+    }
+    [Test]
+    public void v2013()
     {
         using var stream = Streams.FromText(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <package xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
@@ -50,9 +87,7 @@ public class Loads
             {
                 Id = "NuGet.Configuration",
                 Version = "6.13.1",
-                Authors = "Microsoft",
-                Description = "NuGet's configuration settings implementation.",
-                License = "Apache-2.0",
+                License = new() { Type = "expression", Value = "Apache-2.0" },
             }
         });
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
@@ -2,6 +2,7 @@ using DotNetProjectFile.NuGet;
 
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
+/// <summary>Implements <see cref="Rule.ExcludePrivateAssetDependencies"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class ExcludePrivateAssetDependencies() : MsBuildProjectFileAnalyzer(Rule.ExcludePrivateAssetDependencies)
 {
@@ -29,14 +30,9 @@ public sealed class ExcludePrivateAssetDependencies() : MsBuildProjectFileAnalyz
             return false;
         }
 
-        if (NuGet.Packages.All.TryGet(reference.Include) is { } pkg)
+        if (PackageCache.GetPackage(reference.IncludeOrUpdate, reference.ResolveVersion()) is { } package)
         {
-            return pkg.IsPrivateAsset;
-        }
-
-        if (PackageCache.GetPackage(reference.IncludeOrUpdate, reference.ResolveVersion()) is { } cpkg)
-        {
-            return !cpkg.HasRuntimeDll;
+            return !package.HasRuntimeDll || package.IsDevelopmentDependency is true;
         }
 
         // No info.

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
@@ -25,7 +25,7 @@ public sealed class GlobalPackageReferencesAreMeantForPrivateAssetsOnly()
     {
         if (PackageCache.GetPackage(reference.Include, reference.Version) is { } package)
         {
-            return package.HasRuntimeDll || package.IsDevelopmentDependency is true;
+            return package.HasRuntimeDll && package.IsDevelopmentDependency is not true;
         }
 
         // No info.

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
@@ -23,14 +23,9 @@ public sealed class GlobalPackageReferencesAreMeantForPrivateAssetsOnly()
 
     private bool NoPrivateAsset(GlobalPackageReference reference)
     {
-        if (Packages.All.TryGet(reference.Include) is { } pkg)
+        if (PackageCache.GetPackage(reference.Include, reference.Version) is { } package)
         {
-            return !pkg.IsPrivateAsset;
-        }
-
-        if (PackageCache.GetPackage(reference.Include, reference.Version) is { } cpkg)
-        {
-            return cpkg.HasRuntimeDll;
+            return package.HasRuntimeDll || package.IsDevelopmentDependency is true;
         }
 
         // No info.

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Linq.Enumerable.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Linq.Enumerable.cs
@@ -24,4 +24,18 @@ internal static class EnumerableExtensions
             yield return element;
         }
     }
+
+    /// <summary>Returns the first matching element, or null if no match was found.</summary>
+    [Pure]
+    public static T? FirstOrNone<T>(this IEnumerable<T> enumerable, Predicate<T> predicate) where T : struct
+    {
+        foreach (var element in enumerable)
+        {
+            if (predicate(element))
+            {
+                return element;
+            }
+        }
+        return null;
+    }
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/CachedPackage.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/CachedPackage.cs
@@ -12,5 +12,7 @@ public sealed record CachedPackage
 
     public required bool HasRuntimeDll { get; init; }
 
-    public required NuSpecFile? NuSpecFile { get; init; }
+    public bool? IsDevelopmentDependency { get; init; }
+    
+    public string? License { get; init; }
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/CachedPackage.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/CachedPackage.cs
@@ -1,3 +1,5 @@
+using DotNetProjectFile.NuGet.Packaging;
+
 namespace DotNetProjectFile.NuGet;
 
 public sealed record CachedPackage
@@ -9,4 +11,6 @@ public sealed record CachedPackage
     public required bool HasAnalyzerDll { get; init; }
 
     public required bool HasRuntimeDll { get; init; }
+
+    public required NuSpecFile? NuSpecFile { get; init; }
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
@@ -92,13 +92,16 @@ public static class PackageCache
             return null;
         }
 
+        var nuspec = TryLoadNuSpecFile(versionDir, new(name, versionDir.Name));
+
         return new()
         {
             Name = name,
             Version = versionDir.Name,
             HasAnalyzerDll = HasDllFiles("analyzers"),
             HasRuntimeDll = HasDllFiles("lib") || HasDllFiles("runtimes"),
-            NuSpecFile = TryLoadNuSpecFile(versionDir, new(name, versionDir.Name)),
+            License = nuspec?.Metadata.License?.Value,
+            IsDevelopmentDependency = nuspec?.Metadata.DevelopmentDependency,
         };
 
         bool HasDllFiles(string subDir)

--- a/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
@@ -1,4 +1,5 @@
 using DotNetProjectFile.MsBuild;
+using DotNetProjectFile.NuGet.Packaging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -101,6 +102,7 @@ public static class PackageCache
             Version = versionDir.Name,
             HasAnalyzerDll = HasDllFiles("analyzers"),
             HasRuntimeDll = HasDllFiles("lib") || HasDllFiles("runtimes"),
+            NuSpecFile = TryLoadNuSpecFile(versionDir),
         };
 
         bool HasDllFiles(string subDir)
@@ -173,5 +175,19 @@ public static class PackageCache
         {
             return null;
         }
+    }
+
+    private static NuSpecFile? TryLoadNuSpecFile(IODirectory directory)
+    {
+        if(directory.Files("*.nuspec")?.FirstOrDefault() is { HasValue: true} nuspec)
+        {
+            try
+            {
+                using var stream = nuspec.OpenRead();
+                return NuSpecFile.Load(stream);
+            }
+            catch { }
+        }
+        return null;
     }
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/PackageInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/PackageInfo.cs
@@ -1,0 +1,3 @@
+namespace DotNetProjectFile.NuGet;
+
+public readonly record struct PackageInfo(string Name, string? Version);

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packaging/Metadata.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packaging/Metadata.cs
@@ -10,12 +10,9 @@ public sealed record Metadata
     [XmlElement("version")]
     public string? Version { get; init; }
 
-    [XmlElement("description")]
-    public string? Description { get;init; }
-
-    [XmlElement("authors")]
-    public string? Authors { get; init; }
-
     [XmlElement("license")]
-    public string? License { get; init; }
+    public MetadataLicense? License { get; init; }
+
+    [XmlElement("developmentDependency")]
+    public bool? DevelopmentDependency { get; init; }
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packaging/MetadataLicense.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packaging/MetadataLicense.cs
@@ -1,0 +1,28 @@
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace DotNetProjectFile.NuGet.Packaging;
+
+public sealed record MetadataLicense : IXmlSerializable
+{
+    [XmlAttribute("type")]
+    public string? Type { get; set; }
+
+    public string? Value { get; set; }
+
+    public XmlSchema? GetSchema() => null;
+
+    public void ReadXml(XmlReader reader)
+    {
+        Type = reader.GetAttribute("type");
+        Value = reader.ReadElementString();
+
+    }
+
+    public void WriteXml(XmlWriter writer)
+    {
+        writer.WriteAttributeString("type", Type);
+        writer.WriteValue(Value);
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packaging/NuSpecFile.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packaging/NuSpecFile.cs
@@ -3,7 +3,7 @@ using System.Xml.Serialization;
 
 namespace DotNetProjectFile.NuGet.Packaging;
 
-[XmlRoot(ElementName = "package", Namespace = "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd")]
+[XmlRoot(ElementName = "package")]
 public sealed record NuSpecFile
 {
     [XmlElement("metadata")]
@@ -11,7 +11,14 @@ public sealed record NuSpecFile
 
     [Pure]
     public static NuSpecFile Load(Stream stream)
-        => (NuSpecFile)Serializer.Deserialize(stream);
+        => (NuSpecFile)Serializer.Deserialize(new NamespaceIgnorantReader(stream));
 
     private static readonly XmlSerializer Serializer = new(typeof(NuSpecFile));
+
+    private sealed class NamespaceIgnorantReader : System.Xml.XmlTextReader
+    {
+        public NamespaceIgnorantReader(Stream stream) : base(stream) { }
+
+        public override string NamespaceURI => string.Empty;
+    }
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packaging/NuSpecFile.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packaging/NuSpecFile.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace DotNetProjectFile.NuGet.Packaging;
@@ -15,7 +16,7 @@ public sealed record NuSpecFile
 
     private static readonly XmlSerializer Serializer = new(typeof(NuSpecFile));
 
-    private sealed class NamespaceIgnorantReader : System.Xml.XmlTextReader
+    private sealed class NamespaceIgnorantReader : XmlTextReader
     {
         public NamespaceIgnorantReader(Stream stream) : base(stream) { }
 


### PR DESCRIPTION
Rule [Proj1200: Exclude private assets as project file dependency](https://dotnet-project-file-analyzers.github.io/rules/Proj1200.html) currently has a fixed set of packages we advise it for. With the cache in place, and also collecting the `<developmentDependency>` I think it would be better to start using that data to give advise when to markreferences as private assets.