### PR TITLE
Introduction of custom license

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Thrid_Party_license_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Thrid_Party_license_compliance.cs
@@ -54,6 +54,7 @@ public class Reports
 </Project>")
        .HasIssue(Issue.WRN("Proj0502", "The SeeSharpTools.JY.GUI package is distributed as GPL-3.0-only, which is imcompatable with the MIT license of the project."));
 
+    [Ignore("Rule 0504 has not been implemented yet")]
     [Test]
     public void on_package_with_custom_license() => new ThirdPartyLicenseResolver()
        .ForInlineCsproj(@"
@@ -68,7 +69,7 @@ public class Reports
   </ItemGroup>
 
 </Project>")
-       .HasIssue(Issue.WRN("Proj0502", "The SeeSharpTools.JY.GUI package is distributed as GPL-3.0-only, which is imcompatable with the MIT license of the project."));
+       .HasIssue(Issue.WRN("Proj0504", "FluentAssertions package is distributed with a custom license, which has not been registrated."));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Thrid_Party_license_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Thrid_Party_license_compliance.cs
@@ -69,7 +69,7 @@ public class Reports
   </ItemGroup>
 
 </Project>")
-       .HasIssue(Issue.WRN("Proj0504", "FluentAssertions package is distributed with a custom license, which has not been registrated."));
+       .HasIssue(Issue.WRN("Proj0504", "FluentAssertions package is distributed under a custom license, which has not been explicitly accepted."));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Thrid_Party_license_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Thrid_Party_license_compliance.cs
@@ -53,6 +53,22 @@ public class Reports
 
 </Project>")
        .HasIssue(Issue.WRN("Proj0502", "The SeeSharpTools.JY.GUI package is distributed as GPL-3.0-only, which is imcompatable with the MIT license of the project."));
+
+    [Test]
+    public void on_package_with_custom_license() => new ThirdPartyLicenseResolver()
+       .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""FluentAssertions"" Version=""8.0.0"" />
+  </ItemGroup>
+
+</Project>")
+       .HasIssue(Issue.WRN("Proj0502", "The SeeSharpTools.JY.GUI package is distributed as GPL-3.0-only, which is imcompatable with the MIT license of the project."));
 }
 
 public class Guards

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
@@ -39,7 +39,7 @@ public sealed class ThirdPartyLicenseResolver() : MsBuildProjectFileAnalyzer(
         {
             context.ReportDiagnostic(Rule.PackageOnlyContainsDeprecatedLicenseUrl, reference, reference.IncludeOrUpdate);
         }
-        else if (!packageLicense.CompatibleWith(projectLicense))
+        else if (!packageLicense.CompatibleWith(projectLicense) && packageLicense is not CustomLicense)
         {
             context.ReportDiagnostic(Rule.PackageIncompatibleWithProjectLicense, reference, reference.IncludeOrUpdate, packageLicense, projectLicense);
         }

--- a/src/DotNetProjectFile.Analyzers/Licensing/CustomLicense.cs
+++ b/src/DotNetProjectFile.Analyzers/Licensing/CustomLicense.cs
@@ -1,0 +1,20 @@
+using System.Security.Cryptography;
+
+namespace DotNetProjectFile.Licensing;
+
+public sealed record CustomLicense(string Hash) : LicenseExpression
+{
+    public override string Expression => "Custom";
+
+    public override bool SpdxCompliant => false;
+
+    public override bool CompatibleWith(LicenseExpression other) => false;
+
+    public static CustomLicense Create(string content)
+    {
+        var hash = SHA.ComputeHash(System.Text.Encoding.UTF8.GetBytes(content));
+        return new(Convert.ToBase64String(hash).TrimEnd('='));
+    }
+
+    private static readonly SHA1 SHA = SHA1Managed.Create();
+}

--- a/src/DotNetProjectFile.Analyzers/Licensing/Licenses.cs
+++ b/src/DotNetProjectFile.Analyzers/Licensing/Licenses.cs
@@ -249,6 +249,6 @@ public static class Licenses
             }
         }
 
-        return Unknown;
+        return CustomLicense.Create(content);
     }
 }


### PR DESCRIPTION
To make a clear distinction between unknown and custom licenses (such as that of Sonar Source, or XCeed) I've created a custom license, containing an (SHA1) hash.

The idea is that custom licenses should be registered, to be allowed. Previously I've suggested to define this in a MS Build property, but an MS Build item might be more convenient:

``` XML
<ItemGroup Label="Custom licenses">
  <CustomLicense Include="FluentAssertions" Hash="RQN3OPC/wYxT+eMudU1hVTy7smo" />
</ItemGroup>
```