### PR TITLE
Proj0500: Only include packages with an explicitly defined license

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Only_include_packages_with_explicit_license.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Only_include_packages_with_explicit_license.cs
@@ -1,0 +1,29 @@
+namespace Rules.MS_Build.Only_include_packages_with_explicit_license;
+
+public class Reports
+{
+    [Test]
+    public void on_packages_without_license_specified_in_nuspec() => new OnlyIncludePackagesWithExplicitLicense()
+       .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+    <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""Qowaiv"" Version=""1.0.0.139"" />
+  </ItemGroup>
+
+</Project>")
+       .HasIssue(Issue.WRN("Proj0500", "The Qowaiv package is shipped without an explicitly defined license."));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new OnlyIncludePackagesWithExplicitLicense()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OnlyIncludePackagesWithExplicitLicense.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/OnlyIncludePackagesWithExplicitLicense.cs
@@ -1,0 +1,26 @@
+
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+/// <summary>Implements <see cref="Rule.OnlyIncludePackagesWithExplicitLicense"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class OnlyIncludePackagesWithExplicitLicense() : MsBuildProjectFileAnalyzer(Rule.OnlyIncludePackagesWithExplicitLicense)
+{
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
+    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        foreach(var reference in context.File.ItemGroups.SelectMany(g => g.Children)
+            .OfType<PackageReferenceBase>()
+            .Where(r => r.Version is { Length: > 0 } && r.Project == context.File)
+            .Where(WithoutExplicitLicense))
+        {
+            context.ReportDiagnostic(Descriptor, reference, reference.IncludeOrUpdate);
+        }
+    }
+
+    private static bool WithoutExplicitLicense(PackageReferenceBase reference)
+        => NuGet.PackageCache.GetPackage(reference.IncludeOrUpdate, reference.Version) is { } package
+        && package.License is not { Length: > 0 };
+}

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/Category.cs
@@ -9,6 +9,7 @@ public enum Category
     Configuration,
     CPM,
     Formatting,
+    Legal,
     Noise,
     Reliability,
     Obsolete,

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -59,6 +59,8 @@
     <Version>1.5.9</Version>
     <PackageReleaseNotes>
       <![CDATA[
+ToBeReleased:
+- Proj0500: Only include packages with an explicitly defined license. (NEW RULE)
 v1.5.9
 - Proj0034: Import statement could not be resolved by the analyzer. (NEW RULE)
 - Proj0808: Define global package reference only in Directory.Packages.props. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -731,6 +731,16 @@ public static partial class Rule
         tags: ["Unit Testing"],
         category: Category.Bug);
 
+    public static DiagnosticDescriptor OnlyIncludePackagesWithExplicitLicense => New(
+       id: 0500,
+       title: "Only include packages with an explicitly defined license",
+       message: "The {0} package is shipped without an explicitly defined license.",
+       description:
+           "To prevent legal issues do not rely on 3rd party references that do not " +
+           "come with an explicitly defined license.",
+       tags: ["license"],
+       category: Category.Legal);
+
     public static DiagnosticDescriptor AvoidGeneratePackageOnBuildWhenNotPackable => New(
         id: 0600,
         title: "Avoid generating packages on build if not packable",


### PR DESCRIPTION
Before reporting on not allowed licenses, I thought we first might want to report on packages without  (explicitly defined) licenses.

Note that the test that resports is to a high extend a FP: that Nuspec contains a `<licenseUrl>` instead. I hope that we actually can find a package that is beeing shipped without, so that we can have a true valid issue being reported in the test.