### PR TITLE
Apply RS1032 to rule messages

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
@@ -23,6 +23,21 @@ public partial class Rules
         content.Should().Contain($">{rule.Id}: ");
     }
 
+    /// <summary>
+    /// The diagnostic message should not contain any line return character nor any leading or trailing whitespaces and should either be a single sentence without a trailing period or a multi-sentences with a trailing period
+    /// </summary>
+    /// <remarks>
+    /// See: https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md#rs1032-define-diagnostic-message-correctly
+    /// </remarks>
+    [TestCaseSource(nameof(AllRules))]
+    public void has_message_compliant_with_RS1032(Rule rule)
+    {
+        var title = rule.Message.ToString().Trim();
+
+        title.Should().NotContain("\n", "Line return characters are not allowed.")
+            .And.NotEndWith(".", "Be a single line not adding with a trailing dot.");
+    }
+
     [Test]
     public void Root_Readme_mentions_right_number_of_rules()
     {
@@ -102,6 +117,10 @@ public partial class Rules
 public sealed record Rule(DiagnosticDescriptor Descriptor)
 {
     public string Id => Descriptor.Id;
+
+    public LocalizableString Title => Descriptor.Title;
+
+    public LocalizableString Message => Descriptor.MessageFormat;
 
     public string HelpLinkUri => Descriptor.HelpLinkUri;
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Choose_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Choose_specs.cs
@@ -10,18 +10,18 @@ public class Project_contains
         => new NodeReporter()
         .ForProject("ChooseWhen.cs")
         .HasIssues(
-            Issue.WRN("Proj9999", "Found TargetFrameworks.").WithSpan(03, 4, 03, 54),
-            Issue.WRN("Proj9999", "Found Nullable.")/*....*/.WithSpan(04, 4, 04, 31),
-            Issue.WRN("Proj9999", "Found NuGetAudit.")/*..*/.WithSpan(10, 8, 10, 37),
-            Issue.WRN("Proj9999", "Found NuGetAudit.")/*..*/.WithSpan(18, 8, 18, 38),
-            Issue.WRN("Proj9999", "Found Folder.")/*......*/.WithSpan(13, 8, 13, 34),
-            Issue.WRN("Proj9999", "Found Folder.")/*......*/.WithSpan(21, 8, 21, 39));
+            Issue.WRN("Proj9999", "Found TargetFrameworks").WithSpan(03, 4, 03, 54),
+            Issue.WRN("Proj9999", "Found Nullable")/*....*/.WithSpan(04, 4, 04, 31),
+            Issue.WRN("Proj9999", "Found NuGetAudit")/*..*/.WithSpan(10, 8, 10, 37),
+            Issue.WRN("Proj9999", "Found NuGetAudit")/*..*/.WithSpan(18, 8, 18, 38),
+            Issue.WRN("Proj9999", "Found Folder")/*......*/.WithSpan(13, 8, 13, 34),
+            Issue.WRN("Proj9999", "Found Folder")/*......*/.WithSpan(21, 8, 21, 39));
     
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     private sealed class NodeReporter : MsBuildProjectFileAnalyzer
     {
         public NodeReporter() 
-            : base(Rule.New(9999, "", "Found {0}.", "", [], Category.Reliability)) { }
+            : base(Rule.New(9999, "", "Found {0}", "", [], Category.Reliability)) { }
 
         protected override void Register(ProjectFileAnalysisContext context)
         {

--- a/specs/DotNetProjectFile.Analyzers.Specs/Parsing/INI_syntax.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Parsing/INI_syntax.cs
@@ -71,7 +71,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("[]");
 
             syntax.Sections[0].Header!.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4001", "] is unexpected.").WithSpan(0, 1, 0, 2));
+                Issue.ERR("Proj4001", "] is unexpected").WithSpan(0, 1, 0, 2));
         }
 
         [Test]
@@ -80,7 +80,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("[[header]");
 
             syntax.Sections[0].Header!.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4001", "[ is unexpected.").WithSpan(0, 1, 0, 2));
+                Issue.ERR("Proj4001", "[ is unexpected").WithSpan(0, 1, 0, 2));
         }
 
         [Test]
@@ -89,7 +89,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("[header\n");
 
             syntax.Sections[0].Header!.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4001", "] is expected.").WithSpan(0, 7, 1, 0));
+                Issue.ERR("Proj4001", "] is expected").WithSpan(0, 7, 1, 0));
         }
 
         [Test]
@@ -98,7 +98,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("[header]]");
 
             syntax.Sections[0].Header!.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4001", "] is unexpected.").WithSpan(0, 8, 0, 9));
+                Issue.ERR("Proj4001", "] is unexpected").WithSpan(0, 8, 0, 9));
         }
     }
 
@@ -110,7 +110,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("= value \n");
 
             syntax.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4002", "= is unexpected.").WithSpan(0, 0, 0, 1));
+                Issue.ERR("Proj4002", "= is unexpected").WithSpan(0, 0, 0, 1));
         }
 
         [Test]
@@ -119,7 +119,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("key1 = \n");
 
             syntax.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4002", "Value is missing.").WithSpan(0, 6, 0, 7));
+                Issue.ERR("Proj4002", "Value is missing").WithSpan(0, 6, 0, 7));
         }
 
         [Test]
@@ -128,7 +128,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("key1 value1\n");
 
             syntax.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4002", "= or : is expected.").WithSpan(0, 5, 0, 11));
+                Issue.ERR("Proj4002", "= or : is expected").WithSpan(0, 5, 0, 11));
         }
 
         [Test]
@@ -137,7 +137,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("key1 = : value1\n");
 
             syntax.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4002", ": is unexpected.").WithSpan(0, 7, 0, 8));
+                Issue.ERR("Proj4002", ": is unexpected").WithSpan(0, 7, 0, 8));
         }
 
         [Test]
@@ -146,7 +146,7 @@ public class Parses_with_errors
             var syntax = Parse.Syntax("KeyWith Comment = #Comment");
 
             syntax.GetDiagnostics().Should().HaveIssue(
-                Issue.ERR("Proj4002", "= or : is expected.").WithSpan(0, 8, 0, 15));
+                Issue.ERR("Proj4002", "= or : is expected").WithSpan(0, 8, 0, 15));
         }
     }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/EditorConfig/Header_must_be_glob.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/EditorConfig/Header_must_be_glob.cs
@@ -7,7 +7,7 @@ public class Reports
     [Test]
     public void invalid_GLOBs() => new HeaderMustBeGlob()
         .ForProject("InvalidEditorConfigHeaders.cs")
-        .HasIssue(Issue.WRN("Proj4050", "Header [*.{cs,json}}] is not a valid GLOB.").WithSpan(07, 01, 07, 13));
+        .HasIssue(Issue.WRN("Proj4050", "Header [*.{cs,json}}] is not a valid GLOB").WithSpan(07, 01, 07, 13));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/EditorConfig/Use_equals_for_assignment.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/EditorConfig/Use_equals_for_assignment.cs
@@ -8,8 +8,8 @@ public class Reports
     public void colon_signs() => new UseEqualsAssign()
         .ForProject("InvalidEditorConfigHeaders.cs")
         .HasIssues(
-            Issue.WRN("Proj4051", "Use = instead.").WithSpan(13, 12, 13, 13),
-            Issue.WRN("Proj4051", "Use = instead.").WithSpan(14, 11, 14, 12));
+            Issue.WRN("Proj4051", "Use = instead").WithSpan(13, 12, 13, 13),
+            Issue.WRN("Proj4051", "Use = instead").WithSpan(14, 11, 14, 12));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Generic/Only_use_UTF-8_without_BOM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Generic/Only_use_UTF-8_without_BOM.cs
@@ -15,8 +15,8 @@ public class Reports
     public void files_with_UTF8_BOM() => new OnlyUseUTF8WithoutBom()
         .ForProject("MultipleEncodings.cs")
         .HasIssues(
-           Issue.WRN("Proj3000", "This file is using UTF-8 encoding with BOM.").WithPath("utf8-bom.css"),
-           Issue.WRN("Proj3000", "This file is using UTF-8 encoding with BOM.").WithPath("file.utf8-bom"));
+           Issue.WRN("Proj3000", "This file is using UTF-8 encoding with BOM").WithPath("utf8-bom.css"),
+           Issue.WRN("Proj3000", "This file is using UTF-8 encoding with BOM").WithPath("file.utf8-bom"));
 }
 
 public class Does_not_crash
@@ -29,7 +29,7 @@ public class Does_not_crash
 
         new OnlyUseUTF8WithoutBom()
             .ForProject("MultipleEncodings.cs")
-            .HasIssue(Issue.WRN("Proj3000", "This file is using UTF-8 encoding with BOM.").WithPath("file.utf8-bom"));
+            .HasIssue(Issue.WRN("Proj3000", "This file is using UTF-8 encoding with BOM").WithPath("file.utf8-bom"));
     }
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/INI/Empty_section.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/INI/Empty_section.cs
@@ -7,7 +7,7 @@ public class Reports
     [Test]
     public void empty_sections() => new EmptySection()
         .ForProject("IniFileWithEmptySection.cs")
-        .HasIssue(Issue.WRN("Proj4010", "Section [empty.*] is empty.").WithSpan(09, 00, 10, 00));
+        .HasIssue(Issue.WRN("Proj4010", "Section [empty.*] is empty").WithSpan(09, 00, 10, 00));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/INI/INI_syntax.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/INI/INI_syntax.cs
@@ -8,12 +8,12 @@ public class Reports
     public void errors() => new IniSyntaxAnalyzer()
         .ForProject("IniSyntaxErrors.cs")
         .HasIssues(
-            Issue.WRN("Proj4001", "] is expected." /*..,,,.*/).WithSpan(02, 10, 03, 00),
-            Issue.WRN("Proj4002", "= or : is expected." /*.*/).WithSpan(03, 22, 03, 27),
-            Issue.WRN("Proj4002", "Value is missing." /*...*/).WithSpan(04, 16, 04, 17),
-            Issue.WRN("Proj4002", "= or : is expected." /*.*/).WithSpan(10, 08, 10, 15),
-            Issue.WRN("Proj4001", "] is unexpected." /*......*/).WithSpan(12, 01, 12, 02),
-            Issue.WRN("Proj4001", "[ is unexpected." /*....*/).WithSpan(15, 01, 15, 02));
+            Issue.WRN("Proj4001", "] is expected" /*..,,,.*/).WithSpan(02, 10, 03, 00),
+            Issue.WRN("Proj4002", "= or : is expected" /*.*/).WithSpan(03, 22, 03, 27),
+            Issue.WRN("Proj4002", "Value is missing" /*...*/).WithSpan(04, 16, 04, 17),
+            Issue.WRN("Proj4002", "= or : is expected" /*.*/).WithSpan(10, 08, 10, 15),
+            Issue.WRN("Proj4001", "] is unexpected" /*......*/).WithSpan(12, 01, 12, 02),
+            Issue.WRN("Proj4001", "[ is unexpected" /*....*/).WithSpan(15, 01, 15, 02));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Add_additional_files.cs
@@ -6,7 +6,7 @@ public class Reports
     public void project_files_not_additional() => new AddAdditionalFile()
         .ForProject("EmptyProject.cs")
         .HasIssue(
-            Issue.WRN("Proj0006", "Add 'EmptyProject.csproj' to the additional files."));
+            Issue.WRN("Proj0006", "Add 'EmptyProject.csproj' to the additional files"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Adopt_preferred_casing.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Adopt_preferred_casing.cs
@@ -6,9 +6,9 @@ public class Reports
     public void on_alternative_casing() => new AdoptPreferredCasing()
         .ForProject("CaseInsensitive.cs")
         .HasIssues(
-            Issue.WRN("Proj0031", "The node <TARGETFRAMEWORK> has a different casing than the preferred one <TargetFramework>."/*...*/).WithSpan(05, 04, 05, 45),
-            Issue.WRN("Proj0031", "The node <ComPile> has a different casing than the preferred one <Compile>."/*...................*/).WithSpan(09, 04, 09, 43),
-            Issue.WRN("Proj0031", "The node <packagereference> has a different casing than the preferred one <PackageReference>."/*.*/).WithSpan(13, 04, 13, 57));
+            Issue.WRN("Proj0031", "The node <TARGETFRAMEWORK> has a different casing than the preferred one <TargetFramework>"/*...*/).WithSpan(05, 04, 05, 45),
+            Issue.WRN("Proj0031", "The node <ComPile> has a different casing than the preferred one <Compile>"/*...................*/).WithSpan(09, 04, 09, 43),
+            Issue.WRN("Proj0031", "The node <packagereference> has a different casing than the preferred one <PackageReference>"/*.*/).WithSpan(13, 04, 13, 57));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Avoid_generate_on_build.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Avoid_generate_on_build.cs
@@ -7,7 +7,7 @@ public class Reports
        => new AvoidGeneratePackageOnBuildWhenNotPackable()
        .ForProject("GeneratePackageNotPackable.cs")
        .HasIssue(
-           Issue.WRN("Proj0600", "Avoid defining <GeneratePackageOnBuild> node explicitly when <IsPackable> is 'false'.").WithSpan(5, 04, 5, 57));
+           Issue.WRN("Proj0600", "Avoid defining <GeneratePackageOnBuild> node explicitly when <IsPackable> is 'false'").WithSpan(5, 04, 5, 57));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Avoid_using_Moq.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Avoid_using_Moq.cs
@@ -6,7 +6,7 @@ public class Reports
     public void on_Moq_dependency()
        => new AvoidUsingMoq()
        .ForProject("UsesMoq.cs")
-       .HasIssue(Issue.WRN("Proj1100", "Do not use Moq.").WithSpan(9, 04, 9, 55));
+       .HasIssue(Issue.WRN("Proj1100", "Do not use Moq").WithSpan(9, 04, 9, 55));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Build_action_include_should_exist.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Build_action_include_should_exist.cs
@@ -7,11 +7,11 @@ public class Reports
         => new BuildActionIncludeShouldExist()
         .ForProject("EmptyInclude.cs")
         .HasIssues(
-            Issue.WRN("Proj0022", "The Include '*.txt' of <None> does not match any files." /*..........*/).WithSpan(08, 04, 08, 28),
-            Issue.WRN("Proj0022", "The Include 'DoesNotExist.cs' of <None> does not exist." /*..........*/).WithSpan(09, 04, 09, 38),
-            Issue.WRN("Proj0022", "The Include '*.vbproj' of <Content> does not match any files." /*....*/).WithSpan(10, 04, 10, 43),
-            Issue.WRN("Proj0022", "The Include '**/*.bin' of <EmbeddedResource> does not match any files.").WithSpan(11, 04, 11, 43),
-            Issue.WRN("Proj0022", "The Include '*.unknown' of <AdditionalFiles> does not match any files.").WithSpan(12, 04, 12, 43)
+            Issue.WRN("Proj0022", "The Include '*.txt' of <None> does not match any files" /*..........*/).WithSpan(08, 04, 08, 28),
+            Issue.WRN("Proj0022", "The Include 'DoesNotExist.cs' of <None> does not exist" /*..........*/).WithSpan(09, 04, 09, 38),
+            Issue.WRN("Proj0022", "The Include '*.vbproj' of <Content> does not match any files" /*....*/).WithSpan(10, 04, 10, 43),
+            Issue.WRN("Proj0022", "The Include '**/*.bin' of <EmbeddedResource> does not match any files").WithSpan(11, 04, 11, 43),
+            Issue.WRN("Proj0022", "The Include '*.unknown' of <AdditionalFiles> does not match any files").WithSpan(12, 04, 12, 43)
         );
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Build_actions_should_have_single_task.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Build_actions_should_have_single_task.cs
@@ -7,9 +7,9 @@ public class Reports
         => new BuildActionsShouldHaveSingleTask()
         .ForProject("MultipleBuildActionTasks.cs")
         .HasIssues(
-            Issue.WRN("Proj0021", "The <Content> defines multiple tasks." /*...*/).WithSpan(12, 04, 12, 52),
-            Issue.WRN("Proj0021", "The <None> defines multiple tasks." /*......*/).WithSpan(16, 04, 16, 50),
-            Issue.WRN("Proj0021", "The <AdditionalFiles> defines multiple tasks.").WithSpan(20, 04, 20, 67)
+            Issue.WRN("Proj0021", "The <Content> defines multiple tasks" /*...*/).WithSpan(12, 04, 12, 52),
+            Issue.WRN("Proj0021", "The <None> defines multiple tasks" /*......*/).WithSpan(16, 04, 16, 50),
+            Issue.WRN("Proj0021", "The <AdditionalFiles> defines multiple tasks").WithSpan(20, 04, 20, 67)
         );
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Configure_CPM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Configure_CPM.cs
@@ -5,7 +5,7 @@ public class Reports
     [Test]
     public void project_without_CPM() => new ConfigureCentralPackageVersionManagement()
         .ForProject("NoCPM.cs")
