### PR TITLE
Add dotnet as extra search tag

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveCommentedOutCode.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveCommentedOutCode.cs
@@ -1,6 +1,6 @@
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
-/// <<summary>Implements <see cref="Rule.RemoveCommentedOutCode"/>.</summary>>
+/// <summary>Implements <see cref="Rule.RemoveCommentedOutCode"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class RemoveCommentedOutCode() : MsBuildProjectFileAnalyzer(Rule.RemoveCommentedOutCode)
 {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Resx/RemoveCommentedOutCode.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Resx/RemoveCommentedOutCode.cs
@@ -2,7 +2,7 @@ using DotNetProjectFile.Resx;
 
 namespace DotNetProjectFile.Analyzers.Resx;
 
-/// <<summary>Implements <see cref="Rule.RemoveCommentedOutCode"/>.</summary>>
+/// <summary>Implements <see cref="Rule.RemoveCommentedOutCode"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class RemoveCommentedOutCode() : ResourceFileAnalyzer(Rule.RemoveCommentedOutCode)
 {

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />
 
@@ -23,7 +23,7 @@
     <PackageProjectUrl>https://dotnet-project-file-analyzers.github.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
-    <PackageTags>Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
+    <PackageTags>Code Analysis;Project files;project file;dotnet;csproj;vbproj;resx;MS Build;resources;analyser;analyzer;analysis</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>logo_128x128.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/Corniel/dotnet-project-file-analyzers/main/design/logo_128x128.png</PackageIconUrl>

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />
 


### PR DESCRIPTION
I am bothered by the fact that searching for `dotnet project file analyzer` does not make the library appear on nuget, whereas it does appear when searching for `project file analyzer`. I hope adding `dotnet` as a tag will solve this.