### PR TITLE
Rules to validate <ThirdPartyLicense>

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![.NET project file analyzers logo](design/logo_128x128.png)
 # .NET project file analyzers
-Contains 110+ [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
+Contains 120+ [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 (static code) [diagnostic analyzers](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.diagnostics.diagnosticanalyzer)
 that report issues on .NET project files.
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
@@ -1,0 +1,116 @@
+namespace Specs.Rules.MS_Build.ThirdPartyLicensence_compliance;
+
+public class Reports
+{
+    [Test]
+    public void missing_include() => new ThirdPartyLicensenCompliance()
+       .ForInlineCsproj(@$"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ThirdPartyLicense Update=""Qowaiv"" Hash=""QED9yngU7o-Fy128_FSy0w"" />
+  </ItemGroup>
+
+</Project>")
+       .HasIssue(Issue.WRN("Proj0505", "Include has not been specified")
+       .WithSpan(07, 04, 07, 71));
+
+    [Test]
+    public void invalid_glob() => new ThirdPartyLicensenCompliance()
+       .ForInlineCsproj(@$"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ThirdPartyLicense Include=""Qowaiv["" Hash=""QED9yngU7o-Fy128_FSy0w"" />
+  </ItemGroup>
+
+</Project>")
+       .HasIssue(Issue.WRN("Proj0505", "Include is not valid GLOB pattern")
+       .WithSpan(07, 04, 07, 73));
+
+    [Test]
+    public void missing_hash() => new ThirdPartyLicensenCompliance()
+       .ForInlineCsproj(@$"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ThirdPartyLicense Include=""Qowaiv"" />
+  </ItemGroup>
+
+</Project>")
+       .HasIssue(Issue.WRN("Proj0506", "Hash has not been specified")
+       .WithSpan(07, 04, 07, 42));
+
+    [TestCase("QED9yngU7o-Fy128_FSy0")] //   Too short
+    [TestCase("QED9yngU7o-Fy128_FSy023")] // Too long
+    [TestCase("QED9yngU7o%4Fy128FSy02")] //  Invalid character
+    public void invalid_hash(string hash) => new ThirdPartyLicensenCompliance()
+       .ForInlineCsproj(@$"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ThirdPartyLicense Include=""Qowaiv"" Hash=""${hash}"" />
+  </ItemGroup>
+
+</Project>")
+       .HasIssue(Issue.WRN("Proj0506", "Hash is not valid")
+       .WithSpan(07, 04, 07, 51 + hash.Length));
+
+    [Test]
+    public void condtional() => new ThirdPartyLicensenCompliance()
+       .ForInlineCsproj(@$"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Condition=""$(TargetFramework) == 'net8.0'"">
+    <ThirdPartyLicense Include=""Qowaiv"" Hash=""QED9yngU7o-Fy128_FSy0w"" />
+  </ItemGroup>
+
+</Project>")
+       .HasIssue(Issue.WRN("Proj0507", "The <ThirdPartyLicense> can not be conditional")
+       .WithSpan(07, 04, 07, 72));
+
+    public class Guards
+    {
+        [Test]
+        public void unconditonal_fully_specified_node() => new ThirdPartyLicensenCompliance()
+            .ForInlineCsproj(@$"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ThirdPartyLicense Include=""Qowaiv"" Hash=""QED9yngU7o-Fy128_FSy0w"" />
+  </ItemGroup>
+
+</Project>")
+            .HasNoIssues();
+
+        [TestCase("CompliantCSharp.cs")]
+        [TestCase("CompliantCSharpPackage.cs")]
+        public void Projects_without_issues(string project) => new ThirdPartyLicensenCompliance()
+            .ForProject(project)
+            .HasNoIssues();
+    }
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
@@ -3,7 +3,7 @@ namespace Specs.Rules.MS_Build.ThirdPartyLicensence_compliance;
 public class Reports
 {
     [Test]
-    public void missing_include() => new ThirdPartyLicensenCompliance()
+    public void missing_include() => new ThirdPartyLicenseCompliance()
        .ForInlineCsproj(@$"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -20,7 +20,7 @@ public class Reports
        .WithSpan(07, 04, 07, 71));
 
     [Test]
-    public void invalid_glob() => new ThirdPartyLicensenCompliance()
+    public void invalid_glob() => new ThirdPartyLicenseCompliance()
        .ForInlineCsproj(@$"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -37,7 +37,7 @@ public class Reports
        .WithSpan(07, 04, 07, 73));
 
     [Test]
-    public void missing_hash() => new ThirdPartyLicensenCompliance()
+    public void missing_hash() => new ThirdPartyLicenseCompliance()
        .ForInlineCsproj(@$"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -56,7 +56,7 @@ public class Reports
     [TestCase("QED9yngU7o-Fy128_FSy0")] //   Too short
     [TestCase("QED9yngU7o-Fy128_FSy023")] // Too long
     [TestCase("QED9yngU7o%4Fy128FSy02")] //  Invalid character
-    public void invalid_hash(string hash) => new ThirdPartyLicensenCompliance()
+    public void invalid_hash(string hash) => new ThirdPartyLicenseCompliance()
        .ForInlineCsproj(@$"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -73,7 +73,7 @@ public class Reports
        .WithSpan(07, 04, 07, 51 + hash.Length));
 
     [Test]
-    public void condtional() => new ThirdPartyLicensenCompliance()
+    public void condtional() => new ThirdPartyLicenseCompliance()
        .ForInlineCsproj(@$"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -92,7 +92,7 @@ public class Reports
     public class Guards
     {
         [Test]
-        public void unconditonal_fully_specified_node() => new ThirdPartyLicensenCompliance()
+        public void unconditonal_fully_specified_node() => new ThirdPartyLicenseCompliance()
             .ForInlineCsproj(@$"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -109,7 +109,7 @@ public class Reports
 
         [TestCase("CompliantCSharp.cs")]
         [TestCase("CompliantCSharpPackage.cs")]
-        public void Projects_without_issues(string project) => new ThirdPartyLicensenCompliance()
+        public void Projects_without_issues(string project) => new ThirdPartyLicenseCompliance()
             .ForProject(project)
             .HasNoIssues();
     }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
@@ -12,7 +12,7 @@ public class Reports
   </PropertyGroup>
 
   <ItemGroup>
-    <ThirdPartyLicense Update=""Qowaiv"" Hash=""QED9yngU7o-Fy128_FSy0w"" />
+    <ThirdPartyLicense Update=""Qowaiv"" Hash=""QED9yngU7o+Fy128_FSy0w"" />
   </ItemGroup>
 
 </Project>")
@@ -29,7 +29,7 @@ public class Reports
   </PropertyGroup>
 
   <ItemGroup>
-    <ThirdPartyLicense Include=""Qowaiv["" Hash=""QED9yngU7o-Fy128_FSy0w"" />
+    <ThirdPartyLicense Include=""Qowaiv["" Hash=""QED9yngU7o+Fy128_FSy0w"" />
   </ItemGroup>
 
 </Project>")
@@ -82,7 +82,7 @@ public class Reports
   </PropertyGroup>
 
   <ItemGroup Condition=""$(TargetFramework) == 'net8.0'"">
-    <ThirdPartyLicense Include=""Qowaiv"" Hash=""QED9yngU7o-Fy128_FSy0w"" />
+    <ThirdPartyLicense Include=""Qowaiv"" Hash=""QED9yngU7o+Fy128_FSy0w"" />
   </ItemGroup>
 
 </Project>")
@@ -101,7 +101,7 @@ public class Reports
   </PropertyGroup>
 
   <ItemGroup>
-    <ThirdPartyLicense Include=""Qowaiv"" Hash=""QED9yngU7o-Fy128_FSy0w"" />
+    <ThirdPartyLicense Include=""Qowaiv"" Hash=""QED9yngU7o+Fy128_FSy0w"" />
   </ItemGroup>
 
 </Project>")

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
@@ -92,7 +92,7 @@ public class Reports
     public class Guards
     {
         [Test]
-        public void unconditonal_fully_specified_node() => new ThirdPartyLicenseCompliance()
+        public void unconditional_fully_specified_node() => new ThirdPartyLicenseCompliance()
             .ForInlineCsproj(@$"
 <Project Sdk=""Microsoft.NET.Sdk"">
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
@@ -73,7 +73,7 @@ public class Reports
        .WithSpan(07, 04, 07, 51 + hash.Length));
 
     [Test]
-    public void condtional() => new ThirdPartyLicenseCompliance()
+    public void conditional() => new ThirdPartyLicenseCompliance()
        .ForInlineCsproj(@$"
 <Project Sdk=""Microsoft.NET.Sdk"">
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseCompliance.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseCompliance.cs
@@ -5,9 +5,9 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 /// <summary>Validates the <see cref="ThirdPartyLicense"/> node.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class ThirdPartyLicenseCompliance() : MsBuildProjectFileAnalyzer(
-    Rule.ThridPartyLicenseRequiresInclude,
-    Rule.ThridPartyLicenseRequiresHash,
-    Rule.ThridPartyLicenseIsUnconditional)
+    Rule.ThirdPartyLicenseRequiresInclude,
+    Rule.ThirdPartyLicenseRequiresHash,
+    Rule.ThirdPartyLicenseIsUnconditional)
 {
     /// <inheritdoc />
     public override bool DisableOnFailingImport => false;
@@ -21,25 +21,25 @@ public sealed class ThirdPartyLicenseCompliance() : MsBuildProjectFileAnalyzer(
         {
             if (license.Include is not { Length: > 0})
             {
-                context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresInclude, license, "has not been specified");
+                context.ReportDiagnostic(Rule.ThirdPartyLicenseRequiresInclude, license, "has not been specified");
             }
             else if(Glob.TryParse(license.Include) is null)
             {
-                context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresInclude, license, "is not valid GLOB pattern");
+                context.ReportDiagnostic(Rule.ThirdPartyLicenseRequiresInclude, license, "is not valid GLOB pattern");
             }
 
             if(license.Hash is null)
             {
-                context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresHash, license, "has not been specified");
+                context.ReportDiagnostic(Rule.ThirdPartyLicenseRequiresHash, license, "has not been specified");
             }
             else if(!IsBase64Hash(license.Hash))
             {
-                context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresHash, license, "is not valid");
+                context.ReportDiagnostic(Rule.ThirdPartyLicenseRequiresHash, license, "is not valid");
             }
             
             if (license.Conditions().Any())
             {
-                context.ReportDiagnostic(Rule.ThridPartyLicenseIsUnconditional, license);
+                context.ReportDiagnostic(Rule.ThirdPartyLicenseIsUnconditional, license);
             }
         }
     }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseCompliance.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseCompliance.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 
 /// <summary>Validates the <see cref="ThirdPartyLicense"/> node.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-public sealed class ThirdPartyLicensenCompliance() : MsBuildProjectFileAnalyzer(
+public sealed class ThirdPartyLicenseCompliance() : MsBuildProjectFileAnalyzer(
     Rule.ThridPartyLicenseRequiresInclude,
     Rule.ThridPartyLicenseRequiresHash,
     Rule.ThridPartyLicenseIsUnconditional)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicensenCompliance.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicensenCompliance.cs
@@ -19,7 +19,6 @@ public sealed class ThirdPartyLicensenCompliance() : MsBuildProjectFileAnalyzer(
             .ItemGroups.SelectMany(g => g.ThirdPartyLicenses)
             .Where(n => n.Project == context.File.Project))
         {
-            
             if (license.Include is not { Length: > 0})
             {
                 context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresInclude, license, "has not been specified");
@@ -53,5 +52,5 @@ public sealed class ThirdPartyLicensenCompliance() : MsBuildProjectFileAnalyzer(
         => (c >= 'A' && c <= 'Z')
         || (c >= 'a' && c <= 'z')
         || (c >= '0' && c <= '9')
-        || c is '-' or '_';
+        || c is '+' or '_';
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicensenCompliance.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicensenCompliance.cs
@@ -1,0 +1,57 @@
+using DotNetProjectFile.Text;
+
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+/// <summary>Validates the <see cref="ThirdPartyLicense"/> node.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class ThirdPartyLicensenCompliance() : MsBuildProjectFileAnalyzer(
+    Rule.ThridPartyLicenseRequiresInclude,
+    Rule.ThridPartyLicenseRequiresHash,
+    Rule.ThridPartyLicenseIsUnconditional)
+{
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
+    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        foreach(var license in context.File.Project
+            .ItemGroups.SelectMany(g => g.ThirdPartyLicenses)
+            .Where(n => n.Project == context.File.Project))
+        {
+            
+            if (license.Include is not { Length: > 0})
+            {
+                context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresInclude, license, "has not been specified");
+            }
+            else if(Glob.TryParse(license.Include) is null)
+            {
+                context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresInclude, license, "is not valid GLOB pattern");
+            }
+
+            if(license.Hash is null)
+            {
+                context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresHash, license, "has not been specified");
+            }
+            else if(!IsBase64Hash(license.Hash))
+            {
+                context.ReportDiagnostic(Rule.ThridPartyLicenseRequiresHash, license, "is not valid");
+            }
+            
+            if (license.Conditions().Any())
+            {
+                context.ReportDiagnostic(Rule.ThridPartyLicenseIsUnconditional, license);
+            }
+        }
+    }
+
+    private static bool IsBase64Hash(string hash)
+        => hash.Length == 22
+        && hash.All(IsBase64Hash);
+
+    private static bool IsBase64Hash(char c)
+        => (c >= 'A' && c <= 'Z')
+        || (c >= 'a' && c <= 'z')
+        || (c >= '0' && c <= '9')
+        || c is '-' or '_';
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -68,6 +68,9 @@ ToBeReleased:
 - Proj0036: Remove None when redundant. (NEW RULE)
 - Proj0503: Package license is unknown. (NEW RULE)
 - Proj0504: Package license has changed. (NEW RULE)
+- Proj0505: Third-party license registry requires include. (NEW RULE)
+- Proj0506: Third-party license registry requires hash. (NEW RULE)
+- Proj0507: Third-party license registry must be unconditional. (NEW RULE)
 v1.5.10.1
 - Proj0006: Disable as the files to analyze are added by default sincse 1.5.10. (UPDATE)
 v1.5.10

--- a/src/DotNetProjectFile.Analyzers/Licensing/CustomLicense.cs
+++ b/src/DotNetProjectFile.Analyzers/Licensing/CustomLicense.cs
@@ -24,6 +24,6 @@ public sealed record CustomLicense(string Hash) : LicenseExpression
         var hash = sha256.GetHashAndReset();
         var truncated = hash.AsSpan(0, 16).ToArray();
 
-        return new(Convert.ToBase64String(truncated).TrimEnd('='));
+        return new(Convert.ToBase64String(truncated).Replace('/', '_').TrimEnd('='));
     }
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
@@ -31,6 +31,9 @@ public sealed class ItemGroup(XElement element, Node parent, MsBuildProject proj
     /// <summary>Gets the child project references.</summary>
     public Nodes<ProjectReference> ProjectReferences => new(Children);
 
+    /// <summary>Gets the child project third-party licenses.</summary>
+    public Nodes<ThirdPartyLicense> ThirdPartyLicenses => new(Children);
+
     /// <summary>Gets the child folders.</summary>
     public Nodes<Folder> Folders => new(Children);
 

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -88,6 +88,9 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0502** Only include packages compliant with project](https://dotnet-project-file-analyzers.github.io/rules/Proj0502.html)
 * [**Proj0503** Package license is unknown](https://dotnet-project-file-analyzers.github.io/rules/Proj0503.html)
 * [**Proj0504** Package license has changed](https://dotnet-project-file-analyzers.github.io/rules/Proj0504.html)
+* [**Proj0505** Third-party license registry requires include](https://dotnet-project-file-analyzers.github.io/rules/Proj0505.html)
+* [**Proj0506** Third-party license registry requires hash](https://dotnet-project-file-analyzers.github.io/rules/Proj0506.html)
+* [**Proj0507** Third-party license registry must be unconditional](https://dotnet-project-file-analyzers.github.io/rules/Proj0507.html)
 
 ## .NET Project File Analyzers SDK
 * [**Proj0700** Avoid defining &lt;Compile&gt; items in SDK project](https://dotnet-project-file-analyzers.github.io/rules/Proj0700.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -816,7 +816,7 @@ public static partial class Rule
         category: Category.Legal,
         severity: DiagnosticSeverity.Warning);
 
-    public static DiagnosticDescriptor ThridPartyLicenseRequiresInclude => New(
+    public static DiagnosticDescriptor ThirdPartyLicenseRequiresInclude => New(
         id: 0505,
         title: "Third-party license requires registry include",
         message: "Include {0}",

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -818,7 +818,7 @@ public static partial class Rule
 
     public static DiagnosticDescriptor ThirdPartyLicenseRequiresInclude => New(
         id: 0505,
-        title: "Third-party license requires registry include",
+        title: "Third-party license registry requires include",
         message: "Include {0}",
         description:
             "To prevent legal issues do not rely on third-party references where the " +
@@ -840,7 +840,7 @@ public static partial class Rule
 
     public static DiagnosticDescriptor ThirdPartyLicenseIsUnconditional => New(
         id: 0507,
-        title: "Third-party license registry requires must be unconditional",
+        title: "Third-party license registry must be unconditional",
         message: "The <ThirdPartyLicense> can not be conditional",
         description:
             "To prevent legal issues do not rely on third-party references where the " +

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -806,15 +806,48 @@ public static partial class Rule
         severity: DiagnosticSeverity.Warning);
 
     public static DiagnosticDescriptor CustomPackageLicenseHasChanged => New(
-     id: 0504,
-     title: "Package license has changed",
-     message: "The license for {0} has changed as its hash is now {1}",
-     description:
-         "To prevent legal issues do not rely on third-party references where the " +
-         "license has been changed without checking the changes.",
-     tags: ["license"],
-     category: Category.Legal,
-     severity: DiagnosticSeverity.Warning);
+        id: 0504,
+        title: "Package license has changed",
+        message: "The license for {0} has changed as its hash is now {1}",
+        description:
+            "To prevent legal issues do not rely on third-party references where the " +
+            "license has been changed without checking the changes.",
+        tags: ["license"],
+        category: Category.Legal,
+        severity: DiagnosticSeverity.Warning);
+
+    public static DiagnosticDescriptor ThridPartyLicenseRequiresInclude => New(
+        id: 0505,
+        title: "Third-party license requires registry include",
+        message: "Include {0}",
+        description:
+            "To prevent legal issues do not rely on third-party references where the " +
+            "license has been changed without checking the changes.",
+        tags: ["license"],
+        category: Category.Legal,
+        severity: DiagnosticSeverity.Error);
+
+    public static DiagnosticDescriptor ThridPartyLicenseRequiresHash => New(
+        id: 0506,
+        title: "Third-party license registry requires hash",
+        message: "Hash {0}",
+        description:
+            "To prevent legal issues do not rely on third-party references where the " +
+            "license has been changed without checking the changes.",
+        tags: ["license"],
+        category: Category.Legal,
+        severity: DiagnosticSeverity.Error);
+
+    public static DiagnosticDescriptor ThridPartyLicenseIsUnconditional => New(
+        id: 0507,
+        title: "Third-party license registry requires must be unconditional",
+        message: "The <ThirdPartyLicense> can not be conditional",
+        description:
+            "To prevent legal issues do not rely on third-party references where the " +
+            "license has been changed without checking the changes.",
+        tags: ["license"],
+        category: Category.Legal,
+        severity: DiagnosticSeverity.Error);
 
     public static DiagnosticDescriptor AvoidGeneratePackageOnBuildWhenNotPackable => New(
         id: 0600,

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -827,7 +827,7 @@ public static partial class Rule
         category: Category.Legal,
         severity: DiagnosticSeverity.Error);
 
-    public static DiagnosticDescriptor ThridPartyLicenseRequiresHash => New(
+    public static DiagnosticDescriptor ThirdPartyLicenseRequiresHash => New(
         id: 0506,
         title: "Third-party license registry requires hash",
         message: "Hash {0}",

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -838,7 +838,7 @@ public static partial class Rule
         category: Category.Legal,
         severity: DiagnosticSeverity.Error);
 
-    public static DiagnosticDescriptor ThridPartyLicenseIsUnconditional => New(
+    public static DiagnosticDescriptor ThirdPartyLicenseIsUnconditional => New(
         id: 0507,
         title: "Third-party license registry requires must be unconditional",
         message: "The <ThirdPartyLicense> can not be conditional",


### PR DESCRIPTION
Closes #385 

It is not necessary to check if the `<ThirdPartyLicense>` is a child of `<ItemGroup>` or not. If you put it under a `<PropertyGroup>` you get a MSBuild error. So that rule (as suggested with #385) has not been implemented.

I went for three distinct rules, all as errors.