-        .HasIssue(Issue.WRN("Proj0800", "Define the <ManagePackageVersionsCentrally> node with the value 'true', or 'false'.")
+        .HasIssue(Issue.WRN("Proj0800", "Define the <ManagePackageVersionsCentrally> node with the value 'true', or 'false'")
         .WithSpan(00, 00, 00, 32));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Enable_CPM_globally.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Enable_CPM_globally.cs
@@ -6,7 +6,7 @@ public class Reports
     public void enabling_locally()
         => new EnableCentralPackageManagementCentrally()
         .ForProject("EnableCPMLocally.cs")
-        .HasIssue(Issue.WRN("Proj0802", "Enable <ManagePackageVersionsCentrally> in 'Directory.Packages.props' or a shared props file.")
+        .HasIssue(Issue.WRN("Proj0802", "Enable <ManagePackageVersionsCentrally> in 'Directory.Packages.props' or a shared props file")
         .WithSpan(04, 04, 04, 73));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Include_Directory_Packages_props.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Include_Directory_Packages_props.cs
@@ -5,7 +5,7 @@ public class Reports
     [Test]
     public void project_without_file() => new IncludeDirectoryPackagesProps()
         .ForProject("NoDirectoryPackagesProps.cs")
-        .HasIssue(Issue.WRN("Proj0801", "The file 'Directory.Packages.props' could not be located.")
+        .HasIssue(Issue.WRN("Proj0801", "The file 'Directory.Packages.props' could not be located")
         .WithSpan(00, 00, 00, 32));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Use_Directory_Packages_props_only_for_CPM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Use_Directory_Packages_props_only_for_CPM.cs
@@ -8,10 +8,10 @@ public class Reports
         => new UseDirectoryPackagesPropsOnlyForCPM()
         .ForProject("BloatedDirectoryPackagesProps.cs")
         .HasIssues(
-            Issue.WRN("Proj0807", "As <TargetFramework> is not about Central Package Management it should not be in Directory.Packages.props." /*..*/).WithSpan(03, 04, 03, 53),
-            Issue.WRN("Proj0807", "As <OutputType> is not about Central Package Management it should not be in Directory.Packages.props." /*.......*/).WithSpan(04, 04, 04, 36),
-            Issue.WRN("Proj0807", "As <PackageReference> is not about Central Package Management it should not be in Directory.Packages.props." /*.*/).WithSpan(21, 04, 21, 64),
-            Issue.WRN("Proj0807", "As <AdditionalFiles> is not about Central Package Management it should not be in Directory.Packages.props." /*..*/).WithSpan(26, 04, 26, 38));
+            Issue.WRN("Proj0807", "As <TargetFramework> is not about Central Package Management it should not be in Directory.Packages.props" /*..*/).WithSpan(03, 04, 03, 53),
+            Issue.WRN("Proj0807", "As <OutputType> is not about Central Package Management it should not be in Directory.Packages.props" /*.......*/).WithSpan(04, 04, 04, 36),
+            Issue.WRN("Proj0807", "As <PackageReference> is not about Central Package Management it should not be in Directory.Packages.props" /*.*/).WithSpan(21, 04, 21, 64),
+            Issue.WRN("Proj0807", "As <AdditionalFiles> is not about Central Package Management it should not be in Directory.Packages.props" /*..*/).WithSpan(26, 04, 26, 38));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Use_VersionOverride_only_with_CPM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Use_VersionOverride_only_with_CPM.cs
@@ -6,7 +6,7 @@ public class Reports
     public void project_with_VersionOverride_without_CPM()
         => new UseVersionOverrideOnlyWithCpm()
         .ForProject("MisuseVersionOverride.cs")
-        .HasIssue(Issue.WRN("Proj0803", "Use Version instead of VersionOverride when CPM is not enabled.")
+        .HasIssue(Issue.WRN("Proj0803", "Use Version instead of VersionOverride when CPM is not enabled")
         .WithSpan(07, 04, 07, 81));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Use_Version_only_without_CPM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Use_Version_only_without_CPM.cs
@@ -6,7 +6,7 @@ public class Reports
     public void project_with_VersionOverride_without_CPM()
         => new UseVersionOnlyWithoutCpm()
         .ForProject("MisuseVersion.cs")
-        .HasIssue(Issue.WRN("Proj0804", "Do not use Version when CPM is enabled.")
+        .HasIssue(Issue.WRN("Proj0804", "Do not use Version when CPM is enabled")
         .WithSpan(07, 04, 07, 81));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/VersionOverride_should_change_version.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/VersionOverride_should_change_version.cs
@@ -6,7 +6,7 @@ public class Reports
     public void project_with_VersionOverride_without_CPM()
         => new VersionOverrideShouldChangeVersion()
         .ForProject("VersionUpdateNotDifferent.cs")
-        .HasIssue(Issue.WRN("Proj0806", "Remove VersionOverride or change it to a version different than defined by the CPM.")
+        .HasIssue(Issue.WRN("Proj0806", "Remove VersionOverride or change it to a version different than defined by the CPM")
         .WithSpan(08, 04, 08, 65));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_conditions_on_level_1.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_conditions_on_level_1.cs
@@ -6,7 +6,7 @@ public class Reports
     public void conditions_on_other_levels()
         => new DefineConditionsOnLevel1()
         .ForProject("Conditional.cs")
-        .HasIssue(Issue.WRN("Proj0028", "Move the condition to the parent <PropertyGroup>.")
+        .HasIssue(Issue.WRN("Proj0028", "Move the condition to the parent <PropertyGroup>")
         .WithSpan(11, 04, 11, 76));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_global package_reference_only_in_Directory_Packages_props.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_global package_reference_only_in_Directory_Packages_props.cs
@@ -17,7 +17,7 @@ public class Reports
 
 </Project>")
         .HasIssue(
-            Issue.WRN("Proj0808", "The <GlobalPackageReference> should be defined in the Directory.Packages.props.").WithSpan(07, 04, 07, 84));
+            Issue.WRN("Proj0808", "The <GlobalPackageReference> should be defined in the Directory.Packages.props").WithSpan(07, 04, 07, 84));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_is_publishable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_is_publishable.cs
@@ -6,7 +6,7 @@ public class Reports
     public void on_no_is_publishable()
        => new DefineIsPublishable()
        .ForProject("EmptyProject.cs")
-       .HasIssue(Issue.WRN("Proj0400", "Define the <IsPublishable> node explicitly."));
+       .HasIssue(Issue.WRN("Proj0400", "Define the <IsPublishable> node explicitly"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_output_type.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_output_type.cs
@@ -7,7 +7,7 @@ public class Reports
        => new DefineOutputType()
        .ForProject("NoOutputType.cs")
        .HasIssue(
-           Issue.WRN("Proj0010", "Define the <OutputType> node explicitly."));
+           Issue.WRN("Proj0010", "Define the <OutputType> node explicitly"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_package_reference_assets_as_attributes.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_package_reference_assets_as_attributes.cs
@@ -7,8 +7,8 @@ public class Reports
         => new DefinePackageReferenceAssetsAsAttributes()
         .ForProject("PackageReferenceAssetsAsElements.cs")
         .HasIssues(
-            Issue.WRN("Proj0005", "Define package reference assets of 'BackwardsCompatibleFeatures' as attributes.").WithSpan(08, 04, 10, 23),
-            Issue.WRN("Proj0005", "Define package reference assets of 'SonarAnalyzer.CSharp' as attributes." /*..*/).WithSpan(11, 04, 14, 23));
+            Issue.WRN("Proj0005", "Define package reference assets of 'BackwardsCompatibleFeatures' as attributes").WithSpan(08, 04, 10, 23),
+            Issue.WRN("Proj0005", "Define package reference assets of 'SonarAnalyzer.CSharp' as attributes" /*..*/).WithSpan(11, 04, 14, 23));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_package_validation_baseline_version.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_package_validation_baseline_version.cs
@@ -7,7 +7,7 @@ public class Reports
        => new DefinePackageValidationBaselineVersion()
        .ForProject("NoBaselineVersion.cs")
        .HasIssue(
-           Issue.WRN("Proj0241", "Define the <PackageValidationBaselineVersion> node with a previously released stable version."));
+           Issue.WRN("Proj0241", "Define the <PackageValidationBaselineVersion> node with a previously released stable version"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_properties_once.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_properties_once.cs
@@ -7,10 +7,10 @@ public class Reports
         => new DefinePropertiesOnce()
         .ForProject("PropertiesTwice.cs")
         .HasIssues(
-            Issue.WRN("Proj0011", "Property <ImplicitUsings> has been already defined.").WithSpan(/*...*/ 05, 04, 05, 44),
-            Issue.WRN("Proj0011", "Property <TargetFrameworks> has been already defined.").WithSpan(/*.*/ 12, 04, 12, 54),
-            Issue.WRN("Proj0011", "Property <Nullable> has been already defined.").WithSpan(/*.........*/ 13, 04, 13, 36),
-            Issue.WRN("Proj0011", "Property <ProductName> has been already defined.").WithSpan(/*......*/ 22, 04, 22, 66));
+            Issue.WRN("Proj0011", "Property <ImplicitUsings> has been already defined").WithSpan(/*...*/ 05, 04, 05, 44),
+            Issue.WRN("Proj0011", "Property <TargetFrameworks> has been already defined").WithSpan(/*.*/ 12, 04, 12, 54),
+            Issue.WRN("Proj0011", "Property <Nullable> has been already defined").WithSpan(/*.........*/ 13, 04, 13, 36),
+            Issue.WRN("Proj0011", "Property <ProductName> has been already defined").WithSpan(/*......*/ 22, 04, 22, 66));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_single_target_framework.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_single_target_framework.cs
@@ -7,7 +7,7 @@ public class Reports
         => new DefineSingleTargetFramework()
         .ForProject("TargetFrameworksSingle.cs")
         .HasIssues(
-            Issue.WRN("Proj0009", "Use the <TargetFramework> node instead.").WithSpan(3, 4, 3, 47));
+            Issue.WRN("Proj0009", "Use the <TargetFramework> node instead").WithSpan(3, 4, 3, 47));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_usings_explicit.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_usings_explicit.cs
@@ -7,7 +7,7 @@ public class Reports
         => new DefineUsingsExplicit()
         .ForProject("ImplicitUsings.cs")
         .HasIssue(
-            Issue.WRN("Proj0003", "Define usings explicit.").WithSpan(4, 4, 4, 43));
+            Issue.WRN("Proj0003", "Define usings explicit").WithSpan(4, 4, 4, 43));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_version_prefix_if_version_suffix_is_defined.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_version_prefix_if_version_suffix_is_defined.cs
@@ -7,7 +7,7 @@ public class Reports
        => new DefineVersionPrefixIfVersionSuffixIsDefined()
         .ForProject("VersionSuffix.cs")
         .HasIssue(
-           Issue.WRN("Proj0246", "Define the <VersionPrefix> node or remove the <VersionSuffix> node.")
+           Issue.WRN("Proj0246", "Define the <VersionPrefix> node or remove the <VersionSuffix> node")
            .WithSpan(09, 04, 09, 45));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Dont_mix_version_and_version_prefix_or_version_suffix.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Dont_mix_version_and_version_prefix_or_version_suffix.cs
@@ -7,7 +7,7 @@ public class Reports
        => new DontMixVersionAndVersionPrefixOrVersionSuffix()
         .ForProject("VersionPrefixAndVersion.cs")
         .HasIssue(
-           Issue.WRN("Proj0245", "Remove the <Version> node or remove the <VersionPrefix> node.")
+           Issue.WRN("Proj0245", "Remove the <Version> node or remove the <VersionPrefix> node")
            .WithSpan(09, 04, 09, 28));
 
     [Test]
@@ -15,7 +15,7 @@ public class Reports
        => new DontMixVersionAndVersionPrefixOrVersionSuffix()
         .ForProject("VersionSuffixAndVersion.cs")
         .HasIssue(
-           Issue.WRN("Proj0245", "Remove the <Version> node or remove the <VersionSuffix> node.")
+           Issue.WRN("Proj0245", "Remove the <Version> node or remove the <VersionSuffix> node")
            .WithSpan(09, 04, 09, 28));
 
     [Test]
@@ -23,7 +23,7 @@ public class Reports
        => new DontMixVersionAndVersionPrefixOrVersionSuffix()
         .ForProject("VersionPrefixAndSuffixAndVersion.cs")
         .HasIssue(
-           Issue.WRN("Proj0245", "Remove the <Version> node or remove the <VersionPrefix> and <VersionSuffix> nodes.")
+           Issue.WRN("Proj0245", "Remove the <Version> node or remove the <VersionPrefix> and <VersionSuffix> nodes")
            .WithSpan(09, 04, 09, 28));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_attribute_checks.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_attribute_checks.cs
@@ -14,7 +14,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0251", "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 07, 22));
+        .HasIssues(Issue.WRN("Proj0251", "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 07, 22));
 
     [Test]
     public void on_disabled_property() => new EnableApiCompatibilityAttributeChecks()
@@ -29,7 +29,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0251", "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 102));
+        .HasIssues(Issue.WRN("Proj0251", "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(05, 16, 05, 102));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_parameter_name_checks.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_parameter_name_checks.cs
@@ -14,7 +14,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0252", "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 07, 22));
+        .HasIssues(Issue.WRN("Proj0252", "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 07, 22));
 
     [Test]
     public void on_disabled_property() => new EnableApiCompatibilityParameterNameChecks()
@@ -29,7 +29,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0252", "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 114));
+        .HasIssues(Issue.WRN("Proj0252", "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(05, 16, 05, 114));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_package_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_package_validation.cs
@@ -7,14 +7,14 @@ public class Reports
        => new EnablePackageValidation()
        .ForProject("EmptyProject.cs")
        .HasIssue(
-           Issue.WRN("Proj0240", "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'."));
+           Issue.WRN("Proj0240", "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'"));
 
     [Test]
     public void on_disabled()
        => new EnablePackageValidation()
        .ForProject("PackageValidationDisabled.cs")
        .HasIssue(
-           Issue.WRN("Proj0240", "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'."));
+           Issue.WRN("Proj0240", "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_baseline_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_baseline_validation.cs
@@ -16,7 +16,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0247", "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 09, 22));
+        .HasIssues(Issue.WRN("Proj0247", "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 09, 22));
 
     [Test]
     public void on_disabled_property() => new EnableStrictModeForPackageBaselineValidation()
@@ -33,7 +33,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0247", "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(07, 16, 07, 100));
+        .HasIssues(Issue.WRN("Proj0247", "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'").WithSpan(07, 16, 07, 100));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_framework_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_framework_validation.cs
@@ -14,7 +14,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 07, 22));
+        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 07, 22));
 
     [Test]
     public void on_disabled_property() => new EnableStrictModeForPackageFrameworkCompatibilityValidation()
