### PR TITLE
Proj0034: Import statement could not be resolved

### DIFF
--- a/projects/UnresolvableImport/UnresolvableImport.csproj
+++ b/projects/UnresolvableImport/UnresolvableImport.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(MSBuildThisFileDirectory)common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../common/Code.cs" />
+  </ItemGroup>
+
+</Project>

--- a/projects/UnresolvableImport/common.props
+++ b/projects/UnresolvableImport/common.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
@@ -1,0 +1,20 @@
+using DotNetProjectFile.MsBuild;
+
+namespace Rules.MS_Build.Unresolvable_Import;
+
+public class Reports
+{
+    [Test]
+    public void empty_includes() => new UnresolvableImport()
+    .ForProject("UnresolvableImport.cs")
+        .HasIssue(Issue.WRN("Proj0034", "The <Import> '$(MSBuildThisFileDirectory)common.props' could not be resolved.").WithSpan(02, 02, 02, 62));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_with_analyzers(string project) => new UnresolvableImport()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
@@ -7,7 +7,7 @@ public class Reports
     [Test]
     public void empty_includes() => new UnresolvableImport()
     .ForProject("UnresolvableImport.cs")
-        .HasIssue(Issue.WRN("Proj0034", "The <Import> '$(MSBuildThisFileDirectory)common.props' could not be resolved.").WithSpan(02, 02, 02, 62));
+        .HasIssue(Issue.WRN("Proj0034", "The <Import> '$(MSBuildThisFileDirectory)common.props' could not be resolved by the analyzer.").WithSpan(02, 02, 02, 62));
 }
 
 public class Guards

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -60,7 +60,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
-- Proj0034: Import statement could not be resolved. (NEW RULE)
+- Proj0034: Import statement could not be resolved by the analyzer. (NEW RULE)
 - Proj0808: Define global package reference only in Directory.Packages.props. (NEW RULE)
 - Proj0809: Global package references are meant for private assets only. (NEW RULE)
 - Proj1200: Now able to heuristically determine if dependency should be a private asset. (FN)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -60,6 +60,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
+- Proj0034: Import statement could not be resolved. (NEW RULE)
 - Proj0808: Define global package reference only in Directory.Packages.props. (NEW RULE)
 - Proj0809: Global package references are meant for private assets only. (NEW RULE)
 - Proj1200: Now able to heuristically determine if dependency should be a private asset. (FN)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/UnresolvableImport.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/UnresolvableImport.cs
@@ -1,0 +1,16 @@
+using DotNetProjectFile.Analyzers;
+
+namespace DotNetProjectFile.MsBuild;
+
+/// <summary>Implements <see cref="Rule.UnresolvableImport"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class UnresolvableImport() : MsBuildProjectFileAnalyzer(Rule.UnresolvableImport)
+{
+    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        foreach (var import in context.File.Imports.Where(i => i.Value is null))
+        {
+            context.ReportDiagnostic(Descriptor, import, import.Element.Attribute("Project").Value);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -35,6 +35,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0031** Adopt preferred casing of nodes](https://dotnet-project-file-analyzers.github.io/rules/Proj0031.html)
 * [**Proj0032** Migrate away from BinaryFormatter](https://dotnet-project-file-analyzers.github.io/rules/Proj0032.html)
 * [**Proj0033** Project reference includes should exist](https://dotnet-project-file-analyzers.github.io/rules/Proj0033.html)
+* [**Proj0034** Import statement could not be resolved](https://dotnet-project-file-analyzers.github.io/rules/Proj0034.html)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](https://dotnet-project-file-analyzers.github.io/rules/Proj0200.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -308,7 +308,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UnresolvableImport => New(
         id: 0034,
         title: "Import statement could not be resolved",
-        message: "The <Import> '{0}' could not be resolved.",
+        message: "The <Import> '{0}' could not be resolved by the analyzer.",
         description: "The .NET project file analyzer can (unfortunatly) not resolve all import statements.",
         tags: ["limitation"],
         category: Category.Bug);

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -305,6 +305,14 @@ public static partial class Rule
         tags: ["dependencies", "dependency"],
         category: Category.Bug);
 
+    public static DiagnosticDescriptor UnresolvableImport => New(
+        id: 0034,
+        title: "Import statement could not be resolved",
+        message: "The <Import> '{0}' could not be resolved.",
+        description: "The .NET project file analyzer can (unfortunatly) not resolve all import statements.",
+        tags: ["limitation"],
+        category: Category.Bug);
+
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,
         title: "Define the project packability explicitly",


### PR DESCRIPTION
As a result of #321, we should inform the use that we could not resolve the import, and do not perform analysis on rules that require the import statements to work (See #330 ).