### PR TITLE
Disable rules that can not be excecuted correctly on a failing import

### DIFF
--- a/projects/UnresolvableImport/UnresolvableImport.csproj
+++ b/projects/UnresolvableImport/UnresolvableImport.csproj
@@ -6,6 +6,8 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
+  <!-- TODO: should be reported on./ -->
+  
   <ItemGroup>
     <Compile Include="../common/Code.cs" />
   </ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
@@ -1,17 +1,20 @@
-using DotNetProjectFile.MsBuild;
-
 namespace Rules.MS_Build.Unresolvable_Import;
 
 public class Reports
 {
     [Test]
-    public void empty_includes() => new UnresolvableImport()
+    public void on_rule_that_is_not_affected() => new TrackToDoTags()
     .ForProject("UnresolvableImport.cs")
-        .HasIssue(Issue.WRN("Proj0034", "The <Import> '$(MSBuildThisFileDirectory)common.props' could not be resolved by the analyzer.").WithSpan(02, 02, 02, 62));
+        .HasIssue(Issue.WRN("Proj3001", "Complete the task associated to this \"TODO\" comment."));
 }
 
 public class Guards
 {
+    [Test]
+    public void rule_that_is_affected() => new ConfigureCentralPackageVersionManagement()
+    .ForProject("UnresolvableImport.cs")
+        .HasNoIssues();
+
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]
     public void Projects_with_analyzers(string project) => new UnresolvableImport()

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
@@ -3,6 +3,11 @@ namespace Rules.MS_Build.Unresolvable_Import;
 public class Reports
 {
     [Test]
+    public void empty_includes() => new UnresolvableImport()
+    .ForProject("UnresolvableImport.cs")
+        .HasIssue(Issue.WRN("Proj0034", "The <Import> '$(MSBuildThisFileDirectory)common.props' could not be resolved by the analyzer.").WithSpan(02, 02, 02, 62));
+
+    [Test]
     public void on_rule_that_is_not_affected() => new TrackToDoTags()
     .ForProject("UnresolvableImport.cs")
         .HasIssue(Issue.WRN("Proj3001", "Complete the task associated to this \"TODO\" comment."));

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -24,11 +24,11 @@
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers SDK</Description>
     <PackageTags>SDK;Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
-    <Version>1.5.8</Version>
+    <Version>1.5.9</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
-v1.5.8
+v1.5.7
 - Disable signing for .net.csproj file.
 - Include *.yml files too.
 v1.5.5

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AddAdditionalFile.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AddAdditionalFile.cs
@@ -6,6 +6,9 @@ public sealed class AddAdditionalFile() : MsBuildProjectFileAnalyzer(Rule.AddAdd
     /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile_Props;
 
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
         if (!context.File.IsAdditional(context.Options.AdditionalFiles))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AdoptPreferredCasing.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AdoptPreferredCasing.cs
@@ -3,6 +3,9 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class AdoptPreferredCasing() : MsBuildProjectFileAnalyzer(Rule.AdoptPreferredCasing)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
     protected override void Register(ProjectFileAnalysisContext context) => Walk(context.File, context);
 
     private void Walk(Node node, ProjectFileAnalysisContext context)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidCompileItemInSdk.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidCompileItemInSdk.cs
@@ -6,6 +6,10 @@ public sealed class AvoidCompileItemInSdk() : MsBuildProjectFileAnalyzer(Rule.Av
     /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.SDK;
 
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
     {
         foreach (var compile in context.File.ItemGroups

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidLicenseUrl.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidLicenseUrl.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class AvoidLicenseUrl() : MsBuildProjectFileAnalyzer(Rule.AvoidLicenseUrl)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+    
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var lincensUrl in context.File.PropertyGroups.SelectMany(g => g.PackageLicenseUrl))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidUsingMoq.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidUsingMoq.cs
@@ -3,6 +3,9 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class AvoidUsingMoq() : MsBuildProjectFileAnalyzer(Rule.AvoidUsingMoq)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
         var reported = false;

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/BuildActionIncludeShouldExist.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/BuildActionIncludeShouldExist.cs
@@ -4,6 +4,9 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class BuildActionIncludeShouldExist() : MsBuildProjectFileAnalyzer(Rule.BuildActionIncludeShouldExist)
 {
     /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
 
     protected override void Register(ProjectFileAnalysisContext context)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/BuildActionsShouldHaveSingleTask.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/BuildActionsShouldHaveSingleTask.cs
@@ -4,7 +4,11 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class BuildActionsShouldHaveSingleTask() : MsBuildProjectFileAnalyzer(Rule.BuildActionsShouldHaveSingleTask)
 {
+    /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.AllExceptSDK;
+
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
 
     protected override void Register(ProjectFileAnalysisContext context)
     {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineConditionsOnLevel1.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineConditionsOnLevel1.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class DefineConditionsOnLevel1() : MsBuildProjectFileAnalyzer(Rule.DefineConditionsOnLevel1)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var node in context.File

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineGlobalPackageReferenceInDirectoryPackagesOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineGlobalPackageReferenceInDirectoryPackagesOnly.cs
@@ -7,6 +7,9 @@ public sealed class DefineGlobalPackageReferenceInDirectoryPackagesOnly()
 {
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.AllExceptDirectoryPackages;
 
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
     /// <inheritdoc/>
     protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
     {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageReferenceAssetsAsAttributes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageReferenceAssetsAsAttributes.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class DefinePackageReferenceAssetsAsAttributes() : MsBuildProjectFileAnalyzer(Rule.DefinePackageReferenceAssetsAsAttributes)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var reference in context.File.ItemGroups

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineUsingsExplicit.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineUsingsExplicit.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class DefineUsingsExplicit() : MsBuildProjectFileAnalyzer(Rule.DefineUsingsExplicit)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var @implicit in context.File.PropertyGroups

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
@@ -8,6 +8,10 @@ public sealed class ExcludePrivateAssetDependencies() : MsBuildProjectFileAnalyz
     /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
 
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var reference in context.File.ItemGroups

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GeneratePackageOnBuildConditionally.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GeneratePackageOnBuildConditionally.cs
@@ -4,6 +4,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class GeneratePackageOnBuildConditionally()
     : MsBuildProjectFileAnalyzer(Rule.GeneratePackageOnBuildConditionally)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var generate in context.File.PropertyGroups.SelectMany(p => p.GeneratePackageOnBuild)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
@@ -7,6 +7,9 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class GlobalPackageReferencesAreMeantForPrivateAssetsOnly()
     : MsBuildProjectFileAnalyzer(Rule.GlobalPackageReferencesAreMeantForPrivateAssetsOnly)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
     /// <inheritdoc/>
     protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
     {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GuardUnsupported.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GuardUnsupported.cs
@@ -5,6 +5,10 @@ public sealed class GuardUnsupported() : MsBuildProjectFileAnalyzer(
     Rule.ProjectFileCouldNotBeLocated,
     Rule.UpdateLegacyProjects)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(AnalysisContext context)
         => context.RegisterCompilationAction(Locate);
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IndentXml.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IndentXml.cs
@@ -5,11 +5,15 @@ public sealed class IndentXml : MsBuildProjectFileAnalyzer
 {
     private readonly IdentationChecker<MsBuildProject> Checker;
 
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
     public IndentXml() : this(' ', 2) { }
 
     public IndentXml(char ch, int repeat) : base(Rule.IndentXml)
         => Checker = new(ch, repeat, Descriptor);
 
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
         => Checker.Walk(context.File, context.File.Text, context);
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ItemGroupShouldBeUniform.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ItemGroupShouldBeUniform.cs
@@ -16,6 +16,10 @@ public sealed class ItemGroupShouldBeUniform() : MsBuildProjectFileAnalyzer(Rule
     private static readonly IReadOnlyDictionary<Type, IReadOnlyCollection<Type>> Allowed
         = GenerateAllowList();
 
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var group in context.File.ItemGroups)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/MigrateAwayFromBinaryFormatter.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/MigrateAwayFromBinaryFormatter.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class MigrateAwayFromBinaryFormatter() : MsBuildProjectFileAnalyzer(Rule.MigrateAwayFromBinaryFormatter)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
     {
         foreach(var node in context.File.PropertyGroups

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/MigrateFromRulesetToEditorConfigFile.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/MigrateFromRulesetToEditorConfigFile.cs
@@ -4,6 +4,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class MigrateFromRulesetToEditorConfigFile()
     : MsBuildProjectFileAnalyzer(Rule.MigrateFromRulesetToEditorConfigFile)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var ruleset in context.File.PropertyGroups.SelectMany(g => g.CodeAnalysisRuleSet))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OmitXmlDeclarations.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OmitXmlDeclarations.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class OmitXmlDeclarations() : MsBuildProjectFileAnalyzer(Rule.OmitXmlDeclarations)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         if (context.File.Element.Document.Declaration is { })

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderPackageReferencesAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderPackageReferencesAlphabetically.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class OrderPackageReferencesAlphabetically() : MsBuildProjectFileAnalyzer(Rule.OrderPackageReferencesAlphabetically)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var references in context.File.ItemGroups.Select(g => g.PackageReferences))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderPackageVersionsAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderPackageVersionsAlphabetically.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class OrderPackageVersionsAlphabetically() : MsBuildProjectFileAnalyzer(Rule.OrderPackageVersionsAlphabetically)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+    
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var references in context.File.ItemGroups.Select(g => g.PackageVersions))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderProjectReferencesAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderProjectReferencesAlphabetically.cs
@@ -5,6 +5,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class OrderProjectReferencesAlphabetically() : MsBuildProjectFileAnalyzer(Rule.OrderProjectReferencesAlphabetically)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var references in context.File.ItemGroups.Select(g => g.ProjectReferences))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderUsingDirectivesAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderUsingDirectivesAlphabetically.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class OrderUsingDirectivesAlphabetically() : MsBuildProjectFileAnalyzer(Rule.OrderUsingDirectivesAlphabetically)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var group in context.File.ItemGroups

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderUsingDirectivesByType.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OrderUsingDirectivesByType.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class OrderUsingDirectivesByType() : MsBuildProjectFileAnalyzer(Rule.OrderUsingDirectivesByType)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var directives in context.File.ItemGroups.Select(g => g.Usings))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PackageReferencesShouldBeStable.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PackageReferencesShouldBeStable.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class PackageReferencesShouldBeStable() : MsBuildProjectFileAnalyzer(Rule.PackageReferencesShouldBeStable)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var package in context.File.ItemGroups.SelectMany(i => i.PackageReferences))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ProjectReferenceIncludeShouldExist.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ProjectReferenceIncludeShouldExist.cs
@@ -4,6 +4,9 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class ProjectReferenceIncludeShouldExist() : MsBuildProjectFileAnalyzer(Rule.ProjectReferenceIncludeShouldExist)
 {
     /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
 
     protected override void Register(ProjectFileAnalysisContext context)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ProvideCompliantPackageIcon.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ProvideCompliantPackageIcon.cs
@@ -6,6 +6,10 @@ public sealed class ProvideCompliantPackageIcon() : MsBuildProjectFileAnalyzer(R
     /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
 
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         if (!context.File.IsPackable() || context.File.IsTestProject()) return;

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveEmptyNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveEmptyNodes.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class RemoveEmptyNodes() : MsBuildProjectFileAnalyzer(Rule.RemoveEmptyNodes)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var node in context.File.Children)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveFolderNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveFolderNodes.cs
@@ -3,6 +3,9 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class RemoveFolderNodes() : MsBuildProjectFileAnalyzer(Rule.RemoveFolderNodes)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var folder in context.File.ItemGroups.SelectMany(p => p.Folders))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveIncludeAssetsWhenRedundant.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveIncludeAssetsWhenRedundant.cs
@@ -4,6 +4,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class RemoveIncludeAssetsWhenRedundant()
     : MsBuildProjectFileAnalyzer(Rule.RemoveIncludeAssetsWhenRedundant)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var reference in context.File.ItemGroups

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/StaticAliasUsingNotSupported.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/StaticAliasUsingNotSupported.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class StaticAliasUsingNotSupported() : MsBuildProjectFileAnalyzer(Rule.StaticAliasUsingNotSupported)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var directive in context.File.ItemGroups

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TestProjectsRequireSdk.cs
@@ -6,8 +6,10 @@ public sealed class TestProjectsRequireSdk() : MsBuildProjectFileAnalyzer(
     Rule.TestProjectsRequireSdk,
     Rule.UsingMicrosoftNetTestSdkImpliesTestProject)
 {
+    /// <inheritdoc />
     public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
 
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         var isTest = context.File.IsTestProject();

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TrackToDoTags.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TrackToDoTags.cs
@@ -4,7 +4,11 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class TrackToDoTags() : MsBuildProjectFileAnalyzer(Rule.TrackToDoTags)
 {
     private readonly ToDoChecker<MsBuildProject> Checker = new(Rule.TrackToDoTags, GetText);
+  
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
 
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
         => Checker.Check(context.File, context.File.Text, context);
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UnresolvableImport.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UnresolvableImport.cs
@@ -1,11 +1,13 @@
-using DotNetProjectFile.Analyzers;
-
-namespace DotNetProjectFile.MsBuild;
+namespace DotNetProjectFile.Analyzers.MsBuild;
 
 /// <summary>Implements <see cref="Rule.UnresolvableImport"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class UnresolvableImport() : MsBuildProjectFileAnalyzer(Rule.UnresolvableImport)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
     {
         foreach (var import in context.File.Imports.Where(i => i.Value is null))

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCDATAForLargeTexts.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseCDATAForLargeTexts.cs
@@ -5,6 +5,9 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class UseCDATAForLargeTexts() : MsBuildProjectFileAnalyzer(Rule.UseCDATAForLargeTexts)
 {
     /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         Walk(context.File);

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseForwardSlashesInPaths.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseForwardSlashesInPaths.cs
@@ -3,6 +3,10 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class UseForwardSlashesInPaths() : MsBuildProjectFileAnalyzer(Rule.UseForwardSlashesInPaths)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var prop in context.File

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuildProjectFileAnalyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuildProjectFileAnalyzer.cs
@@ -16,11 +16,14 @@ public abstract class MsBuildProjectFileAnalyzer(
     /// </remarks>
     public virtual IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.All;
 
+    /// <summary>Indicates that the rule will not be executed once an import could not be resolved (default is true).</summary>
+    public virtual bool DisableOnFailingImport => true;
+
     /// <summary>Registers the analyzer for all MS Build projects files.</summary>
     protected override void Register(AnalysisContext context)
         => context.RegisterProjectFileAction(c =>
         {
-            if (ApplicableTo.Contains(c.File.FileType))
+            if (ApplicableTo.Contains(c.File.FileType) && !(c.File.HasFailingImport && DisableOnFailingImport))
             {
                 Register(c);
             }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -56,15 +56,16 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.5.8</Version>
+    <Version>1.5.9</Version>
     <PackageReleaseNotes>
       <![CDATA[
-ToBeReleased:
+v1.5.9
 - Proj0034: Import statement could not be resolved by the analyzer. (NEW RULE)
 - Proj0808: Define global package reference only in Directory.Packages.props. (NEW RULE)
 - Proj0809: Global package references are meant for private assets only. (NEW RULE)
 - Proj1200: Now able to heuristically determine if dependency should be a private asset. (FN)
 - Fix AD0001 when provided paths are not validly formatted. (BUG)
+- Disable rules that can not be excecuted correctly on a failing import. (FP)
 v1.5.8
 - Proj1001: Take <GlobalPackageReference>'s also into account. (FP)
 v1.5.7

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -42,6 +42,9 @@ public sealed partial class Project : Node, ProjectFile
 
     public bool IsLegacy => Element.Name.NamespaceName is { Length: > 0 };
 
+    /// <summary>Returns true if any import is failing.</summary>
+    public bool HasFailingImport => Imports.Any(i => i.Value is not { HasFailingImport: false });
+
     public string? Sdk => Attribute();
 
     public IOFile Path { get; }


### PR DESCRIPTION
When an import fails (due to the fact that the analyzer can resolve the path (reported by [Proj0034](https://dotnet-project-file-analyzers.github.io/rules/Proj0034.html)) a big chunk of the rules can not be correctly executed, as the outcome of the analysis is likely effected by what is defined in the (failed) import.

All MS Build file rules are now disabled in that case, unless specified otherwise.

Closes #330 and #321