@@ -29,7 +29,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 122));
+        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(05, 16, 05, 122));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_runtime_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_runtime_validation.cs
@@ -15,7 +15,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0248", "Define the <EnableStrictModeForCompatibleTfms> node with value 'true' or remove the <EnableStrictModeForCompatibleTfms> node with value 'false' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 92));
+        .HasIssues(Issue.WRN("Proj0248", "Define the <EnableStrictModeForCompatibleTfms> node with value 'true' or remove the <EnableStrictModeForCompatibleTfms> node with value 'false' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(05, 16, 05, 92));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Exclude_private_asset_dependencies.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Exclude_private_asset_dependencies.cs
@@ -6,8 +6,8 @@ public class Reports
     public void private_assets_not_being_private()=> new ExcludePrivateAssetDependencies()
         .ForProject("PrivateAssets.cs")
         .HasIssues(
-            Issue.WRN("Proj1200", @"Mark the package reference ""coverlet.collector"" as a private asset." /*.*/).WithSpan(16, 04, 16, 069),
-            Issue.WRN("Proj1200", @"Mark the package reference ""NUnit.Analyzers"" as a private asset." /*....*/).WithSpan(17, 04, 17, 147));
+            Issue.WRN("Proj1200", @"Mark the package reference ""coverlet.collector"" as a private asset" /*.*/).WithSpan(16, 04, 16, 069),
+            Issue.WRN("Proj1200", @"Mark the package reference ""NUnit.Analyzers"" as a private asset" /*....*/).WithSpan(17, 04, 17, 147));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_SBOM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_SBOM.cs
@@ -5,20 +5,20 @@ public class Reports
     [Test]
     public void on_missing_property() => new GenerateSbom()
         .ForProject("PackageWithoutSBOM.cs")
-        .HasIssue(Issue.WRN("Proj0243", "Enable SBOM generation with <GenerateSBOM> is 'true' or define the <IsPackable> node with value 'false'.")
+        .HasIssue(Issue.WRN("Proj0243", "Enable SBOM generation with <GenerateSBOM> is 'true' or define the <IsPackable> node with value 'false'")
         .WithSpan(00, 00, 11, 10));
 
 
     [Test]
     public void on_disabled_property() => new GenerateSbom()
         .ForProject("PackageWithSBOMDisabled.cs")
-        .HasIssue(Issue.WRN("Proj0243", "Enable SBOM generation with <GenerateSBOM> is 'true' or define the <IsPackable> node with value 'false'.")
+        .HasIssue(Issue.WRN("Proj0243", "Enable SBOM generation with <GenerateSBOM> is 'true' or define the <IsPackable> node with value 'false'")
         .WithSpan(05, 04, 05, 38));
 
     [Test]
     public void on_missing_reference() => new GenerateSbom()
         .ForProject("PackageWithoutSBOMReference.cs")
-        .HasIssue(Issue.WRN("Proj0243", "Register the NuGet package 'Microsoft.Sbom.Targets' or define the <IsPackable> node with value 'false'.")
+        .HasIssue(Issue.WRN("Proj0243", "Register the NuGet package 'Microsoft.Sbom.Targets' or define the <IsPackable> node with value 'false'")
         .WithSpan(05, 04, 05, 37));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_api_compatibility_suppression_file.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_api_compatibility_suppression_file.cs
@@ -14,7 +14,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0250", "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(00, 00, 07, 22));
+        .HasIssues(Issue.WRN("Proj0250", "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 07, 22));
 
     [Test]
     public void on_disabled_property() => new GenerateApiCompatibilitySuppressionFile()
@@ -29,7 +29,7 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0250", "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.").WithSpan(05, 16, 05, 90));
+        .HasIssues(Issue.WRN("Proj0250", "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(05, 16, 05, 90));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_documentation_file.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_documentation_file.cs
@@ -5,26 +5,26 @@ public class Reports
     [Test]
     public void on_missing_property() => new EnableGenerateDocumentationFile()
         .ForProject("GenerateDocumentationFileMissing.cs")
-        .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'.")
+        .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'")
         .WithSpan(00, 00, 07, 10));
 
 
     [Test]
     public void on_disabled_property() => new EnableGenerateDocumentationFile()
         .ForProject("GenerateDocumentationFileDisabledWithoutFile.cs")
-        .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'.")
+        .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'")
         .WithSpan(05, 04, 05, 64));
 
     [Test]
     public void on_disabled_property_with_file_path() => new EnableGenerateDocumentationFile()
         .ForProject("GenerateDocumentationFileDisabledWithFile.cs")
-        .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'.")
+        .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'")
         .WithSpan(05, 04, 05, 64));
 
     [Test]
     public void on_missing_property_with_empty_file_path() => new EnableGenerateDocumentationFile()
     .ForProject("GenerateDocumentationFileMissingWithEmptyFile.cs")
-    .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'.")
+    .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'")
     .WithSpan(05, 04, 05, 43));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_on_build_conditionally.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_on_build_conditionally.cs
@@ -7,7 +7,7 @@ public class Reports
        => new GeneratePackageOnBuildConditionally()
        .ForProject("GeneratePackageOnBuildUnconditionally.cs")
        .HasIssue(
-           Issue.WRN("Proj0242", "Add a condition to <GeneratePackageOnBuild>.").WithSpan(4, 4, 4, 57));
+           Issue.WRN("Proj0242", "Add a condition to <GeneratePackageOnBuild>").WithSpan(4, 4, 4, 57));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Global_package_references_are_meant_fo_private_assets_only.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Global_package_references_are_meant_fo_private_assets_only.cs
@@ -7,7 +7,7 @@ public class Reports
         => new GlobalPackageReferencesAreMeantForPrivateAssetsOnly()
         .ForProject("GlobalPackageReferenceRuntimeDependency.cs")
         .HasIssues(
-            Issue.WRN("Proj0809", @"The global package reference 'Qowaiv' is not supposed to be a private asset.")
+            Issue.WRN("Proj0809", @"The global package reference 'Qowaiv' is not supposed to be a private asset")
                 .WithSpan(07, 04, 07, 63)
                 .WithPath("Directory.Packages.props"));
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_package_references_once.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_package_references_once.cs
@@ -7,9 +7,9 @@ public class Reports
        => new IncludePackageReferencesOnce()
        .ForProject("DoublePackageReferences.cs")
        .HasIssues(
-            Issue.WRN("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(04, 04, 04, 57).WithPath("DoublePackageReferences.props"),
-            Issue.WRN("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(10, 04, 10, 57).WithPath("DoublePackageReferences.csproj"),
-            Issue.WRN("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(11, 04, 11, 57).WithPath("DoublePackageReferences.csproj"));
+            Issue.WRN("Proj0013", "Package 'Qowaiv' is already referenced").WithSpan(04, 04, 04, 57).WithPath("DoublePackageReferences.props"),
+            Issue.WRN("Proj0013", "Package 'Qowaiv' is already referenced").WithSpan(10, 04, 10, 57).WithPath("DoublePackageReferences.csproj"),
+            Issue.WRN("Proj0013", "Package 'Qowaiv' is already referenced").WithSpan(11, 04, 11, 57).WithPath("DoublePackageReferences.csproj"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_project_references_once.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_project_references_once.cs
@@ -7,7 +7,7 @@ public class Reports
        => new IncludeProjectReferencesOnce()
        .ForProject("DoubleProjectReferences.cs")
        .HasIssues(
-            Issue.WRN("Proj0014", @"Project './../../projects/EmptyNodes/EmptyNodes.csproj' is already referenced.").WithSpan(11, 04, 11, 80));
+            Issue.WRN("Proj0014", @"Project './../../projects/EmptyNodes/EmptyNodes.csproj' is already referenced").WithSpan(11, 04, 11, 80));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Indent_XML.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Indent_XML.cs
@@ -7,11 +7,11 @@ public class Reports
         => new IndentXml()
         .ForProject("FaultyIndenting.cs")
         .HasIssues(
-            Issue.WRN("Proj1700", "The element <PropertyGroup> has not been properly indented." /*...*/).WithSpan(04, 04, 04, 18),
-            Issue.WRN("Proj1700", "The element <TargetFramework> has not been properly indented." /*.*/).WithSpan(05, 02, 05, 18),
-            Issue.WRN("Proj1700", "The element </PropertyGroup> has not been properly indented." /*..*/).WithSpan(06, 05, 06, 21),
-            Issue.WRN("Proj1700", "The element <Compile> has not been properly indented." /*.........*/).WithSpan(09, 04, 09, 43),
-            Issue.WRN("Proj1700", "The element <Folder> has not been properly indented." /*..........*/).WithSpan(12, 13, 12, 21));
+            Issue.WRN("Proj1700", "The element <PropertyGroup> has not been properly indented" /*...*/).WithSpan(04, 04, 04, 18),
+            Issue.WRN("Proj1700", "The element <TargetFramework> has not been properly indented" /*.*/).WithSpan(05, 02, 05, 18),
+            Issue.WRN("Proj1700", "The element </PropertyGroup> has not been properly indented" /*..*/).WithSpan(06, 05, 06, 21),
+            Issue.WRN("Proj1700", "The element <Compile> has not been properly indented" /*.........*/).WithSpan(09, 04, 09, 43),
+            Issue.WRN("Proj1700", "The element <Folder> has not been properly indented" /*..........*/).WithSpan(12, 13, 12, 21));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Item_group_should_only_contain_nodes_of_single_type.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Item_group_should_only_contain_nodes_of_single_type.cs
@@ -7,7 +7,7 @@ public class Reports
        => new ItemGroupShouldBeUniform()
        .ForProject("MixedItemGroup.cs")
        .HasIssue(
-           Issue.WRN("Proj0020", @"<ItemGroup> should only contain nodes of a single type.").WithSpan(6, 2, 9, 14));
+           Issue.WRN("Proj0020", @"<ItemGroup> should only contain nodes of a single type").WithSpan(6, 2, 9, 14));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Migrate_away_from_BinaryFormatter.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Migrate_away_from_BinaryFormatter.cs
@@ -5,7 +5,7 @@ public class Reports
     [Test]
     public void when_BinaryFormatter_is_enabled() => new MigrateAwayFromBinaryFormatter()
         .ForProject("BinaryFormattingEnabled.cs")
-        .HasIssue(Issue.WRN("Proj0032", "Migrate away from BinaryFormatter and do not enable <EnableUnsafeBinaryFormatterSerialization>.")
+        .HasIssue(Issue.WRN("Proj0032", "Migrate away from BinaryFormatter and do not enable <EnableUnsafeBinaryFormatterSerialization>")
             .WithSpan(04, 04, 04, 93));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Migrate_from_Ruleset_to_EditorConfig_file.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Migrate_from_Ruleset_to_EditorConfig_file.cs
@@ -6,7 +6,7 @@ public class Reports
     public void private_assets_not_being_private()
          => new MigrateFromRulesetToEditorConfigFile()
          .ForProject("WithRuleset.cs")
-         .HasIssue(Issue.WRN("Proj0025", @"Migrate ruleset 'MyPreferences.ruleset' to an .editorconfig file.")
+         .HasIssue(Issue.WRN("Proj0025", @"Migrate ruleset 'MyPreferences.ruleset' to an .editorconfig file")
          .WithSpan(04, 04, 04, 68));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Avoid_license_url.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Avoid_license_url.cs
@@ -7,7 +7,7 @@ public class Reports
        => new AvoidLicenseUrl()
        .ForProject("WithLicenseUrl.cs")
        .HasIssue(
-            Issue.WRN("Proj0211", "Replace deprecated <PackageLicenseUrl> with <PackageLicenseExpression> or <PackageLicenseFile> node.")
+            Issue.WRN("Proj0211", "Replace deprecated <PackageLicenseUrl> with <PackageLicenseExpression> or <PackageLicenseFile> node")
                 .WithSpan(30, 4, 30, 101));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Define_is_packable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Define_is_packable.cs
@@ -7,7 +7,7 @@ public class Reports
        => new DefineIsPackable()
        .ForProject("NoIsPackable.cs")
        .HasIssue(
-           Issue.WRN("Proj0200", "Define the <IsPackable> node explicitly."));
+           Issue.WRN("Proj0200", "Define the <IsPackable> node explicitly"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Define_package_info.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Define_package_info.cs
@@ -7,118 +7,118 @@ public class Reports_on_missing
        => new DefinePackageInfo()
        .ForProject("NoPackageInfo.cs")
        .HasIssues(
-           Issue.WRN("Proj0201", "Define the <Version> or <VersionPrefix> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0202", "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0203", "Define the <Authors> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0204", "Define the <PackageTags> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0205", "Define the <RepositoryUrl> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0206", "Define the <PackageProjectUrl> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0207", "Define the <Copyright> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0208", "Define the <PackageReleaseNotes> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0209", "Define the <PackageReadmeFile> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0210", "Define the <PackageLicenseExpression> or <PackageLicenseFile> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0212", "Define the <PackageIcon> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0213", "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0214", "Define the <PackageId> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0216", "Define the <ProductName> node explicitly or define the <IsPackable> node with value 'false'."),
-           Issue.WRN("Proj0217", "Define the <PackageRequireLicenseAcceptance> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0201", "Define the <Version> or <VersionPrefix> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0202", "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0203", "Define the <Authors> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0204", "Define the <PackageTags> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0205", "Define the <RepositoryUrl> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0206", "Define the <PackageProjectUrl> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0207", "Define the <Copyright> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0208", "Define the <PackageReleaseNotes> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0209", "Define the <PackageReadmeFile> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0210", "Define the <PackageLicenseExpression> or <PackageLicenseFile> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0212", "Define the <PackageIcon> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0213", "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0214", "Define the <PackageId> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0216", "Define the <ProductName> node explicitly or define the <IsPackable> node with value 'false'"),
+           Issue.WRN("Proj0217", "Define the <PackageRequireLicenseAcceptance> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void version()
        => new DefinePackageInfo()
        .ForProject("NoVersion.cs")
        .HasIssue(
-           Issue.WRN("Proj0201", "Define the <Version> or <VersionPrefix> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0201", "Define the <Version> or <VersionPrefix> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void description()
        => new DefinePackageInfo()
        .ForProject("NoDescription.cs")
        .HasIssue(
-           Issue.WRN("Proj0202", "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0202", "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void authors()
        => new DefinePackageInfo()
        .ForProject("NoAuthors.cs")
        .HasIssue(
-           Issue.WRN("Proj0203", "Define the <Authors> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0203", "Define the <Authors> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void tags()
        => new DefinePackageInfo()
        .ForProject("NoTags.cs")
        .HasIssue(
-           Issue.WRN("Proj0204", "Define the <PackageTags> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0204", "Define the <PackageTags> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void repository_url()
        => new DefinePackageInfo()
        .ForProject("NoRepositoryUrl.cs")
        .HasIssue(
-           Issue.WRN("Proj0205", "Define the <RepositoryUrl> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0205", "Define the <RepositoryUrl> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void url()
        => new DefinePackageInfo()
        .ForProject("NoUrl.cs")
        .HasIssue(
-           Issue.WRN("Proj0206", "Define the <PackageProjectUrl> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0206", "Define the <PackageProjectUrl> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void copyright()
        => new DefinePackageInfo()
        .ForProject("NoCopyright.cs")
        .HasIssue(
-           Issue.WRN("Proj0207", "Define the <Copyright> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0207", "Define the <Copyright> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void release_notes()
        => new DefinePackageInfo()
        .ForProject("NoReleaseNotes.cs")
        .HasIssue(
-           Issue.WRN("Proj0208", "Define the <PackageReleaseNotes> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0208", "Define the <PackageReleaseNotes> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void readme()
        => new DefinePackageInfo()
        .ForProject("NoReadme.cs")
        .HasIssue(
-           Issue.WRN("Proj0209", "Define the <PackageReadmeFile> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0209", "Define the <PackageReadmeFile> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void license()
        => new DefinePackageInfo()
        .ForProject("NoLicense.cs")
        .HasIssue(
-           Issue.WRN("Proj0210", "Define the <PackageLicenseExpression> or <PackageLicenseFile> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0210", "Define the <PackageLicenseExpression> or <PackageLicenseFile> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void icon()
        => new DefinePackageInfo()
        .ForProject("NoIcon.cs")
        .HasIssue(
-           Issue.WRN("Proj0212", "Define the <PackageIcon> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0212", "Define the <PackageIcon> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void icon_url()
        => new DefinePackageInfo()
        .ForProject("NoIconUrl.cs")
        .HasIssue(
-           Issue.WRN("Proj0213", "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'."));
+           Issue.WRN("Proj0213", "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void product_name()
       => new DefinePackageInfo()
       .ForProject("NoProductName.cs")
       .HasIssue(
-          Issue.WRN("Proj0216", "Define the <ProductName> node explicitly or define the <IsPackable> node with value 'false'."));
+          Issue.WRN("Proj0216", "Define the <ProductName> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
     public void missing_require_package_license_acceptance()
       => new DefinePackageInfo()
         .ForProject(@"NoPackageRequireLicenseAcceptance.cs")
-        .HasIssue(Issue.WRN("Proj0217", "Define the <PackageRequireLicenseAcceptance> node explicitly or define the <IsPackable> node with value 'false'."));
+        .HasIssue(Issue.WRN("Proj0217", "Define the <PackageRequireLicenseAcceptance> node explicitly or define the <IsPackable> node with value 'false'"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Package_icon.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Package_icon.cs
@@ -7,14 +7,14 @@ public class Reports
         => new ProvideCompliantPackageIcon()
         .ForProject("BmpIcon.cs")
         .HasIssues(
-            Issue.WRN("Proj0215", "The package icon 'big-icon.bmp' is recommended to be a PNG.").WithSpan(07, 04, 07, 43),
-            Issue.WRN("Proj0215", "The package icon 'big-icon.bmp' must be less then 1MB."/*.*/).WithSpan(07, 04, 07, 43));
+            Issue.WRN("Proj0215", "The package icon 'big-icon.bmp' is recommended to be a PNG").WithSpan(07, 04, 07, 43),
+            Issue.WRN("Proj0215", "The package icon 'big-icon.bmp' must be less then 1MB"/*.*/).WithSpan(07, 04, 07, 43));
 
     [Test]
     public void Different_dimensions()
        => new ProvideCompliantPackageIcon()
        .ForProject("BigIcon.cs")
-       .HasIssue(Issue.WRN("Proj0215", "The package icon 'logo_400x400.png' is recommended to be 128x128 not 400x400.")
+       .HasIssue(Issue.WRN("Proj0215", "The package icon 'logo_400x400.png' is recommended to be 128x128 not 400x400")
        .WithSpan(07, 04, 07, 47));
 }
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Ommit_XML_declaration.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Ommit_XML_declaration.cs
@@ -5,7 +5,7 @@ public class Reports
     [Test]
     public void on_double_imports() => new OmitXmlDeclarations()
        .ForProject("XmlDeclaration.cs")
-       .HasIssue(Issue.WRN("Proj1702", "Remove the XML declaration as it is redundant.")
+       .HasIssue(Issue.WRN("Proj1702", "Remove the XML declaration as it is redundant")
        .WithSpan(01, 00, 01, 32));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_package_references_in_alphabetical_order.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_package_references_in_alphabetical_order.cs
@@ -7,7 +7,7 @@ public class Reports
        => new OrderPackageReferencesAlphabetically()
        .ForProject("NonAlphabeticalPackageReferences.cs")
        .HasIssue(
-           Issue.WRN("Proj0015", "Package 'Qowaiv.Analyzers.CSharp' is not ordered alphabetically and should appear before 'StyleCop.Analyzers'.").WithSpan(9, 04, 9, 74));
+           Issue.WRN("Proj0015", "Package 'Qowaiv.Analyzers.CSharp' is not ordered alphabetically and should appear before 'StyleCop.Analyzers'").WithSpan(9, 04, 9, 74));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_package_versions_in_alphabetical_order.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_package_versions_in_alphabetical_order.cs
@@ -7,7 +7,7 @@ public class Reports
        => new OrderPackageVersionsAlphabetically()
        .ForProject("NonAlphabeticalPackageVersions.cs")
        .HasIssue(
-           Issue.WRN("Proj0024", "Package version for 'Qowaiv.Analyzers.CSharp' is not ordered alphabetically and should appear before 'StyleCop.Analyzers'.").WithSpan(9, 4, 9, 72));
+           Issue.WRN("Proj0024", "Package version for 'Qowaiv.Analyzers.CSharp' is not ordered alphabetically and should appear before 'StyleCop.Analyzers'").WithSpan(9, 4, 9, 72));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_project_references_in_alphabetical_order.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_project_references_in_alphabetical_order.cs
@@ -7,7 +7,7 @@ public class Reports
        => new OrderProjectReferencesAlphabetically()
        .ForProject("NonAlphabeticalProjectReferences.cs")
        .HasIssue(
-           Issue.WRN("Proj0016", @"Project '../EmptyNodes/EmptyNodes.csproj' is not ordered alphabetically and should appear before '../FolderNodes/FolderNodes.csproj'.").WithSpan(8, 04, 8, 66));
+           Issue.WRN("Proj0016", @"Project '../EmptyNodes/EmptyNodes.csproj' is not ordered alphabetically and should appear before '../FolderNodes/FolderNodes.csproj'").WithSpan(8, 04, 8, 66));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_using_directives_by_type.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_using_directives_by_type.cs
@@ -8,7 +8,7 @@ public class Reports
        .ForProject("IncorrectlyOrderedUsingDirectives.cs")
        .HasIssues(
            Issue.ERR("CS8085", @"A 'using static' directive cannot be used to declare an alias" /*............................................................*/).WithSpan(05, 20, 05, 23),
-           Issue.WRN("Proj0018", @"Using Static directive for 'NamespaceB.Placeholder' should appear before Using Alias directive for 'NamespaceA.Placeholder'.").WithSpan(10, 04, 10, 60));
+           Issue.WRN("Proj0018", @"Using Static directive for 'NamespaceB.Placeholder' should appear before Using Alias directive for 'NamespaceA.Placeholder'").WithSpan(10, 04, 10, 60));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_using_directives_in_alphabetical_order.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Order_using_directives_in_alphabetical_order.cs
@@ -8,7 +8,7 @@ public class Reports
        .ForProject("IncorrectlyOrderedUsingDirectives.cs")
        .HasIssues(
            Issue.ERR("CS8085", @"A 'using static' directive cannot be used to declare an alias" /*.................................*/).WithSpan(5, 20, 5, 23),
-           Issue.WRN("Proj0019", @"Using directive 'NamespaceA' is not ordered alphabetically and should appear before 'NamespaceB'.").WithSpan(9, 04, 9, 34));
+           Issue.WRN("Proj0019", @"Using directive 'NamespaceA' is not ordered alphabetically and should appear before 'NamespaceB'").WithSpan(9, 04, 9, 34));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Package_references_should_be_stable.cs
@@ -7,16 +7,16 @@ public class Reports
         => new PackageReferencesShouldBeStable()
         .ForProject("UnstablePackageReferences.cs")
         .HasIssues(
-            Issue.WRN("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'.").WithSpan(08, 04, 08, 86).WithPath("UnstablePackageReferences.csproj"),
-            Issue.WRN("Proj1101", "Use a stable version of 'System.Text.Json', instead of '*-*'." /*.................*/).WithSpan(09, 04, 09, 65).WithPath("UnstablePackageReferences.csproj"));
+            Issue.WRN("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-preview.7.24405.7'").WithSpan(08, 04, 08, 86).WithPath("UnstablePackageReferences.csproj"),
+            Issue.WRN("Proj1101", "Use a stable version of 'System.Text.Json', instead of '*-*'" /*.................*/).WithSpan(09, 04, 09, 65).WithPath("UnstablePackageReferences.csproj"));
 
     [Test]
     public void unstable_versions_via_CPM()
         => new PackageReferencesShouldBeStable()
         .ForProject("UnstableVersionsCPM.cs")
         .HasIssues(
-            Issue.WRN("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-rc.2.24473.5'.").WithSpan(09, 04, 09, 88).WithPath("UnstableVersionsCPM.csproj"),
-            Issue.WRN("Proj1101", "Use a stable version of 'Warpstone', instead of '2.0.0-preview2'.").WithSpan(10, 04, 10, 67).WithPath("Directory.Packages.props"));
+            Issue.WRN("Proj1101", "Use a stable version of 'System.IO.Hashing', instead of '9.0.0-rc.2.24473.5'").WithSpan(09, 04, 09, 88).WithPath("UnstableVersionsCPM.csproj"),
+            Issue.WRN("Proj1101", "Use a stable version of 'Warpstone', instead of '2.0.0-preview2'").WithSpan(10, 04, 10, 67).WithPath("Directory.Packages.props"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Project_reference_include_should_exist.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Project_reference_include_should_exist.cs
@@ -6,7 +6,7 @@ public class Reports
     public void empty_includes()
         => new ProjectReferenceIncludeShouldExist()
         .ForProject("ProjectReferenceMissingInclude.cs")
-        .HasIssue(Issue.WRN("Proj0033", "The Include './foo.csproj' of <ProjectReference> does not exist.").WithSpan(08, 04, 08, 47));
+        .HasIssue(Issue.WRN("Proj0033", "The Include './foo.csproj' of <ProjectReference> does not exist").WithSpan(08, 04, 08, 47));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Reassign_properties_with_different_value.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Reassign_properties_with_different_value.cs
@@ -7,9 +7,9 @@ public class Reports
        => new ReassignPropertiesWithDifferentValue()
        .ForProject("ReassignProperties.cs")
        .HasIssues(
-            Issue.WRN("Proj0012", "Property <OutputType> has been previously defined with the same value." /*.*/).WithSpan(05, 04, 05, 36),
-            Issue.WRN("Proj0012", "Property <Nullable> has been previously defined with the same value." /*...*/).WithSpan(06, 04, 06, 31),
-            Issue.WRN("Proj0012", "Property <OutputType> has been previously defined with the same value." /*.*/).WithSpan(07, 04, 07, 36));
+            Issue.WRN("Proj0012", "Property <OutputType> has been previously defined with the same value" /*.*/).WithSpan(05, 04, 05, 36),
+            Issue.WRN("Proj0012", "Property <Nullable> has been previously defined with the same value" /*...*/).WithSpan(06, 04, 06, 31),
+            Issue.WRN("Proj0012", "Property <OutputType> has been previously defined with the same value" /*.*/).WithSpan(07, 04, 07, 36));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Remove_IncludeAssets_when_redundant.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Remove_IncludeAssets_when_redundant.cs
@@ -7,8 +7,8 @@ public class Reports
        => new RemoveIncludeAssetsWhenRedundant()
        .ForProject("IncludeAssets.cs")
        .HasIssues(
-           Issue.WRN("Proj0026", "Remove <IncludeAssets> as it is redundant when all assets are private." /*.*/).WithSpan(20, 04, 23, 23),
-           Issue.WRN("Proj0026", "Remove IncludeAssets as it is redundant when all assets are private." /*...*/).WithSpan(24, 04, 24, 163));
+           Issue.WRN("Proj0026", "Remove <IncludeAssets> as it is redundant when all assets are private" /*.*/).WithSpan(20, 04, 23, 23),
+           Issue.WRN("Proj0026", "Remove IncludeAssets as it is redundant when all assets are private" /*...*/).WithSpan(24, 04, 24, 163));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Remove_empty_nodes.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Remove_empty_nodes.cs
@@ -7,13 +7,13 @@ public class Reports
         => new RemoveEmptyNodes()
         .ForProject("EmptyNodes.cs")
         .HasIssues(
-            Issue.WRN("Proj0007", "Remove empty PropertyGroup node." /*.*/).WithSpan(10, 2, 10, 33),
-            Issue.WRN("Proj0007", "Remove empty PropertyGroup node." /*.*/).WithSpan(12, 2, 12, 19),
-            Issue.WRN("Proj0007", "Remove empty PropertyGroup node." /*.*/).WithSpan(14, 2, 14, 33),
-            Issue.WRN("Proj0007", "Remove empty PropertyGroup node." /*.*/).WithSpan(16, 2, 19, 18),
-            Issue.WRN("Proj0007", "Remove empty ItemGroup node." /*.....*/).WithSpan(21, 2, 21, 15),
-            Issue.WRN("Proj0007", "Remove empty ItemGroup node."  /*....*/).WithSpan(23, 2, 24, 14),
-            Issue.WRN("Proj0007", "Remove empty ImportGroup node." /*...*/).WithSpan(30, 2, 30, 17));
+            Issue.WRN("Proj0007", "Remove empty PropertyGroup node" /*.*/).WithSpan(10, 2, 10, 33),
+            Issue.WRN("Proj0007", "Remove empty PropertyGroup node" /*.*/).WithSpan(12, 2, 12, 19),
+            Issue.WRN("Proj0007", "Remove empty PropertyGroup node" /*.*/).WithSpan(14, 2, 14, 33),
+            Issue.WRN("Proj0007", "Remove empty PropertyGroup node" /*.*/).WithSpan(16, 2, 19, 18),
+            Issue.WRN("Proj0007", "Remove empty ItemGroup node" /*.....*/).WithSpan(21, 2, 21, 15),
+            Issue.WRN("Proj0007", "Remove empty ItemGroup node" /*.....*/).WithSpan(23, 2, 24, 14),
+            Issue.WRN("Proj0007", "Remove empty ImportGroup node" /*...*/).WithSpan(30, 2, 30, 17));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Remove_folder_nodes.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Remove_folder_nodes.cs
@@ -7,8 +7,8 @@ public class Reports
         => new RemoveFolderNodes()
         .ForProject("FolderNodes.cs")
         .HasIssues(
-            Issue.WRN("Proj0008", "Remove folder node 'SomeFolder'." /*..*/).WithSpan(08, 4, 08, 36),
-            Issue.WRN("Proj0008", "Remove folder node 'OtherFolder'." /*.*/).WithSpan(12, 4, 12, 37));
+            Issue.WRN("Proj0008", "Remove folder node 'SomeFolder'" /*..*/).WithSpan(08, 4, 08, 36),
+            Issue.WRN("Proj0008", "Remove folder node 'OtherFolder'" /*.*/).WithSpan(12, 4, 12, 37));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Run_NuGet_security_audits_automatically.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Run_NuGet_security_audits_automatically.cs
@@ -6,8 +6,7 @@ public class Reports
     public void on_disabled_NuGet_audit()
        => new RunNuGetSecurityAuditsAutomatically()
        .ForProject("DisabledNugetAudit.cs")
-       .HasIssue(
-           Issue.WRN("Proj0004", "Run NuGet security audits automatically."));
+       .HasIssue(Issue.WRN("Proj0004", "Run NuGet security audits automatically"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Static_alias_using_not_supported.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Static_alias_using_not_supported.cs
@@ -8,7 +8,7 @@ public class Reports
        .ForProject("IncorrectlyOrderedUsingDirectives.cs")
        .HasIssues(
            Issue.ERR("CS8085", @"A 'using static' directive cannot be used to declare an alias" /*.................*/).WithSpan(05, 20, 05, 23),
-           Issue.WRN("Proj0017", @"Using directive for 'NamespaceB.Placeholder' can not be both an alias and static.").WithSpan(11, 04, 11, 72));
+           Issue.WRN("Proj0017", @"Using directive for 'NamespaceB.Placeholder' can not be both an alias and static").WithSpan(11, 04, 11, 72));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
@@ -6,14 +6,14 @@ public class Reports
     public void publishable_test_project()
         => new TestProjectsRequireSdk()
         .ForProject("TestProjectWithoutSdk.cs")
-        .HasIssue(Issue.WRN("Proj0452", @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />.")
+        .HasIssue(Issue.WRN("Proj0452", @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />")
         .WithSpan(00, 00, 11, 10));
 
     [Test]
     public void SDK_without_test_project()
         => new TestProjectsRequireSdk()
         .ForProject("TestSdkOnly.cs")
-        .HasIssue(Issue.WRN("Proj0453", "Set <IsTestProject> to true.")
+        .HasIssue(Issue.WRN("Proj0453", "Set <IsTestProject> to true")
         .WithSpan(00, 00, 14, 10));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_packable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_packable.cs
@@ -6,14 +6,14 @@ public class Reports
     public void packable_test_project()
         => new TestProjectShouldNotBePackable()
         .ForProject("PackablePublishableTestProject.cs")
-        .HasIssue(Issue.WRN("Proj0450", "Set <IsPackable> to false.")
+        .HasIssue(Issue.WRN("Proj0450", "Set <IsPackable> to false")
         .WithSpan(05, 04, 05, 33));
 
     [Test]
     public void implicit_packable_test_project()
         => new TestProjectShouldNotBePackable()
         .ForProject("ImplicitPackablePublishableTestProject.cs")
-        .HasIssue(Issue.WRN("Proj0450", "Set <IsPackable> to false.")
+        .HasIssue(Issue.WRN("Proj0450", "Set <IsPackable> to false")
         .WithSpan(00, 00, 15, 10));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_publishable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_publishable.cs
@@ -6,14 +6,14 @@ public class Reports
     public void publishable_test_project()
         => new TestProjectShouldNotBePublishable()
         .ForProject("PackablePublishableTestProject.cs")
-        .HasIssue(Issue.WRN("Proj0451", "Set <IsPublishable> to false.")
+        .HasIssue(Issue.WRN("Proj0451", "Set <IsPublishable> to false")
         .WithSpan(06, 04, 06, 39));
 
     [Test]
     public void implicit_publishable_test_project()
         => new TestProjectShouldNotBePublishable()
         .ForProject("ImplicitPackablePublishableTestProject.cs")
-        .HasIssue(Issue.WRN("Proj0451", "Set <IsPublishable> to false.")
+        .HasIssue(Issue.WRN("Proj0451", "Set <IsPublishable> to false")
         .WithSpan(00, 00, 15, 10));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Thrid_Party_license_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Thrid_Party_license_compliance.cs
@@ -19,7 +19,7 @@ public class Reports
   </ItemGroup>
 
 </Project>")
-       .HasIssue(Issue.WRN("Proj0500", "The Microsoft.DotNet.PlatformAbstractions package is shipped without an explicitly defined license."));
+       .HasIssue(Issue.WRN("Proj0500", "The Microsoft.DotNet.PlatformAbstractions package is shipped without an explicitly defined license"));
 
     [Test]
     public void on_packages_with_deprecated_URL_in_nuspec() => new ThirdPartyLicenseResolver()
@@ -35,9 +35,9 @@ public class Reports
   </ItemGroup>
 
 </Project>")
-       .HasIssue(Issue.WRN("Proj0501", "The SimpleInjector.Extensions.ExecutionContextScoping package only contains a deprecated license URL."));
+       .HasIssue(Issue.WRN("Proj0501", "The SimpleInjector.Extensions.ExecutionContextScoping package only contains a deprecated license URL"));
 
-    [Test, Ignore("PackageLicenseExpression is not resolvable due to a test issue.")]
+    [Test, Ignore("PackageLicenseExpression is not resolvable due to a test issue")]
     public void on_package_with_license_incompatable_to_project() => new ThirdPartyLicenseResolver()
        .ForInlineCsproj(@"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -52,7 +52,7 @@ public class Reports
   </ItemGroup>
 
 </Project>")
-       .HasIssue(Issue.WRN("Proj0502", "The SeeSharpTools.JY.GUI package is distributed as GPL-3.0-only, which is imcompatable with the MIT license of the project."));
+       .HasIssue(Issue.WRN("Proj0502", "The SeeSharpTools.JY.GUI package is distributed as GPL-3.0-only, which is imcompatable with the MIT license of the project"));
 
     [Ignore("Rule 0504 has not been implemented yet")]
     [Test]
@@ -69,7 +69,7 @@ public class Reports
   </ItemGroup>
 
 </Project>")
-       .HasIssue(Issue.WRN("Proj0504", "FluentAssertions package is distributed under a custom license, which has not been explicitly accepted."));
+       .HasIssue(Issue.WRN("Proj0504", "FluentAssertions package is distributed under a custom license, which has not been explicitly accepted"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Track_TODO_tags.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Track_TODO_tags.cs
@@ -6,17 +6,17 @@ public class Reports
     public void TODOs_and_FIXMEs_in_MS_BUILD() => new DotNetProjectFile.Analyzers.MsBuild.TrackToDoTags()
         .ForProject("ToDo.cs")
         .HasIssues(
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""Fixme"" comment.").WithSpan(08, 54, 10, 02).WithPath("ToDo.csproj"),
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""FIX ME"" comment.").WithSpan(12, 06, 14, 02).WithPath("ToDo.csproj"),
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment.").WithSpan(06, 06, 06, 34).WithPath("ToDo.csproj"),
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""to-do"" comment.").WithSpan(16, 56, 18, 02).WithPath("ToDo.csproj"));
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""Fixme"" comment").WithSpan(08, 54, 10, 02).WithPath("ToDo.csproj"),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""FIX ME"" comment").WithSpan(12, 06, 14, 02).WithPath("ToDo.csproj"),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment").WithSpan(06, 06, 06, 34).WithPath("ToDo.csproj"),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""to-do"" comment").WithSpan(16, 56, 18, 02).WithPath("ToDo.csproj"));
 
     [Test]
     public void TODOs_and_FIXMEs_in_RESX() => new DotNetProjectFile.Analyzers.Resx.TrackToDoTags()
         .ForProject("ToDo.cs")
         .HasIssues(
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment.").WithSpan(14, 06, 14, 36).WithPath("Resources.resx"),
-            Issue.WRN("Proj3001", @"Complete the task associated to this ""TO-DOs"" comment.").WithSpan(20, 09, 20, 52).WithPath("Resources.resx"));
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TODO"" comment").WithSpan(14, 06, 14, 36).WithPath("Resources.resx"),
+            Issue.WRN("Proj3001", @"Complete the task associated to this ""TO-DOs"" comment").WithSpan(20, 09, 20, 52).WithPath("Resources.resx"));
 }
 
 public class Has_no_issues

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Unresolvable_Import.cs
@@ -5,12 +5,12 @@ public class Reports
     [Test]
     public void empty_includes() => new UnresolvableImport()
     .ForProject("UnresolvableImport.cs")
-        .HasIssue(Issue.WRN("Proj0034", "The <Import> '$(MSBuildThisFileDirectory)common.props' could not be resolved by the analyzer.").WithSpan(02, 02, 02, 62));
+        .HasIssue(Issue.WRN("Proj0034", "The <Import> '$(MSBuildThisFileDirectory)common.props' could not be resolved by the analyzer").WithSpan(02, 02, 02, 62));
 
     [Test]
     public void on_rule_that_is_not_affected() => new TrackToDoTags()
     .ForProject("UnresolvableImport.cs")
-        .HasIssue(Issue.WRN("Proj3001", "Complete the task associated to this \"TODO\" comment."));
+        .HasIssue(Issue.WRN("Proj3001", "Complete the task associated to this \"TODO\" comment"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Update_legacy_project.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Update_legacy_project.cs
@@ -17,6 +17,6 @@ public class Reports
     public void Legacy_project()
         => new GuardUnsupported()
         .ForProject("LegacyProject.cs")
-        .HasIssue(Issue.WRN("Proj0002", "Upgrade legacy MS Build project file."));
+        .HasIssue(Issue.WRN("Proj0002", "Upgrade legacy MS Build project file"));
 }
 #endif

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_CDATA_for_large_texts.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_CDATA_for_large_texts.cs
@@ -5,7 +5,7 @@ public class Reports
     [Test]
     public void missing_CDATA() => new UseCDATAForLargeTexts()
         .ForProject("MissingCDATA.cs")
-        .HasIssue(Issue.WRN("Proj1701", "Add <![CDATA[ and ]]> around this text.")
+        .HasIssue(Issue.WRN("Proj1701", "Add <![CDATA[ and ]]> around this text")
         .WithSpan(17, 24, 23, 04));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_CSharp_specific_only_in_CSharp_context.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_CSharp_specific_only_in_CSharp_context.cs
@@ -7,12 +7,12 @@ public class Reports
         => new UseInCSharpContextOnly()
         .ForProject("CSharpOnlyPropertiesVB.vb")
         .HasIssues(
-            Issue.WRN("Proj0029", "The property <AllowUnsafeBlocks> is only applicable when using C# and can therefor be removed." /*...*/).WithSpan(03, 4, 03, 48).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0029", "The property <AllowUnsafeBlocks> is only applicable when using C# and can therefor be removed." /*...*/).WithSpan(05, 4, 05, 48).WithPath("CSharpOnlyPropertiesVB.vbproj"),
-            Issue.WRN("Proj0029", "The property <CheckForOverflowUnderflow> is only applicable when using C# and can therefor be removed.").WithSpan(04, 4, 04, 63).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0029", "The property <CheckForOverflowUnderflow> is only applicable when using C# and can therefor be removed.").WithSpan(06, 4, 06, 63).WithPath("CSharpOnlyPropertiesVB.vbproj"),
-            Issue.WRN("Proj0029", "The property <Nullable> is only applicable when using C# and can therefor be removed." /*............*/).WithSpan(05, 4, 05, 31).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0029", "The property <Nullable> is only applicable when using C# and can therefor be removed." /*............*/).WithSpan(07, 4, 07, 31).WithPath("CSharpOnlyPropertiesVB.vbproj"));
+            Issue.WRN("Proj0029", "The property <AllowUnsafeBlocks> is only applicable when using C# and can therefor be removed" /*...*/).WithSpan(03, 4, 03, 48).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0029", "The property <AllowUnsafeBlocks> is only applicable when using C# and can therefor be removed" /*...*/).WithSpan(05, 4, 05, 48).WithPath("CSharpOnlyPropertiesVB.vbproj"),
+            Issue.WRN("Proj0029", "The property <CheckForOverflowUnderflow> is only applicable when using C# and can therefor be removed").WithSpan(04, 4, 04, 63).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0029", "The property <CheckForOverflowUnderflow> is only applicable when using C# and can therefor be removed").WithSpan(06, 4, 06, 63).WithPath("CSharpOnlyPropertiesVB.vbproj"),
+            Issue.WRN("Proj0029", "The property <Nullable> is only applicable when using C# and can therefor be removed" /*............*/).WithSpan(05, 4, 05, 31).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0029", "The property <Nullable> is only applicable when using C# and can therefor be removed" /*............*/).WithSpan(07, 4, 07, 31).WithPath("CSharpOnlyPropertiesVB.vbproj"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_NET_analyzers.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_NET_analyzers.cs
@@ -8,7 +8,7 @@ public class Reports
        => new UseDotNetAnalyzers()
        .ForProject(project)
        .HasIssue(
-            Issue.WRN("Proj1002", "Use Microsoft's .NET analyzers by setting <EnableNETAnalyzers> to true."));
+            Issue.WRN("Proj1002", "Use Microsoft's .NET analyzers by setting <EnableNETAnalyzers> to true"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_Sonar_analyzers.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_Sonar_analyzers.cs
@@ -7,12 +7,12 @@ public class Reports
     [Test]
     public void missing_analyzer_for_CSharp() => new UseSonarAnalyzers()
         .ForProject("EmptyProject.cs")
-        .HasIssue(Issue.WRN("Proj1003", "Add SonarAnalyzer.CSharp."));
+        .HasIssue(Issue.WRN("Proj1003", "Add SonarAnalyzer.CSharp"));
 
     [Test]
     public void missing_analyzer_for_Visual_Basic() => new UseSonarAnalyzers()
         .ForProject("EmptyProjectVB.vb")
-        .HasIssue(Issue.WRN("Proj1003", "Add SonarAnalyzer.VisualBasic."));
+        .HasIssue(Issue.WRN("Proj1003", "Add SonarAnalyzer.VisualBasic"));
 
     [Test]
     public void only_added_as_project_version() => new UseSonarAnalyzers().ForInlineCsproj(@"
@@ -27,7 +27,7 @@ public class Reports
   </ItemGroup>
 
 </Project>")
-        .HasIssue(Issue.WRN("Proj1003", "Add SonarAnalyzer.CSharp."));
+        .HasIssue(Issue.WRN("Proj1003", "Add SonarAnalyzer.CSharp"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_VB_specific_only_in_VB_context.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_VB_specific_only_in_VB_context.cs
@@ -7,22 +7,22 @@ public class Reports
         => new UseInVBContextOnly()
         .ForProject("VBOnlyPropertiesCSharp.cs")
         .HasIssues(
-            Issue.WRN("Proj0030", "The property <FrameworkPathOverride> is only applicable when using VB.NET and can therefor be removed." /*.*/).WithSpan(03, 4, 03, 29).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0030", "The property <FrameworkPathOverride> is only applicable when using VB.NET and can therefor be removed." /*.*/).WithSpan(06, 4, 06, 29).WithPath("VBOnlyPropertiesCSharp.csproj"),
-            Issue.WRN("Proj0030", "The property <NoVBRuntimeReference> is only applicable when using VB.NET and can therefor be removed." /*..*/).WithSpan(04, 4, 04, 53).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0030", "The property <NoVBRuntimeReference> is only applicable when using VB.NET and can therefor be removed." /*..*/).WithSpan(07, 4, 07, 53).WithPath("VBOnlyPropertiesCSharp.csproj"),
-            Issue.WRN("Proj0030", "The property <OptionExplicit> is only applicable when using VB.NET and can therefor be removed." /*........*/).WithSpan(05, 4, 05, 39).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0030", "The property <OptionExplicit> is only applicable when using VB.NET and can therefor be removed." /*........*/).WithSpan(08, 4, 08, 39).WithPath("VBOnlyPropertiesCSharp.csproj"),
-            Issue.WRN("Proj0030", "The property <OptionInfer> is only applicable when using VB.NET and can therefor be removed." /*...........*/).WithSpan(06, 4, 06, 33).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0030", "The property <OptionInfer> is only applicable when using VB.NET and can therefor be removed." /*...........*/).WithSpan(09, 4, 09, 33).WithPath("VBOnlyPropertiesCSharp.csproj"),
-            Issue.WRN("Proj0030", "The property <OptionStrict> is only applicable when using VB.NET and can therefor be removed." /*..........*/).WithSpan(07, 4, 07, 35).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0030", "The property <OptionStrict> is only applicable when using VB.NET and can therefor be removed." /*..........*/).WithSpan(10, 4, 10, 35).WithPath("VBOnlyPropertiesCSharp.csproj"),
-            Issue.WRN("Proj0030", "The property <RemoveIntegerChecks> is only applicable when using VB.NET and can therefor be removed." /*...*/).WithSpan(08, 4, 08, 51).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0030", "The property <RemoveIntegerChecks> is only applicable when using VB.NET and can therefor be removed." /*...*/).WithSpan(11, 4, 11, 51).WithPath("VBOnlyPropertiesCSharp.csproj"),
-            Issue.WRN("Proj0030", "The property <VbcVerbosity> is only applicable when using VB.NET and can therefor be removed." /*..........*/).WithSpan(09, 4, 09, 40).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0030", "The property <VbcVerbosity> is only applicable when using VB.NET and can therefor be removed." /*..........*/).WithSpan(12, 4, 12, 40).WithPath("VBOnlyPropertiesCSharp.csproj"),
-            Issue.WRN("Proj0030", "The property <VbcToolPath> is only applicable when using VB.NET and can therefor be removed." /*...........*/).WithSpan(10, 4, 10, 19).WithPath("Directory.Build.props"),
-            Issue.WRN("Proj0030", "The property <VbcToolPath> is only applicable when using VB.NET and can therefor be removed." /*...........*/).WithSpan(13, 4, 13, 19).WithPath("VBOnlyPropertiesCSharp.csproj"));
+            Issue.WRN("Proj0030", "The property <FrameworkPathOverride> is only applicable when using VB.NET and can therefor be removed" /*.*/).WithSpan(03, 4, 03, 29).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0030", "The property <FrameworkPathOverride> is only applicable when using VB.NET and can therefor be removed" /*.*/).WithSpan(06, 4, 06, 29).WithPath("VBOnlyPropertiesCSharp.csproj"),
+            Issue.WRN("Proj0030", "The property <NoVBRuntimeReference> is only applicable when using VB.NET and can therefor be removed" /*..*/).WithSpan(04, 4, 04, 53).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0030", "The property <NoVBRuntimeReference> is only applicable when using VB.NET and can therefor be removed" /*..*/).WithSpan(07, 4, 07, 53).WithPath("VBOnlyPropertiesCSharp.csproj"),
+            Issue.WRN("Proj0030", "The property <OptionExplicit> is only applicable when using VB.NET and can therefor be removed" /*........*/).WithSpan(05, 4, 05, 39).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0030", "The property <OptionExplicit> is only applicable when using VB.NET and can therefor be removed" /*........*/).WithSpan(08, 4, 08, 39).WithPath("VBOnlyPropertiesCSharp.csproj"),
+            Issue.WRN("Proj0030", "The property <OptionInfer> is only applicable when using VB.NET and can therefor be removed" /*...........*/).WithSpan(06, 4, 06, 33).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0030", "The property <OptionInfer> is only applicable when using VB.NET and can therefor be removed" /*...........*/).WithSpan(09, 4, 09, 33).WithPath("VBOnlyPropertiesCSharp.csproj"),
+            Issue.WRN("Proj0030", "The property <OptionStrict> is only applicable when using VB.NET and can therefor be removed" /*..........*/).WithSpan(07, 4, 07, 35).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0030", "The property <OptionStrict> is only applicable when using VB.NET and can therefor be removed" /*..........*/).WithSpan(10, 4, 10, 35).WithPath("VBOnlyPropertiesCSharp.csproj"),
+            Issue.WRN("Proj0030", "The property <RemoveIntegerChecks> is only applicable when using VB.NET and can therefor be removed" /*...*/).WithSpan(08, 4, 08, 51).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0030", "The property <RemoveIntegerChecks> is only applicable when using VB.NET and can therefor be removed" /*...*/).WithSpan(11, 4, 11, 51).WithPath("VBOnlyPropertiesCSharp.csproj"),
+            Issue.WRN("Proj0030", "The property <VbcVerbosity> is only applicable when using VB.NET and can therefor be removed" /*..........*/).WithSpan(09, 4, 09, 40).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0030", "The property <VbcVerbosity> is only applicable when using VB.NET and can therefor be removed" /*..........*/).WithSpan(12, 4, 12, 40).WithPath("VBOnlyPropertiesCSharp.csproj"),
+            Issue.WRN("Proj0030", "The property <VbcToolPath> is only applicable when using VB.NET and can therefor be removed" /*...........*/).WithSpan(10, 4, 10, 19).WithPath("Directory.Build.props"),
+            Issue.WRN("Proj0030", "The property <VbcToolPath> is only applicable when using VB.NET and can therefor be removed" /*...........*/).WithSpan(13, 4, 13, 19).WithPath("VBOnlyPropertiesCSharp.csproj"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_analyzers_for_packages.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_analyzers_for_packages.cs
@@ -9,27 +9,27 @@ public class Reports
     public void missing_analyzers() => new UseAnalyzersForPackages()
         .ForProject("PackagesWithoutAnalyzers.cs")
         .HasIssues(
-            new("Proj1001", "Use Ardalis.ApiEndpoints.CodeAnalyzers to analyze Ardalis.ApiEndpoints."),
-            new("Proj1001", "Use FakeItEasy.Analyzer.CSharp to analyze FakeItEasy."),
-            new("Proj1001", "Use FluentAssertions.Analyzers to analyze FluentAssertions."),
-            new("Proj1001", "Use Libplanet.Analyzers to analyze Libplanet."),
-            new("Proj1001", "Use Lucene.Net.Analysis.Common to analyze Lucene.Net."),
-            new("Proj1001", "Use MassTransit.Analyzers to analyze MassTransit."),
-            new("Proj1001", "Use MessagePackAnalyzer to analyze MessagePack."),
-            new("Proj1001", "Use MessagePipe.Analyzer to analyze MessagePipe."),
-            new("Proj1001", "Use Microsoft.AspNetCore.Components.Analyzers to analyze Microsoft.AspNetCore."),
-            new("Proj1001", "Use Microsoft.Azure.Functions.Analyzers to analyze Microsoft.Azure.Functions.Extensions."),
-            new("Proj1001", "Use Microsoft.CodeAnalysis.Analyzers to analyze Microsoft.CodeAnalysis."),
-            new("Proj1001", "Use Microsoft.EntityFrameworkCore.Analyzers to analyze Microsoft.EntityFrameworkCore."),
-            new("Proj1001", "Use Microsoft.ServiceHub.Analyzers to analyze Microsoft.ServiceHub.Framework."),
-            new("Proj1001", "Use MongoDB.Analyzer to analyze MongoDB.Bson."),
-            new("Proj1001", "Use Moq.Analyzers to analyze Moq."),
-            new("Proj1001", "Use NSubstitute.Analyzers.CSharp to analyze NSubstitute."),
-            new("Proj1001", "Use NUnit.Analyzers to analyze nunit.framework."),
-            new("Proj1001", "Use RuntimeContracts.Analyzer to analyze RuntimeContracts."),
-            new("Proj1001", "Use SerilogAnalyzer to analyze Serilog."),
-            new("Proj1001", "Use xunit.analyzers to analyze xunit.core."),
-            new("Proj1001", "Use ZeroFormatter.Analyzer to analyze ZeroFormatter."));
+            new("Proj1001", "Use Ardalis.ApiEndpoints.CodeAnalyzers to analyze Ardalis.ApiEndpoints"),
+            new("Proj1001", "Use FakeItEasy.Analyzer.CSharp to analyze FakeItEasy"),
+            new("Proj1001", "Use FluentAssertions.Analyzers to analyze FluentAssertions"),
+            new("Proj1001", "Use Libplanet.Analyzers to analyze Libplanet"),
+            new("Proj1001", "Use Lucene.Net.Analysis.Common to analyze Lucene.Net"),
+            new("Proj1001", "Use MassTransit.Analyzers to analyze MassTransit"),
+            new("Proj1001", "Use MessagePackAnalyzer to analyze MessagePack"),
+            new("Proj1001", "Use MessagePipe.Analyzer to analyze MessagePipe"),
+            new("Proj1001", "Use Microsoft.AspNetCore.Components.Analyzers to analyze Microsoft.AspNetCore"),
+            new("Proj1001", "Use Microsoft.Azure.Functions.Analyzers to analyze Microsoft.Azure.Functions.Extensions"),
+            new("Proj1001", "Use Microsoft.CodeAnalysis.Analyzers to analyze Microsoft.CodeAnalysis"),
+            new("Proj1001", "Use Microsoft.EntityFrameworkCore.Analyzers to analyze Microsoft.EntityFrameworkCore"),
+            new("Proj1001", "Use Microsoft.ServiceHub.Analyzers to analyze Microsoft.ServiceHub.Framework"),
+            new("Proj1001", "Use MongoDB.Analyzer to analyze MongoDB.Bson"),
+            new("Proj1001", "Use Moq.Analyzers to analyze Moq"),
+            new("Proj1001", "Use NSubstitute.Analyzers.CSharp to analyze NSubstitute"),
+            new("Proj1001", "Use NUnit.Analyzers to analyze nunit.framework"),
+            new("Proj1001", "Use RuntimeContracts.Analyzer to analyze RuntimeContracts"),
+            new("Proj1001", "Use SerilogAnalyzer to analyze Serilog"),
+            new("Proj1001", "Use xunit.analyzers to analyze xunit.core"),
+            new("Proj1001", "Use ZeroFormatter.Analyzer to analyze ZeroFormatter"));
 }
 
 #if RELEASE

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_coverlet_collector_or_msbuild.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_coverlet_collector_or_msbuild.cs
@@ -15,7 +15,7 @@ public class Reports
   </ItemGroup>
 </Project>")
         .HasIssue(
-           Issue.WRN("Proj1102", "Choose either coverlet.collector or coverlet.msbuild.")
+           Issue.WRN("Proj1102", "Choose either coverlet.collector or coverlet.msbuild")
             .WithSpan(5, 04, 5, 89));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_dotnet_project_file_analyzers.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_dotnet_project_file_analyzers.cs
@@ -6,8 +6,7 @@ public class Reports
     public void missing_analyzers()
         => new UseAnalyzers()
         .ForProject("EmptyProject.cs")
-        .HasIssue(
-            Issue.WRN("Proj1000", "Use the .NET project file analyzers."));
+        .HasIssue(Issue.WRN("Proj1000", "Use the .NET project file analyzers"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_forward_slashes_in_paths.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_forward_slashes_in_paths.cs
@@ -7,11 +7,11 @@ public class Reports
        => new UseForwardSlashesInPaths()
        .ForProject("BackwardSlashes.cs")
        .HasIssues(
-           Issue.WRN("Proj0023", "<Import Project> contains backward slashes." /*..*/).WithSpan(02, 2, 02, 44),
-           Issue.WRN("Proj0023", "<Compile Include> contains backward slashes." /*.*/).WithSpan(09, 4, 09, 66),
-           Issue.WRN("Proj0023", "<Compile Link> contains backward slashes." /*....*/).WithSpan(09, 4, 09, 66),
-           Issue.WRN("Proj0023", "<Folder Include> contains backward slashes." /*..*/).WithSpan(13, 4, 13, 41),
-           Issue.WRN("Proj0023", "<None Remove> contains backward slashes." /*.....*/).WithSpan(17, 4, 17, 29));
+           Issue.WRN("Proj0023", "<Import Project> contains backward slashes" /*..*/).WithSpan(02, 2, 02, 44),
+           Issue.WRN("Proj0023", "<Compile Include> contains backward slashes" /*.*/).WithSpan(09, 4, 09, 66),
+           Issue.WRN("Proj0023", "<Compile Link> contains backward slashes" /*....*/).WithSpan(09, 4, 09, 66),
+           Issue.WRN("Proj0023", "<Folder Include> contains backward slashes" /*..*/).WithSpan(13, 4, 13, 41),
+           Issue.WRN("Proj0023", "<None Remove> contains backward slashes" /*.....*/).WithSpan(17, 4, 17, 29));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Warning_pragma_disable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Warning_pragma_disable.cs
@@ -7,5 +7,5 @@ public class Guard
         => new RemoveFolderNodes()
         .ForProject("SuppressIssues.cs")
         .Add(new IncludeProjectReferencesOnce())
-        .HasIssue(Issue.WRN("Proj0008", @"Remove folder node 'Third'.").WithSpan(20, 04, 20, 30));
+        .HasIssue(Issue.WRN("Proj0008", @"Remove folder node 'Third'").WithSpan(20, 04, 20, 30));
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_additional_files.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_additional_files.cs
@@ -5,8 +5,8 @@ public class Reports
     [Test]
     public void project_files_not_additional() => new Resx.AddAdditionalFile()
         .ForProject("ResxUnsorted.cs")
-        .HasIssue(
-            Issue.WRN("Proj0006", "Add 'Resources.resx' to the additional files.").WithPath("Resources.resx"));
+        .HasIssue(Issue.WRN("Proj0006", "Add 'Resources.resx' to the additional files")
+        .WithPath("Resources.resx"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_invariant_fallback_resources.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_invariant_fallback_resources.cs
@@ -6,8 +6,7 @@ public class Reports
     public void missing_invariant_resource()
         => new Resx.AddInvariantFallbackResources()
         .ForProject("ResxNoInvariant.cs")
-        .HasIssue(
-            Issue.WRN("Proj2003", "Add invariant fallback resource."));
+        .HasIssue(Issue.WRN("Proj2003", "Add invariant fallback resource"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_invariant_fallback_values.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_invariant_fallback_values.cs
@@ -7,10 +7,10 @@ public class Reports
         => new Resx.AddInvariantFallbackValues()
         .ForProject("ResxMissingInvariant.cs")
         .HasIssues(
-            Issue.WRN("Proj2004", "Add invariant fallback value for 'Bishop'.").WithSpan(11, 2, 13, 9),
-            Issue.WRN("Proj2004", "Add invariant fallback value for 'Rook'.").WithSpan(0014, 2, 16, 9),
-            Issue.WRN("Proj2004", "Add invariant fallback value for 'Knight'.").WithSpan(11, 2, 13, 9),
-            Issue.WRN("Proj2004", "Add invariant fallback value for 'Pawn'.").WithSpan(0014, 2, 16, 9));
+            Issue.WRN("Proj2004", "Add invariant fallback value for 'Bishop'").WithSpan(11, 2, 13, 9),
+            Issue.WRN("Proj2004", "Add invariant fallback value for 'Rook'").WithSpan(0014, 2, 16, 9),
+            Issue.WRN("Proj2004", "Add invariant fallback value for 'Knight'").WithSpan(11, 2, 13, 9),
+            Issue.WRN("Proj2004", "Add invariant fallback value for 'Pawn'").WithSpan(0014, 2, 16, 9));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Define_data_in_resource.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Define_data_in_resource.cs
@@ -6,8 +6,7 @@ public class Reports
     public void unsorted_data()
         => new Resx.DefineData()
         .ForProject("ResxNoData.cs")
-        .HasIssue(
-            Issue.WRN("Proj2001", "Resource does not contain any data."));
+        .HasIssue(Issue.WRN("Proj2001", "Resource does not contain any data"));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Escape_XML_nodes_resource_values.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Escape_XML_nodes_resource_values.cs
@@ -5,7 +5,7 @@ public class Reports
     [Test]
     public void on_value_with_HTML() => new Resx.EscapeXmlNodesResourceValues()
         .ForProject("ResxWithHtmlContent.cs")
-        .HasIssue(Issue.WRN("Proj2005", "Escape the XML node in 'Html'.").WithSpan(12, 04, 12, 30));
+        .HasIssue(Issue.WRN("Proj2005", "Escape the XML node in 'Html'").WithSpan(12, 04, 12, 30));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Indent_RESX.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Indent_RESX.cs
@@ -7,10 +7,10 @@ public class Reports
         => new Resx.IndentResx()
         .ForProject("FaultyIndenting.cs")
         .HasIssues(
-            Issue.WRN("Proj2100", "The element <resheader> has not been properly indented." /*.*/).WithSpan(05, 03, 05, 27),
-            Issue.WRN("Proj2100", "The element <data> has not been properly indented." /*......*/).WithSpan(11, 03, 11, 41),
-            Issue.WRN("Proj2100", "The element </data> has not been properly indented." /*.....*/).WithSpan(13, 02, 13, 09),
-            Issue.WRN("Proj2100", "The element <value> has not been properly indented." /*.....*/).WithSpan(15, 07, 15, 13));
+            Issue.WRN("Proj2100", "The element <resheader> has not been properly indented" /*.*/).WithSpan(05, 03, 05, 27),
+            Issue.WRN("Proj2100", "The element <data> has not been properly indented" /*......*/).WithSpan(11, 03, 11, 41),
+            Issue.WRN("Proj2100", "The element </data> has not been properly indented" /*.....*/).WithSpan(13, 02, 13, 09),
+            Issue.WRN("Proj2100", "The element <value> has not been properly indented" /*.....*/).WithSpan(15, 07, 15, 13));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Sort_data_alphabetically.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Sort_data_alphabetically.cs
@@ -7,7 +7,7 @@ public class Reports
         => new Resx.SortDataAlphabetically()
         .ForProject("ResxUnsorted.cs")
         .HasIssue(
-            Issue.WRN("Proj2002", "Resource 'B' is not ordered alphabetically and should appear before 'C'.").WithSpan(20, 2, 22, 9));
+            Issue.WRN("Proj2002", "Resource 'B' is not ordered alphabetically and should appear before 'C'").WithSpan(20, 2, 22, 9));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/SDK/Avoid_compile_items.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/SDK/Avoid_compile_items.cs
@@ -5,7 +5,7 @@ public class Reports
     [Test]
     public void SDK_with_compile_items() => new AvoidCompileItemInSdk()
         .ForSDkProject("SdkWithCompileItems")
-        .HasIssue(Issue.WRN("Proj0700", "The .net.csproj SDK project should not contain <Compile> items.").WithSpan(5, 04, 5, 43));
+        .HasIssue(Issue.WRN("Proj0700", "The .net.csproj SDK project should not contain <Compile> items").WithSpan(5, 04, 5, 43));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/SDK/Does_not_report.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/SDK/Does_not_report.cs
@@ -12,8 +12,8 @@ public class On
     public void Project_not_available_as_additional() => new AddAdditionalFile()
         .ForSDkProject("DotnetProjectFilesSdk")
         .HasIssues(
-            Issue.WRN("Proj0006", "Add 'DotNetProjectFile.Analyzers.Sdk.props' to the additional files."),
-            Issue.WRN("Proj0006", "Add 'DotNetProjectFile.Analyzers.Sdk.targets' to the additional files."));
+            Issue.WRN("Proj0006", "Add 'DotNetProjectFile.Analyzers.Sdk.props' to the additional files"),
+            Issue.WRN("Proj0006", "Add 'DotNetProjectFile.Analyzers.Sdk.targets' to the additional files"));
 
     [Test]
     public void Unresolved_Project() => new GuardUnsupported()

--- a/src/DotNetProjectFile.Analyzers/Ini/HeaderSyntax.cs
+++ b/src/DotNetProjectFile.Analyzers/Ini/HeaderSyntax.cs
@@ -22,24 +22,24 @@ public sealed record HeaderSyntax : IniSyntax
                 case TokenKind.HeaderStartToken:
                     if (++start > 1)
                     {
-                        return [Diagnostic.Create(Rule.Ini.InvalidHeader, SyntaxTree.GetLocation(token.LinePositionSpan), "[ is unexpected.")];
+                        return [Diagnostic.Create(Rule.Ini.InvalidHeader, SyntaxTree.GetLocation(token.LinePositionSpan), "[ is unexpected")];
                     }
                     break;
 
                 case TokenKind.HeaderEndToken:
                     if (++end > 1)
                     {
-                        return [Diagnostic.Create(Rule.Ini.InvalidHeader, SyntaxTree.GetLocation(token.LinePositionSpan), "] is unexpected.")];
+                        return [Diagnostic.Create(Rule.Ini.InvalidHeader, SyntaxTree.GetLocation(token.LinePositionSpan), "] is unexpected")];
                     }
                     if (text == 0)
                     {
-                        return [Diagnostic.Create(Rule.Ini.InvalidHeader, SyntaxTree.GetLocation(token.LinePositionSpan), "] is unexpected.")];
+                        return [Diagnostic.Create(Rule.Ini.InvalidHeader, SyntaxTree.GetLocation(token.LinePositionSpan), "] is unexpected")];
                     }
                     break;
             }
         }
         return end == 0
-            ? [Diagnostic.Create(Rule.Ini.InvalidHeader, SyntaxTree.GetLocation(Tokens[^1].LinePositionSpan), "] is expected.")]
+            ? [Diagnostic.Create(Rule.Ini.InvalidHeader, SyntaxTree.GetLocation(Tokens[^1].LinePositionSpan), "] is expected")]
             : [];
     }
 

--- a/src/DotNetProjectFile.Analyzers/Ini/KeyValuePairSyntax.cs
+++ b/src/DotNetProjectFile.Analyzers/Ini/KeyValuePairSyntax.cs
@@ -27,7 +27,7 @@ public sealed record KeyValuePairSyntax : IniSyntax
                 case TokenKind.KeyToken:
                     if (++key > 1)
                     {
-                        return [Diagnostic.Create(Rule.Ini.InvalidKeyValuePair, SyntaxTree.GetLocation(token.LinePositionSpan), "= or : is expected.")];
+                        return [Diagnostic.Create(Rule.Ini.InvalidKeyValuePair, SyntaxTree.GetLocation(token.LinePositionSpan), "= or : is expected")];
                     }
                     break;
 
@@ -35,20 +35,20 @@ public sealed record KeyValuePairSyntax : IniSyntax
                 case TokenKind.ColonToken:
                     if (key == 0 || ++sig > 1)
                     {
-                        return [Diagnostic.Create(Rule.Ini.InvalidKeyValuePair, SyntaxTree.GetLocation(token.LinePositionSpan), $"{token.Text} is unexpected.")];
+                        return [Diagnostic.Create(Rule.Ini.InvalidKeyValuePair, SyntaxTree.GetLocation(token.LinePositionSpan), $"{token.Text} is unexpected")];
                     }
                     break;
 
                 case TokenKind.ValueToken:
                     if (sig == 0 || ++val > 1)
                     {
-                        return [Diagnostic.Create(Rule.Ini.InvalidKeyValuePair, SyntaxTree.GetLocation(token.LinePositionSpan), "= or : is expected.")];
+                        return [Diagnostic.Create(Rule.Ini.InvalidKeyValuePair, SyntaxTree.GetLocation(token.LinePositionSpan), "= or : is expected")];
                     }
                     break;
             }
         }
         return val == 0
-            ? [Diagnostic.Create(Rule.Ini.InvalidKeyValuePair, SyntaxTree.GetLocation(Tokens[^1].LinePositionSpan), "Value is missing.")]
+            ? [Diagnostic.Create(Rule.Ini.InvalidKeyValuePair, SyntaxTree.GetLocation(Tokens[^1].LinePositionSpan), "Value is missing")]
             : [];
     }
 

--- a/src/DotNetProjectFile.Analyzers/Rule.Ini.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.Ini.cs
@@ -10,7 +10,7 @@ public static partial class Rule
            id: 4000,
            title: "Invalid INI file",
            message: "File could not be parsed",
-           description: "A INI header should have the format [<Header>].",
+           description: "A INI header should have the format [<Header>]",
            tags: ["INI", "syntax error"],
            category: Category.SyntaxError,
            isEnabled: false);
@@ -19,7 +19,7 @@ public static partial class Rule
            id: 4001,
            title: "Invalid INI Header",
            message: "{0}",
-           description: "A INI header should have the format [<Header>].",
+           description: "A INI header should have the format [<Header>]",
            tags: ["INI", "syntax error"],
            category: Category.SyntaxError,
            isEnabled: false);
@@ -36,7 +36,7 @@ public static partial class Rule
         public static DiagnosticDescriptor EmptySection => New(
             id: 4010,
             title: "Sections should contain at least one key-value pair",
-            message: "Section [{0}] is empty.",
+            message: "Section [{0}] is empty",
             description:
                 "A Section in INI file groups key-value pairs. Having an empty " +
                 "section has no added value.",
@@ -47,7 +47,7 @@ public static partial class Rule
         public static DiagnosticDescriptor HeaderMustBeGlob => New(
             id: 4050,
             title: "Header must be a GLOB",
-            message: "Header [{0}] is not a valid GLOB.",
+            message: "Header [{0}] is not a valid GLOB",
             description:
                 ".editorconfig files work on the premise that header texts are " +
                 "GLOB's matching files the key-value pairs of the section apply " +
@@ -59,7 +59,7 @@ public static partial class Rule
         public static DiagnosticDescriptor UseEqualsAssign => New(
             id: 4051,
             title: "Use equals sign for key-value assignments",
-            message: "Use = instead.",
+            message: "Use = instead",
             description: "In .editorconfig files instead of : use = as assignment sign.",
             tags: ["INI", ".editorconfig"],
             category: Category.Clarity,

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -7,7 +7,7 @@ public static partial class Rule
     public static DiagnosticDescriptor ProjectFileCouldNotBeLocated => New(
         id: 0001,
         title: "MS Build project file could not be located",
-        message: "The project file '{0}' could not be located.",
+        message: "The project file '{0}' could not be located",
         description: "In order to make these rules work, the project file should be located.",
         tags: ["Configuration"],
         category: Category.Configuration);
@@ -15,7 +15,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UpdateLegacyProjects => New(
         id: 0002,
         title: "Upgrade legacy MS Build project files",
-        message: "Upgrade legacy MS Build project file.",
+        message: "Upgrade legacy MS Build project file",
         description: "MS Build legacy projects are not supported.",
         tags: ["project file", "legacy", "obsolete"],
         category: Category.Obsolete);
@@ -23,7 +23,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineUsingsExplicit => New(
         id: 0003,
         title: "Define usings explicit",
-        message: "Define usings explicit.",
+        message: "Define usings explicit",
         description:
             "The included namespaces should be clear. To reduce the statements " +
             "per file, consider global using statements.",
@@ -33,7 +33,7 @@ public static partial class Rule
     public static DiagnosticDescriptor RunNuGetSecurityAudit => New(
         id: 0004,
         title: "Run NuGet security audits automatically",
-        message: "Run NuGet security audits automatically.",
+        message: "Run NuGet security audits automatically",
         description:
             "To reduce security issues, NuGets security audit should be run on " +
             "every build automatically.",
@@ -43,7 +43,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefinePackageReferenceAssetsAsAttributes => New(
         id: 0005,
         title: "Define package reference assets as attributes",
-        message: "Define package reference assets of '{0}' as attributes.",
+        message: "Define package reference assets of '{0}' as attributes",
         description:
             "To reduce security issues, NuGets security audit should be run on " +
             "every build automatically.",
@@ -53,7 +53,7 @@ public static partial class Rule
     public static DiagnosticDescriptor AddAdditionalFile => New(
         id: 0006,
         title: "Add additional files to improve static code analysis",
-        message: "Add '{0}' to the additional files.",
+        message: "Add '{0}' to the additional files",
         description:
             "By adding additional non-compiling files, those files become " +
             "available in the analyzer context too.",
@@ -63,7 +63,7 @@ public static partial class Rule
     public static DiagnosticDescriptor RemoveEmptyNodes => New(
         id: 0007,
         title: "Remove empty nodes",
-        message: "Remove empty {0} node.",
+        message: "Remove empty {0} node",
         description: "Empty nodes only add noise, as they contain no information.",
         tags: ["noise"],
         category: Category.Noise);
@@ -71,7 +71,7 @@ public static partial class Rule
     public static DiagnosticDescriptor RemoveFolderNodes => New(
         id: 0008,
         title: "Remove folder nodes",
-        message: "Remove folder node '{0}'.",
+        message: "Remove folder node '{0}'",
         description:
             "Folders nodes only add noise. They are leftovers of directories " +
             "created in the IDE, without adding an actual file to it.",
@@ -81,7 +81,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineSingleTargetFramework => New(
         id: 0009,
         title: "Use the <TargetFramework> node for a single target framework",
-        message: "Use the <TargetFramework> node instead.",
+        message: "Use the <TargetFramework> node instead",
         description:
             "To prevent confusion, only use the <TargetFrameworks> node when " +
             "there are multiple target frameworks.",
@@ -91,7 +91,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineOutputType => New(
         id: 0010,
         title: "Define the project output type explicitly",
-        message: "Define the <OutputType> node explicitly.",
+        message: "Define the <OutputType> node explicitly",
         description:
             "To prevent confusion, explicitly define the OutputType " +
             "as 'Library', 'Exe', 'WinExe' or 'Module'.",
@@ -101,7 +101,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefinePropertiesOnce => New(
         id: 0011,
         title: "Define properties once",
-        message: "Property <{0}> has been already defined.",
+        message: "Property <{0}> has been already defined",
         description: "MS Build will only select one value of a property.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -109,7 +109,7 @@ public static partial class Rule
     public static DiagnosticDescriptor ReassignPropertiesWithDifferentValue => New(
         id: 0012,
         title: "Reassign properties with a different value",
-        message: "Property <{0}> has been previously defined with the same value.",
+        message: "Property <{0}> has been previously defined with the same value",
         description: "Reassigning a property with the same value is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -117,7 +117,7 @@ public static partial class Rule
     public static DiagnosticDescriptor IncludePackageReferencesOnce => New(
         id: 0013,
         title: "Include package references only once",
-        message: "Package '{0}' is already referenced.",
+        message: "Package '{0}' is already referenced",
         description: "Including package references twice is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -125,7 +125,7 @@ public static partial class Rule
     public static DiagnosticDescriptor IncludeProjectReferencesOnce => New(
         id: 0014,
         title: "Include project references only once",
-        message: "Project '{0}' is already referenced.",
+        message: "Project '{0}' is already referenced",
         description: "Including project references twice is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -133,7 +133,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OrderPackageReferencesAlphabetically => New(
         id: 0015,
         title: "Order package references alphabetically",
-        message: "Package '{0}' is not ordered alphabetically and should appear before '{1}'.",
+        message: "Package '{0}' is not ordered alphabetically and should appear before '{1}'",
         description: "Not ordering package references alphabetically is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -141,7 +141,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OrderProjectReferencesAlphabetically => New(
         id: 0016,
         title: "Order project references alphabetically",
-        message: "Project '{0}' is not ordered alphabetically and should appear before '{1}'.",
+        message: "Project '{0}' is not ordered alphabetically and should appear before '{1}'",
         description: "Not ordering project references alphabetically is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -149,7 +149,7 @@ public static partial class Rule
     public static DiagnosticDescriptor StaticAliasUsingNotSupported => New(
         id: 0017,
         title: "Can't create alias for static using directive",
-        message: "Using directive for '{0}' can not be both an alias and static.",
+        message: "Using directive for '{0}' can not be both an alias and static",
         description: "Using directives can not be both static and an alias.",
         tags: ["Bug", "Code Generation"],
         category: Category.Bug,
@@ -158,7 +158,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OrderUsingDirectivesByType => New(
         id: 0018,
         title: "Order using directives by type",
-        message: "{0} directive for '{1}' should appear before {2} directive for '{3}'.",
+        message: "{0} directive for '{1}' should appear before {2} directive for '{3}'",
         description: "Not ordering using directives by type is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -166,7 +166,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OrderUsingDirectivesAlphabetically => New(
         id: 0019,
         title: "Order using directives alphabetically",
-        message: "{0} directive '{1}' is not ordered alphabetically and should appear before '{2}'.",
+        message: "{0} directive '{1}' is not ordered alphabetically and should appear before '{2}'",
         description: "Not ordering using directives alphabetically is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -174,7 +174,7 @@ public static partial class Rule
     public static DiagnosticDescriptor ItemGroupShouldBeUniform => New(
         id: 0020,
         title: "Item group should only contain nodes of a single type",
-        message: "<ItemGroup> should only contain nodes of a single type.",
+        message: "<ItemGroup> should only contain nodes of a single type",
         description: "Mixing nodes of different types in a single <ItemGroup> is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -182,7 +182,7 @@ public static partial class Rule
     public static DiagnosticDescriptor BuildActionsShouldHaveSingleTask => New(
         id: 0021,
         title: "Build actions should have a single task",
-        message: "The <{0}> defines multiple tasks.",
+        message: "The <{0}> defines multiple tasks",
         description:
             "For readability, a build action should define only one task.",
         tags: ["Readability"],
@@ -191,7 +191,7 @@ public static partial class Rule
     public static DiagnosticDescriptor BuildActionIncludeShouldExist => New(
         id: 0022,
         title: "Build action includes should exist",
-        message: "The Include '{0}' of <{1}> does not {2}.",
+        message: "The Include '{0}' of <{1}> does not {2}",
         description:
             "Build action include statements that do not include any file, are most " +
             "likely a left over, or a bug.",
@@ -201,7 +201,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseForwardSlashesInPaths => New(
         id: 0023,
         title: "Use forward slashes in paths",
-        message: "<{0} {1}> contains backward slashes.",
+        message: "<{0} {1}> contains backward slashes",
         description:
             "The use of forward slashes is preferred as they work both for UNIX and" +
             "Windows. This is not true for backward slashes.",
@@ -211,7 +211,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OrderPackageVersionsAlphabetically => New(
         id: 0024,
         title: "Order package versions alphabetically",
-        message: "Package version for '{0}' is not ordered alphabetically and should appear before '{1}'.",
+        message: "Package version for '{0}' is not ordered alphabetically and should appear before '{1}'",
         description: "Not ordering package versions alphabetically is considered noise.",
         tags: ["Configuration", "confusion"],
         category: Category.Clarity);
@@ -219,7 +219,7 @@ public static partial class Rule
     public static DiagnosticDescriptor MigrateFromRulesetToEditorConfigFile => New(
         id: 0025,
         title: "Migrate from ruleset file to .editorconfig file",
-        message: "Migrate ruleset '{0}' to an .editorconfig file.",
+        message: "Migrate ruleset '{0}' to an .editorconfig file",
         description:
             "XML based ruleset files are defacto deprecated. Ruleset can be " +
             "automatically converted using Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.",
@@ -229,7 +229,7 @@ public static partial class Rule
     public static DiagnosticDescriptor RemoveIncludeAssetsWhenRedundant => New(
         id: 0026,
         title: "Remove IncludeAssets when redundant",
-        message: "Remove {0} as it is redundant when all assets are private.",
+        message: "Remove {0} as it is redundant when all assets are private",
         description: "When all assets are private, none of them will be included.",
         tags: ["redundant"],
         category: Category.Noise);
@@ -237,7 +237,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OverrideTargetFrameworksWithTargetFrameworks => New(
         id: 0027,
         title: "Override <TargetFrameworks> with <TargetFrameworks>",
-        message: "This <TargetFramework> will be ignored due to the earlier use of <TargetFrameworks>.",
+        message: "This <TargetFramework> will be ignored due to the earlier use of <TargetFrameworks>",
         description:
             "The <TargetFrameworks> node precedes <TargetFramework>. Hence, " +
             "once the first has been used, the use of the latter has no effect.",
@@ -247,7 +247,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineConditionsOnLevel1 => New(
         id: 0028,
         title: "Define conditions on level 1",
-        message: "Move the condition to the parent <{0}>.",
+        message: "Move the condition to the parent <{0}>",
         description:
             "Both to keep lines short, and to group configuration that is bound " +
             "to the some constraints, it best to define condtions on level 1.",
@@ -257,7 +257,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseInCSharpContextOnly => New(
         id: 0029,
         title: "Use C# specific properties only when applicable",
-        message: "The property <{0}> is only applicable when using C# and can therefor be removed.",
+        message: "The property <{0}> is only applicable when using C# and can therefor be removed",
         description:
             "Properties only applicable to C# are noise when none of " +
             "the involved targets is a C# target.",
@@ -267,7 +267,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseInVBContextOnly => New(
         id: 0030,
         title: "Use VB.NET specific properties only when applicable",
-        message: "The property <{0}> is only applicable when using VB.NET and can therefor be removed.",
+        message: "The property <{0}> is only applicable when using VB.NET and can therefor be removed",
         description:
             "Properties only applicable to VB.NET are noise when none of " +
             "the involved targets is a VB.NET target.",
@@ -277,7 +277,7 @@ public static partial class Rule
     public static DiagnosticDescriptor AdoptPreferredCasing => New(
         id: 0031,
         title: "Adopt preferred casing of nodes",
-        message: "The node <{0}> has a different casing than the preferred one <{1}>.",
+        message: "The node <{0}> has a different casing than the preferred one <{1}>",
         description:
             "MS Build is (mostly) case insensitive. To prevent issues, however, " +
             "it is preferred to use the same casing consistently.",
@@ -287,7 +287,7 @@ public static partial class Rule
     public static DiagnosticDescriptor MigrateAwayFromBinaryFormatter => New(
         id: 0032,
         title: "Migrate away from BinaryFormatter",
-        message: "Migrate away from BinaryFormatter and do not enable <{0}>.",
+        message: "Migrate away from BinaryFormatter and do not enable <{0}>",
         description:
             "Microsoft strongly recommends that you investigate options to stop " +
             "using BinaryFormatter due to the associated security risks.",
@@ -297,7 +297,7 @@ public static partial class Rule
     public static DiagnosticDescriptor ProjectReferenceIncludeShouldExist => New(
         id: 0033,
         title: "Project reference includes should exist",
-        message: "The Include '{0}' of <{1}> does not exist.",
+        message: "The Include '{0}' of <{1}> does not exist",
         description:
             "Project reference include statements that do not include any file, are most likely bugs.",
         tags: ["dependencies", "dependency"],
@@ -306,7 +306,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UnresolvableImport => New(
         id: 0034,
         title: "Import statement could not be resolved",
-        message: "The <Import> '{0}' could not be resolved by the analyzer.",
+        message: "The <Import> '{0}' could not be resolved by the analyzer",
         description: "The .NET project file analyzer can (unfortunatly) not resolve all import statements.",
         tags: ["limitation"],
         category: Category.Bug);
@@ -325,7 +325,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,
         title: "Define the project packability explicitly",
-        message: "Define the <IsPackable> node explicitly.",
+        message: "Define the <IsPackable> node explicitly",
         description:
             "To prevent confusion, explicitly define the " +
             "<IsPackable> node.",
@@ -335,7 +335,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineVersion => New(
         id: 0201,
         title: "Define the project version explicitly",
-        message: "Define the <Version> or <VersionPrefix> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <Version> or <VersionPrefix> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <Version> or <VersionPrefix> node or " +
@@ -347,7 +347,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineDescription => New(
         id: 0202,
         title: "Define the project description explicitly",
-        message: "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, explicitly define " +
             "the <Description> or <PackageDescription> node or disable package " +
@@ -358,7 +358,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineAuthors => New(
         id: 0203,
         title: "Define the project authors explicitly",
-        message: "Define the <Authors> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <Authors> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <Authors> node or " +
@@ -370,7 +370,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineTags => New(
         id: 0204,
         title: "Define the project tags explicitly",
-        message: "Define the <PackageTags> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageTags> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <PackageTags> node or " +
@@ -382,7 +382,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineRepositoryUrl => New(
         id: 0205,
         title: "Define the project repository URL explicitly",
-        message: "Define the <RepositoryUrl> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <RepositoryUrl> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <RepositoryUrl> node or " +
@@ -394,7 +394,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineUrl => New(
         id: 0206,
         title: "Define the project URL explicitly",
-        message: "Define the <PackageProjectUrl> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageProjectUrl> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <PackageProjectUrl> node or " +
@@ -406,7 +406,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineCopyright => New(
         id: 0207,
         title: "Define the project copyright explicitly",
-        message: "Define the <Copyright> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <Copyright> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <Copyright> node or " +
@@ -418,7 +418,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineReleaseNotes => New(
         id: 0208,
         title: "Define the project release notes explicitly",
-        message: "Define the <PackageReleaseNotes> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageReleaseNotes> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <PackageReleaseNotes> node or " +
@@ -430,7 +430,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineReadmeFile => New(
         id: 0209,
         title: "Define the project readme file explicitly",
-        message: "Define the <PackageReadmeFile> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageReadmeFile> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <PackageReadmeFile> node or " +
@@ -442,7 +442,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineLicense => New(
         id: 0210,
         title: "Define the project license expression explicitly",
-        message: "Define the <PackageLicenseExpression> or <PackageLicenseFile> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageLicenseExpression> or <PackageLicenseFile> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages " +
             "and for maximum compatibility with external tools, " +
@@ -456,7 +456,7 @@ public static partial class Rule
     public static DiagnosticDescriptor AvoidLicenseUrl => New(
         id: 0211,
         title: "Avoid using deprecated license definition",
-        message: "Replace deprecated <PackageLicenseUrl> with <PackageLicenseExpression> or <PackageLicenseFile> node.",
+        message: "Replace deprecated <PackageLicenseUrl> with <PackageLicenseExpression> or <PackageLicenseFile> node",
         description:
             "The <PackageLicenseUrl> node has been deprecated " +
             "and should be replaced by either the " +
@@ -467,7 +467,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineIcon => New(
         id: 0212,
         title: "Define the project icon file explicitly",
-        message: "Define the <PackageIcon> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageIcon> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages " +
             "and for maximum compatibility with external tools, " +
@@ -480,7 +480,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineIconUrl => New(
         id: 0213,
         title: "Define the project icon URL explicitly",
-        message: "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages " +
             "and for maximum compatibility with external tools, " +
@@ -493,7 +493,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefinePackageId => New(
         id: 0214,
         title: "Define the NuGet project ID explicitly",
-        message: "Define the <PackageId> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageId> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <PackageId> node or " +
@@ -505,7 +505,7 @@ public static partial class Rule
     public static DiagnosticDescriptor ProvideCompliantPackageIcon => New(
         id: 0215,
         title: "Provide a compliant NuGet package icon",
-        message: "The package icon '{0}' {1}.",
+        message: "The package icon '{0}' {1}",
         description:
             "To ensure the creation of well-formed packages, use an image that is " +
             "128x128 and has a transparent background(PNG) for the best viewing results.",
@@ -515,7 +515,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineProductName => New(
         id: 0216,
         title: "Define the project name explicitly",
-        message: "Define the <ProductName> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <ProductName> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure the creation of well-formed packages, " +
             "explicitly define the <ProductName> node or " +
@@ -527,7 +527,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefinePackageRequireLicenseAcceptance => New(
         id: 0217,
         title: "Define requiring license acceptance explicitly",
-        message: "Define the <PackageRequireLicenseAcceptance> node explicitly or define the <IsPackable> node with value 'false'.",
+        message: "Define the <PackageRequireLicenseAcceptance> node explicitly or define the <IsPackable> node with value 'false'",
         description:
             "To ensure consumers of your packages are prompted or intentionally " +
             "not prompted to agree with the terms of your license, " +
@@ -540,7 +540,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EnablePackageValidation => New(
         id: 0240,
         title: "Enable package validation",
-        message: "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'.",
+        message: "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'",
         description:
             "To ensure the (backwards) compatibility " +
             "of the API surface of your package, it is advised " +
@@ -554,7 +554,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefinePackageValidationBaselineVersion => New(
         id: 0241,
         title: "Enable package baseline validation",
-        message: "Define the <PackageValidationBaselineVersion> node with a previously released stable version.",
+        message: "Define the <PackageValidationBaselineVersion> node with a previously released stable version",
         description:
             "To ensure the backwards compatibility " +
             "of the API surface of your package, it is advised " +
@@ -569,7 +569,7 @@ public static partial class Rule
     public static DiagnosticDescriptor GeneratePackageOnBuildConditionally => New(
         id: 0242,
         title: "Generate NuGet packages conditionally",
-        message: "Add a condition to <GeneratePackageOnBuild>.",
+        message: "Add a condition to <GeneratePackageOnBuild>",
         description:
             "To ensure that packages are not interdependently shipped in DEBUG " +
             "(or other) mode, a conditional statement should be defined.",
@@ -581,7 +581,7 @@ public static partial class Rule
     public static DiagnosticDescriptor GenerateSbom => New(
         id: 0243,
         title: "Generate software bill of materials",
-        message: "{0} or define the <IsPackable> node with value 'false'.",
+        message: "{0} or define the <IsPackable> node with value 'false'",
         description:
            "To be compliant with USA legislation, a software bill of materials " +
            "should be included with a shipped package.",
@@ -593,7 +593,7 @@ public static partial class Rule
     public static DiagnosticDescriptor GenerateDocumentationFile => New(
         id: 0244,
         title: "Generate documentation file",
-        message: "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'.",
+        message: "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'",
         description:
            "In order for code documentation to be visible for package consumers " +
            "it is important that the documentation is generated.",
@@ -605,7 +605,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DontMixVersionAndVersionPrefixOrVersionSuffix => New(
         id: 0245,
         title: "Don't mix Version and VersionPrefix/VersionSuffix",
-        message: "Remove the <Version> node or remove the {0}.",
+        message: "Remove the <Version> node or remove the {0}",
         description:
             "Version node overrides VersionPrefix and VersionSuffix nodes " +
             ", therefore you should either remove the Version node " +
@@ -620,7 +620,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineVersionPrefixIfVersionSuffixIsDefined => New(
         id: 0246,
         title: "Define VersionPrefix if VersionSuffix is defined",
-        message: "Define the <VersionPrefix> node or remove the <VersionSuffix> node.",
+        message: "Define the <VersionPrefix> node or remove the <VersionSuffix> node",
         description:
             "VersionSuffix indicates the desire to use the VersionPrefix and VersionSuffix system " +
             ", but when only defining the VersionSuffix node, the default value of VersionPrefix (1.0.0) " +
@@ -633,7 +633,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EnableStrictModeForPackageBaselineValidation => New(
         id: 0247,
         title: "Enable strict mode for package baseline validation",
-        message: "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'.",
+        message: "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'",
         description:
             "When ensuring backwards compatibility of the API surface " +
             "of your package, it is advised to do this in strict mode. " +
@@ -646,7 +646,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EnableStrictModeForPackageRuntimeCompatibilityValidation => New(
         id: 0248,
         title: "Enable strict mode for package runtime compatibility validation",
-        message: "Define the <EnableStrictModeForCompatibleTfms> node with value 'true' or remove the <EnableStrictModeForCompatibleTfms> node with value 'false' or remove the <EnablePackageValidation> node with value 'true'.",
+        message: "Define the <EnableStrictModeForCompatibleTfms> node with value 'true' or remove the <EnableStrictModeForCompatibleTfms> node with value 'false' or remove the <EnablePackageValidation> node with value 'true'",
         description:
             "When building your package for multiple runtimes it " +
             "is advised to enable the strict mode of the runtime " +
@@ -659,7 +659,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EnableStrictModeForPackageFrameworkCompatibilityValidation => New(
         id: 0249,
         title: "Enable strict mode for package framework compatibility validation",
-        message: "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
+        message: "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'",
         description:
             "When building your package for multiple runtimes it " +
             "is advised to enable the strict mode of the framework " +
@@ -672,7 +672,7 @@ public static partial class Rule
     public static DiagnosticDescriptor GenerateApiCompatibilitySuppressionFile => New(
         id: 0250,
         title: "Generate API compatibility suppression file",
-        message: "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
+        message: "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'",
         description:
             "This suppression file can be created manually, or automatically generated " +
             "by enabling the `GenerateCompatibilitySuppressionFile` property.It is advised " +
@@ -686,7 +686,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EnableApiCompatibilityAttributeChecks => New(
         id: 0251,
         title: "Enable API compatibility attribute checks",
-        message: "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
+        message: "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'",
         description:
             "When package validation is enabled, it is advised to opt-in " +
             "to the strict attribute compatibility checks.",
@@ -698,7 +698,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EnableApiCompatibilityParameterNameChecks => New(
         id: 0252,
         title: "Enable API compatibility parameter name checks",
-        message: "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'.",
+        message: "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'",
         description:
             "When package validation is enabled, it is advised to opt-in " +
             "to the strict parameter name compatibility checks.",
@@ -710,7 +710,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineIsPublishable => New(
         id: 0400,
         title: "Define the project publishability explicitly",
-        message: "Define the <IsPublishable> node explicitly.",
+        message: "Define the <IsPublishable> node explicitly",
         description:
             "To prevent confusion, explicitly define the " +
             "<IsPublishable> node.",
@@ -720,7 +720,7 @@ public static partial class Rule
     public static DiagnosticDescriptor TestProjectShouldNotBePackable => New(
         id: 0450,
         title: "Test projects should not be packable",
-        message: "Set <IsPackable> to false.",
+        message: "Set <IsPackable> to false",
         description:
             "Test projects should only be responsible for running tests. Hence " +
             "they should not be packable.",
@@ -730,7 +730,7 @@ public static partial class Rule
     public static DiagnosticDescriptor TestProjectShouldNotBePublishable => New(
         id: 0451,
         title: "Test projects should not be publishable",
-        message: "Set <IsPublishable> to false.",
+        message: "Set <IsPublishable> to false",
         description:
             "Test projects should only be responsible for running tests. Hence " +
             "they should not be publishable.",
@@ -740,7 +740,7 @@ public static partial class Rule
     public static DiagnosticDescriptor TestProjectsRequireSdk => New(
         id: 0452,
         title: "Test projects require Microsoft.NET.Test.Sdk",
-        message: @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />.",
+        message: @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />",
         description: "Tests in a test projects do not run properly without the Microsoft.NET.Test.Sdk being included.",
         tags: ["Unit Testing"],
         category: Category.Bug);
@@ -748,7 +748,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UsingMicrosoftNetTestSdkImpliesTestProject => New(
         id: 0453,
         title: "Using Microsoft.NET.Test.Sdk implies a test project",
-        message: @"Set <IsTestProject> to true.",
+        message: @"Set <IsTestProject> to true",
         description: "Including the Microsoft.NET.Test.Sdk is only useful for test projects.",
         tags: ["Unit Testing"],
         category: Category.Bug);
@@ -756,7 +756,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OnlyIncludePackagesWithExplicitLicense => New(
         id: 0500,
         title: "Only include packages with an explicitly defined license",
-        message: "The {0} package is shipped without an explicitly defined license.",
+        message: "The {0} package is shipped without an explicitly defined license",
         description:
             "To prevent legal issues do not rely on third-party references that do not " +
             "come with an explicitly defined license.",
@@ -766,7 +766,7 @@ public static partial class Rule
     public static DiagnosticDescriptor PackageOnlyContainsDeprecatedLicenseUrl => New(
         id: 0501,
         title: "Package only contains a deprecated license URL",
-        message: "The {0} package only contains a deprecated license URL.",
+        message: "The {0} package only contains a deprecated license URL",
         description:
             "To prevent legal issues do not rely on thrid-party references that do not " +
             "come with an ferifiable deprecated license URL.",
@@ -776,7 +776,7 @@ public static partial class Rule
     public static DiagnosticDescriptor PackageIncompatibleWithProjectLicense => New(
         id: 0502,
         title: "Only include packages compliant with project",
-        message: "The {0} package is distributed as {1}, which is imcompatable with the {2} license of the project.",
+        message: "The {0} package is distributed as {1}, which is imcompatable with the {2} license of the project",
         description:
             "To prevent legal issues do not rely on third-party references that have " +
             "an incompatable license.",
@@ -788,7 +788,7 @@ public static partial class Rule
     public static DiagnosticDescriptor AvoidGeneratePackageOnBuildWhenNotPackable => New(
         id: 0600,
         title: "Avoid generating packages on build if not packable",
-        message: "Avoid defining <GeneratePackageOnBuild> node explicitly when <IsPackable> is 'false'.",
+        message: "Avoid defining <GeneratePackageOnBuild> node explicitly when <IsPackable> is 'false'",
         description:
             "The <GeneratePackageOnBuild> option has no effect " +
             "when <IsPackable> the node is disabled. " +
@@ -800,7 +800,7 @@ public static partial class Rule
     public static DiagnosticDescriptor AvoidCompileItemInSdk => New(
         id: 0700,
         title: "Avoid defining <Compile> items in SDK project",
-        message: "The .net.csproj SDK project should not contain <Compile> items.",
+        message: "The .net.csproj SDK project should not contain <Compile> items",
         description:
             "The .net.csproj SDK project is a placeholder for non-compiling " +
             "files. Compile items should be avoided.",
@@ -810,7 +810,7 @@ public static partial class Rule
     public static DiagnosticDescriptor ConfigureCentralPackageVersionManagement => New(
         id: 0800,
         title: "Configure Central Package Management explicitly",
-        message: "Define the <ManagePackageVersionsCentrally> node with the value 'true', or 'false'.",
+        message: "Define the <ManagePackageVersionsCentrally> node with the value 'true', or 'false'",
         description:
             "In situations where you manage common dependencies for many " +
             "different projects, you can leverage Central Package Version " +
@@ -821,7 +821,7 @@ public static partial class Rule
     public static DiagnosticDescriptor IncludeDirectoryPackagesProps => New(
         id: 0801,
         title: "Include 'Directory.Packages.props'",
-        message: "The file 'Directory.Packages.props' could not be located.",
+        message: "The file 'Directory.Packages.props' could not be located",
         description: "When CPM is enabled 'Directory.Packages.props' should be resolvable.",
         tags: ["configuration", "versioning"],
         category: Category.CPM);
@@ -829,7 +829,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EnableCentralPackageManagementCentrally => New(
         id: 0802,
         title: "Enable Central Package Management centrally",
-        message: "Enable <ManagePackageVersionsCentrally> in 'Directory.Packages.props' or a shared props file.",
+        message: "Enable <ManagePackageVersionsCentrally> in 'Directory.Packages.props' or a shared props file",
         description: "Enabling it per project would defy the purpose of CPM.",
         tags: ["Maintainability"],
         category: Category.CPM);
@@ -837,7 +837,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseVersionOverrideOnlyWithCpm => New(
         id: 0803,
         title: "Use VersionOverride only with Central Package Management enabled",
-        message: "Use Version instead of VersionOverride when CPM is not enabled.",
+        message: "Use Version instead of VersionOverride when CPM is not enabled",
         description:
             "When CPM is not enabled the use of <PackageReference VersionOveride /> " +
             "`has no effect, and is most likely a mistake.",
@@ -847,7 +847,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseVersionOnlyWithoutCpm => New(
         id: 0804,
         title: "Use Version only with Central Package Management not enabled",
-        message: "Do not use Version when CPM is enabled.",
+        message: "Do not use Version when CPM is enabled",
         description:
             "When CPM is enabled the use of <PackageReference Version /> " +
             "`has no effect, and is most likely a mistake.",
@@ -857,7 +857,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefinePackageReferenceVersion => New(
         id: 0805,
         title: "Define version for PackageReference",
-        message: "Define version for '{0}' PackageReference.",
+        message: "Define version for '{0}' PackageReference",
         description:
             "PackageReference nodes require a version number in order to " +
             "properly resolve the package. This can be done by either using the " +
@@ -869,7 +869,7 @@ public static partial class Rule
     public static DiagnosticDescriptor VersionOverrideShouldChangeVersion => New(
         id: 0806,
         title: "VersionOverride should change the version",
-        message: "Remove VersionOverride or change it to a version different than defined by the CPM.",
+        message: "Remove VersionOverride or change it to a version different than defined by the CPM",
         description:
             "The use of VersionOverride on a <PackageReference> is only useful " +
             "when it defines a different version then already defined by the CPM.",
@@ -879,7 +879,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OnlyUseDirectoryPackagesPropsForCPM => New(
         id: 0807,
         title: "Only use Directory.Packages.props for Central Package Management",
-        message: "As <{0}> is not about Central Package Management it should not be in Directory.Packages.props.",
+        message: "As <{0}> is not about Central Package Management it should not be in Directory.Packages.props",
         description:
             "The use of VersionOverride on a <PackageReference> is only useful " +
             "when it defines a different version then already defined by the CPM.",
@@ -889,7 +889,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineGlobalPackageReferenceInDirectoryPackagesOnly => New(
         id: 0808,
         title: "Define global package reference only in Directory.Packages.props",
-        message: "The <GlobalPackageReference> should be defined in the Directory.Packages.props.",
+        message: "The <GlobalPackageReference> should be defined in the Directory.Packages.props",
         description:
             "The use of <GlobalPackageReference> is only useful " +
             "when defined in Directory.Packages.props.",
@@ -899,7 +899,7 @@ public static partial class Rule
     public static DiagnosticDescriptor GlobalPackageReferencesAreMeantForPrivateAssetsOnly => New(
         id: 0809,
         title: "Global package references are meant for private assets only",
-        message: "The global package reference '{0}' is not supposed to be a private asset.",
+        message: "The global package reference '{0}' is not supposed to be a private asset",
         description:
             "When using <GlobalPackageReference>, the reference is included as " +
             "private asset. Packages not meant as private asset should not be " +
@@ -920,7 +920,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseDotNetProjectFileAnalyzers => New(
         id: 1000,
         title: "Use the .NET project file analyzers",
-        message: "Use the .NET project file analyzers.",
+        message: "Use the .NET project file analyzers",
         description: "To improve the code quality of .NET project files.",
         tags: ["roslyn", "analyzer", "cbproj", "vbproj"],
         category: Category.CodeQuality,
@@ -929,7 +929,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseAnalyzersForPackages => New(
         id: 1001,
         title: "Use analyzers for packages",
-        message: "Use {0} to analyze {1}.",
+        message: "Use {0} to analyze {1}",
         description:
             "Some NuGet packages come with there own/dedicated Roslyn analyzers; " +
             "they just contain rules to improve the usage of those packages. " +
@@ -941,7 +941,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseDotNetAnalyzers => New(
         id: 1002,
         title: "Use Microsoft's .NET analyzers",
-        message: "Use Microsoft's .NET analyzers by setting <EnableNETAnalyzers> to true.",
+        message: "Use Microsoft's .NET analyzers by setting <EnableNETAnalyzers> to true",
         description: "Improve the code quality by adding Microsoft's Roslyn analyzers.",
         tags: ["roslyn", "analyzer", "Microsoft"],
         category: Category.CodeQuality);
@@ -949,7 +949,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseSonarAnalyzers => New(
         id: 1003,
         title: "Use Sonar analyzers for packages",
-        message: "Add {0}.",
+        message: "Add {0}",
         description: "Improve the code quality by adding Sonar's Roslyn analyzers.",
         tags: ["roslyn", "analyzer", "Sonar"],
         category: Category.CodeQuality);
@@ -957,7 +957,7 @@ public static partial class Rule
     public static DiagnosticDescriptor AvoidUsingMoq => New(
         id: 1100,
         title: "Avoid using Moq",
-        message: "Do not use Moq.",
+        message: "Do not use Moq",
         description: "Moq has built in data harvesting that violates GDPR.",
         tags: ["GDPR", "privacy"],
         category: Category.Security,
@@ -966,7 +966,7 @@ public static partial class Rule
     public static DiagnosticDescriptor PackageReferencesShouldBeStable => New(
         id: 1101,
         title: "Package references should have stable versions",
-        message: "Use a stable version of '{0}', instead of '{1}'.",
+        message: "Use a stable version of '{0}', instead of '{1}'",
         description: "The use of nightly builds and other pre-releases should be avoided.",
         tags: ["NuGet", "Versioning"],
         category: Category.Reliability);
@@ -974,7 +974,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseCoverletCollectorOrMsBuild => New(
         id: 1102,
         title: "Use Coverlet Collector or MSBuild",
-        message: "Choose either coverlet.collector or coverlet.msbuild.",
+        message: "Choose either coverlet.collector or coverlet.msbuild",
         description:
             "The packages coverlet.collector and coverlet.msbuild have the " +
             "same purpose but should not be used together.",
@@ -1004,7 +1004,7 @@ public static partial class Rule
     public static DiagnosticDescriptor ExcludePrivateAssetDependencies => New(
         id: 1200,
         title: "Exclude private assets as project file dependency",
-        message: "Mark the package reference \"{0}\" as a private asset.",
+        message: "Mark the package reference \"{0}\" as a private asset",
         description:
             "Private assets (such as analyzers) will not result in being a " +
             "project dependency after being compiled.",
@@ -1014,7 +1014,7 @@ public static partial class Rule
     public static DiagnosticDescriptor IndentXml => New(
         id: 1700,
         title: "Indent XML files",
-        message: "The element <{0}> has not been properly indented.",
+        message: "The element <{0}> has not been properly indented",
         description: "To improve readability, XML elements should be properly indented.",
         tags: ["XML", "indentation"],
         category: Category.Formatting);
@@ -1022,7 +1022,7 @@ public static partial class Rule
     public static DiagnosticDescriptor UseCDATAForLargeTexts => New(
         id: 1701,
         title: "Use <![CDATA[ for large texts",
-        message: "Add <![CDATA[ and ]]> around this text.",
+        message: "Add <![CDATA[ and ]]> around this text",
         description: "To improve readability, large texts should be CDATA.",
         tags: ["XML", "CDATA"],
         category: Category.Formatting);
@@ -1030,7 +1030,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OmitXmlDeclarations => New(
         id: 1702,
         title: "Omit XML declarations",
-        message: "Remove the XML declaration as it is redundant.",
+        message: "Remove the XML declaration as it is redundant",
         description: "The XML declaration is redundant for MS Build project files.",
         tags: ["XML", "declaration"],
         category: Category.Formatting);
@@ -1047,7 +1047,7 @@ public static partial class Rule
     public static DiagnosticDescriptor DefineData => New(
         id: 2001,
         title: "Define data in a resource file",
-        message: "Resource does not contain any data.",
+        message: "Resource does not contain any data",
         description: "A resource file without `<data>` elements is of no use.",
         tags: ["resx", "resources"],
         category: Category.Noise);
@@ -1055,7 +1055,7 @@ public static partial class Rule
     public static DiagnosticDescriptor SortDataAlphabetically => New(
         id: 2002,
         title: "Sort resource file values alphabetically",
-        message: "Resource '{0}' is not ordered alphabetically and should appear before '{1}'.",
+        message: "Resource '{0}' is not ordered alphabetically and should appear before '{1}'",
         description:
             "To improve readability, and reduce the number of merge conflicts, " +
             "the `<data>` elements should be sorted based on the `@name` attribute.",
@@ -1065,7 +1065,7 @@ public static partial class Rule
     public static DiagnosticDescriptor AddInvariantFallbackResources => New(
         id: 2003,
         title: "Add invariant fallback resources",
-        message: "Add invariant fallback resource.",
+        message: "Add invariant fallback resource",
         description:
             "To ensure that localized values can be resolved, a localized resource " +
             "file must have a culture invariant alternative.",
@@ -1075,7 +1075,7 @@ public static partial class Rule
     public static DiagnosticDescriptor AddInvariantFallbackValues => New(
        id: 2004,
        title: "Add invariant fallback values",
-       message: "Add invariant fallback value for '{0}'.",
+       message: "Add invariant fallback value for '{0}'",
        description:
            "To ensure that localized values can be resolved, a localized value " +
            "file must have a culture invariant alternative.",
@@ -1085,7 +1085,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EscapeXmlNodesResourceValues => New(
       id: 2005,
       title: "Escape XML nodes of resource values",
-      message: "Escape the XML node in '{0}'.",
+      message: "Escape the XML node in '{0}'",
       description: "To ensure correct handling, XML nodes within resource values should be escaped.",
       tags: ["resx", "resources", "XML", "escaping"],
       category: Category.Bug);
@@ -1093,7 +1093,7 @@ public static partial class Rule
     public static DiagnosticDescriptor IndentResx => New(
       id: 2100,
       title: "Indent XML files",
-      message: "The element <{0}> has not been properly indented.",
+      message: "The element <{0}> has not been properly indented",
       description: "To improve readability, XML elements should be properly indented.",
       tags: ["XML", "indentation"],
       category: Category.Formatting);
@@ -1101,7 +1101,7 @@ public static partial class Rule
     public static DiagnosticDescriptor OnlyUseUTF8WithoutBom => New(
         id: 3000,
         title: "Ony use UTF-8 encoding without BOM",
-        message: "This file is using UTF-8 encoding with BOM.",
+        message: "This file is using UTF-8 encoding with BOM",
         description:
             "The use of BOM for UTF-8 can cause systems to malfunction. This " +
             "includes multiple web based files such as Javascript and CSS.",
@@ -1111,7 +1111,7 @@ public static partial class Rule
     public static DiagnosticDescriptor TrackToDoTags => New(
         id: 3001,
         title: @"Track uses of ""TODO"" tags",
-        message: @"Complete the task associated to this ""{0}"" comment.",
+        message: @"Complete the task associated to this ""{0}"" comment",
         description:
             "Developers often use TODO tags to mark areas in the code where " +
             "additional work or improvements are needed but are not implemented " +


### PR DESCRIPTION
As rule [RS1032: Define diagnostic message correctly](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md#rs1032-define-diagnostic-message-correctly) states:
> The diagnostic message should not contain any line return character nor any leading or trailing whitespaces and should either be a single sentence without a trailing period or a multi-sentences with a trailing period

So, all messages that did not meet this rule yet, now also do.