### PR TITLE
Introduction of PackageReferenceBase

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GenerateSbom.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GenerateSbom.cs
@@ -16,7 +16,7 @@ public sealed class GenerateSbom() : MsBuildProjectFileAnalyzer(Rule.GenerateSbo
         var property = context.File.Property<GenerateSBOM>();
         var registered = context.File
            .Walk().OfType<PackageReference>()
-           .Any(r => r.Include == NuGet.Packages.Microsoft_Sbom_Targets.Name);
+           .Any(NuGet.Packages.Microsoft_Sbom_Targets.IsMatch);
 
         if (property is { })
         {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
@@ -8,13 +8,11 @@ public sealed class UseAnalyzersForPackages() : MsBuildProjectFileAnalyzer(Rule.
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        var packageReferences = context.File.Walk().OfType<PackageReference>();
-        var globalReferences = context.File.Walk().OfType<GlobalPackageReference>();
+        var packageReferences = context.File.Walk().OfType<PackageReferenceBase>().Where(p => p is not PackageVersion);
 
         var unusedAnalyzers = Analyzers.Where(analyzer
             => analyzer.IsApplicable(context.Compilation.Options.Language)
-            && packageReferences.None(analyzer.IsMatch)
-            && globalReferences.None(analyzer.IsMatch));
+            && packageReferences.None(analyzer.IsMatch));
 
         foreach (var analyzer in unusedAnalyzers)
         {

--- a/src/DotNetProjectFile.Analyzers/MsBuild/GlobalPackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/GlobalPackageReference.cs
@@ -1,11 +1,6 @@
 namespace DotNetProjectFile.MsBuild;
 
 public sealed class GlobalPackageReference(XElement element, Node parent, MsBuildProject project)
-    : Node(element, parent, project)
+    : PackageReferenceBase(element, parent, project)
 {
-    public string? Include => Attribute();
-
-    public string? Version => Attribute();
-
-    public string? PrivateAssets => Attribute() ?? Child();
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
@@ -1,17 +1,9 @@
 namespace DotNetProjectFile.MsBuild;
 
 public sealed class PackageReference(XElement element, Node parent, MsBuildProject project)
-    : Node(element, parent, project)
+    : PackageReferenceBase(element, parent, project)
 {
-    public string? Include => Attribute();
-
-    public string? Update => Attribute();
-
-    public string? Version => Attribute();
-
     public string? VersionOverride => Attribute();
-
-    public string IncludeOrUpdate => Include ?? Update ?? string.Empty;
 
     public string VersionOrVersionOverride => Version ?? VersionOverride ?? string.Empty;
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageReferenceBase.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageReferenceBase.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotNetProjectFile.MsBuild;
+
+public abstract class PackageReferenceBase(XElement element, Node parent, MsBuildProject project)
+    : Node(element, parent, project)
+{
+    public string? Include => Attribute();
+
+    public string? Update => Attribute();
+
+    public string? Version => Attribute();
+
+    public string IncludeOrUpdate => Include ?? Update ?? string.Empty;
+}

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageVersion.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageVersion.cs
@@ -1,13 +1,6 @@
 namespace DotNetProjectFile.MsBuild;
 
 public sealed class PackageVersion(XElement element, Node parent, MsBuildProject project)
-    : Node(element, parent, project)
+    : PackageReferenceBase(element, parent, project)
 {
-    public string? Include => Attribute();
-
-    public string? Update => Attribute();
-
-    public string? Version => Attribute();
-
-    public string IncludeOrUpdate => Include ?? Update ?? string.Empty;
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/Analyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Analyzer.cs
@@ -12,10 +12,6 @@ public sealed record Analyzer : Package
     public bool IsApplicable(string compilationLanguage)
         => Language is null || Language == compilationLanguage;
 
-    public bool IsMatch(PackageReference reference) => reference.Include.IsMatch(Name);
-
-    public bool IsMatch(GlobalPackageReference reference) => reference.Include.IsMatch(Name);
-
     public bool IsMatch(AssemblyIdentity assembly)
         => assembly.Name.StartsWith(Match, StringComparison.OrdinalIgnoreCase)
         && (assembly.Name.Length == Match.Length

--- a/src/DotNetProjectFile.Analyzers/NuGet/Package.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Package.cs
@@ -15,4 +15,6 @@ public record Package
     public bool IsPrivateAsset { get; }
 
     public string? Language { get; }
+
+    public bool IsMatch(PackageReferenceBase reference) => reference.Include.IsMatch(Name);
 }


### PR DESCRIPTION
As `PackageReference`, `PackageVersion`, and `GlobalPackageReference` have a lot in common, it is beneficial to let them have a shared base class.