### PR TITLE
Change suggested analyzer logic to use packagereferences rather than assembly names

### DIFF
--- a/projects/PackagesWithoutAnalyzers/PackagesWithoutAnalyzers.csproj
+++ b/projects/PackagesWithoutAnalyzers/PackagesWithoutAnalyzers.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
@@ -14,7 +15,7 @@
     <PackageReference Include="MassTransit" Version="8.0.16" />
     <PackageReference Include="MessagePack" Version="2.5.124" />
     <PackageReference Include="MessagePipe" Version="1.7.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.8" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.8" />

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_analyzers_for_packages.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_analyzers_for_packages.cs
@@ -12,12 +12,13 @@ public class Reports
             new("Proj1001", "Use Ardalis.ApiEndpoints.CodeAnalyzers to analyze Ardalis.ApiEndpoints"),
             new("Proj1001", "Use FakeItEasy.Analyzer.CSharp to analyze FakeItEasy"),
             new("Proj1001", "Use FluentAssertions.Analyzers to analyze FluentAssertions"),
+            new("Proj1001", "Use AwesomeAssertions.Analyzers to analyze AwesomeAssertions"),
             new("Proj1001", "Use Libplanet.Analyzers to analyze Libplanet"),
             new("Proj1001", "Use Lucene.Net.Analysis.Common to analyze Lucene.Net"),
             new("Proj1001", "Use MassTransit.Analyzers to analyze MassTransit"),
             new("Proj1001", "Use MessagePackAnalyzer to analyze MessagePack"),
             new("Proj1001", "Use MessagePipe.Analyzer to analyze MessagePipe"),
-            new("Proj1001", "Use Microsoft.AspNetCore.Components.Analyzers to analyze Microsoft.AspNetCore"),
+            new("Proj1001", "Use Microsoft.AspNetCore.Components.Analyzers to analyze Microsoft.AspNetCore.Components"),
             new("Proj1001", "Use Microsoft.Azure.Functions.Analyzers to analyze Microsoft.Azure.Functions.Extensions"),
             new("Proj1001", "Use Microsoft.CodeAnalysis.Analyzers to analyze Microsoft.CodeAnalysis"),
             new("Proj1001", "Use Microsoft.EntityFrameworkCore.Analyzers to analyze Microsoft.EntityFrameworkCore"),
@@ -25,10 +26,10 @@ public class Reports
             new("Proj1001", "Use MongoDB.Analyzer to analyze MongoDB.Bson"),
             new("Proj1001", "Use Moq.Analyzers to analyze Moq"),
             new("Proj1001", "Use NSubstitute.Analyzers.CSharp to analyze NSubstitute"),
-            new("Proj1001", "Use NUnit.Analyzers to analyze nunit.framework"),
+            new("Proj1001", "Use NUnit.Analyzers to analyze NUnit"),
             new("Proj1001", "Use RuntimeContracts.Analyzer to analyze RuntimeContracts"),
             new("Proj1001", "Use SerilogAnalyzer to analyze Serilog"),
-            new("Proj1001", "Use xunit.analyzers to analyze xunit.core"),
+            new("Proj1001", "Use xunit.analyzers to analyze xunit"),
             new("Proj1001", "Use ZeroFormatter.Analyzer to analyze ZeroFormatter"));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_analyzers_for_packages.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Use_analyzers_for_packages.cs
@@ -9,6 +9,7 @@ public class Reports
     public void missing_analyzers() => new UseAnalyzersForPackages()
         .ForProject("PackagesWithoutAnalyzers.cs")
         .HasIssues(
+            // Direct.
             new("Proj1001", "Use Ardalis.ApiEndpoints.CodeAnalyzers to analyze Ardalis.ApiEndpoints"),
             new("Proj1001", "Use FakeItEasy.Analyzer.CSharp to analyze FakeItEasy"),
             new("Proj1001", "Use FluentAssertions.Analyzers to analyze FluentAssertions"),
@@ -30,7 +31,12 @@ public class Reports
             new("Proj1001", "Use RuntimeContracts.Analyzer to analyze RuntimeContracts"),
             new("Proj1001", "Use SerilogAnalyzer to analyze Serilog"),
             new("Proj1001", "Use xunit.analyzers to analyze xunit"),
-            new("Proj1001", "Use ZeroFormatter.Analyzer to analyze ZeroFormatter"));
+            new("Proj1001", "Use ZeroFormatter.Analyzer to analyze ZeroFormatter"),
+            
+            // Transitive.
+            new("Proj1001", "Use SerilogAnalyzer to analyze Libplanet"),
+            new("Proj1001", "Use MessagePackAnalyzer to analyze Microsoft.ServiceHub.Framework"),
+            new("Proj1001", "Use MessagePackAnalyzer to analyze StreamJsonRpc"));
 }
 
 #if RELEASE

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
@@ -30,7 +30,7 @@ public sealed class ExcludePrivateAssetDependencies() : MsBuildProjectFileAnalyz
             return false;
         }
 
-        if (PackageCache.GetPackage(reference.IncludeOrUpdate, reference.ResolveVersion()) is { } package)
+        if (reference.ResolveCachedPackage() is { } package)
         {
             if (package.IsDevelopmentDependency is true)
             {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
@@ -23,7 +23,7 @@ public sealed class GlobalPackageReferencesAreMeantForPrivateAssetsOnly()
 
     private bool NoPrivateAsset(GlobalPackageReference reference)
     {
-        if (PackageCache.GetPackage(reference.Include, reference.Version) is { } package)
+        if (reference.ResolveCachedPackage() is { } package)
         {
             return package.HasRuntimeDll && package.IsDevelopmentDependency is not true;
         }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
@@ -67,7 +67,7 @@ public sealed class ThirdPartyLicenseResolver() : MsBuildProjectFileAnalyzer(
 file static class Extensions
 {
     public static CachedPackage? GetLicensedPackage(this PackageReferenceBase reference)
-       => NuGet.PackageCache.GetPackage(reference.IncludeOrUpdate, reference.Version) is { } package
+       => reference.ResolveCachedPackage() is { } package
        && (package.LicenseExpression is { Length: > 0 }
        || package.LicenseFile is { Length: > 0 }
        || package.LicenseUrl is { Length: > 0 })

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
@@ -1,3 +1,5 @@
+using DotNetProjectFile.NuGet;
+
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
@@ -8,23 +10,29 @@ public sealed class UseAnalyzersForPackages() : MsBuildProjectFileAnalyzer(Rule.
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        var packageReferences = context.File.Walk().OfType<PackageReferenceBase>().Where(p => p is not PackageVersion);
+        var packageReferences = context.File
+            .Walk()
+            .OfType<PackageReferenceBase>()
+            .Where(p => p is not PackageVersion && !string.IsNullOrWhiteSpace(p.IncludeOrUpdate));
 
-        var unusedAnalyzers = Analyzers.Where(analyzer
-            => analyzer.IsApplicable(context.Compilation.Options.Language)
-            && packageReferences.None(analyzer.IsMatch));
+        var analyzers = GetAnalyzers(context.Compilation.Language);
 
-        foreach (var analyzer in unusedAnalyzers)
+        foreach (var reference in packageReferences)
         {
-            if (context.Compilation.ReferencedAssemblyNames
-                .Where(analyzer.IsMatch)
-                .OrderBy(asm => asm.Name.Length)
-                .FirstOrDefault() is { } reference)
+            var requiredAnalyzers = analyzers.Where(analyzer => analyzer.IsAnalyzerFor(reference));
+            var missingAnalyzers = requiredAnalyzers.Where(analyzer => packageReferences.None(analyzer.IsMatch));
+
+            foreach (var analyzer in missingAnalyzers)
             {
-                context.ReportDiagnostic(Descriptor, context.File, analyzer.Name, reference.Name);
+                context.ReportDiagnostic(Descriptor, reference, analyzer.Name, reference.IncludeOrUpdate);
             }
         }
     }
+
+    private static NuGet.Analyzer[] GetAnalyzers(string language)
+        => Analyzers
+        .Where(analyzer => analyzer.IsApplicable(language))
+        .ToArray();
 
     private static readonly NuGet.Analyzer[] Analyzers = NuGet.Packages.All
         .OfType<NuGet.Analyzer>()

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -73,7 +73,7 @@ ToBeReleased:
 - Proj0506: Third-party license registry requires hash. (NEW RULE)
 - Proj0507: Third-party license registry must be unconditional. (NEW RULE)
 - Proj1001: Suggested analyzers now based on package references rather than assembly names. (FP)
-- Proj1001: Now suggest to use AwesomeAssertions.Analyzers for AwesomeAssertions.
+- Proj1001: Now suggest to use AwesomeAssertions.Analyzers for AwesomeAssertions. (FN)
 - Proj1200: Fix compilation packages (that only hold a collective set of dependencies) incorrectly marked as development-dependencies. (FP)
 - Proj1701: Do not report on short (less then 3 lines) release notes. (FP)
 v1.5.10.1

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -73,6 +73,7 @@ ToBeReleased:
 - Proj0506: Third-party license registry requires hash. (NEW RULE)
 - Proj0507: Third-party license registry must be unconditional. (NEW RULE)
 - Proj1001: Suggested analyzers now based on package references rather than assembly names. (FP)
+- Proj1001: Now suggest to use AwesomeAssertions.Analyzers for AwesomeAssertions.
 - Proj1200: Fix compilation packages (that only hold a collective set of dependencies) incorrectly marked as development-dependencies. (FP)
 - Proj1701: Do not report on short (less then 3 lines) release notes. (FP)
 v1.5.10.1

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -72,6 +72,7 @@ ToBeReleased:
 - Proj0505: Third-party license registry requires include. (NEW RULE)
 - Proj0506: Third-party license registry requires hash. (NEW RULE)
 - Proj0507: Third-party license registry must be unconditional. (NEW RULE)
+- Proj1001: Suggested analyzers now based on package references rather than assembly names. (FP)
 - Proj1200: Fix compilation packages (that only hold a collective set of dependencies) incorrectly marked as development-dependencies. (FP)
 - Proj1701: Do not report on short (less then 3 lines) release notes. (FP)
 v1.5.10.1

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
@@ -8,45 +8,4 @@ public sealed class PackageReference(XElement element, Node parent, MsBuildProje
     public string VersionOrVersionOverride => Version ?? VersionOverride ?? string.Empty;
 
     public string? PrivateAssets => Attribute() ?? Child();
-
-    public (Node Node, string Version)? ResolveVersionVerbose()
-    {
-        if (Project.ManagePackageVersionsCentrally() is true)
-        {
-            if (VersionOverride is { Length: > 0 })
-            {
-                return (this, VersionOverride);
-            }
-
-            var versionOverrideNode = Project
-                .WalkBackward()
-                .OfType<PackageReference>()
-                .FirstOrDefault(p => p.IncludeOrUpdate == IncludeOrUpdate);
-
-            if (versionOverrideNode?.VersionOverride is { Length: > 0 } versionOverride)
-            {
-                return (versionOverrideNode, versionOverride);
-            }
-
-            var versionNode = Project
-                .WalkBackward()
-                .OfType<PackageVersion>()
-                .FirstOrDefault(v => v.Include == IncludeOrUpdate);
-
-            if (versionNode?.Version is { Length: > 0 } version)
-            {
-                return (versionNode, version);
-            }
-        }
-        else if (Version is { Length: > 0 })
-        {
-            return (this, Version);
-        }
-
-        return null;
-    }
-
-    /// <summary>Resolves the version taking CPM into account.</summary>
-    public string? ResolveVersion()
-        => ResolveVersionVerbose()?.Version;
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageReferenceBase.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageReferenceBase.cs
@@ -1,3 +1,5 @@
+using DotNetProjectFile.NuGet;
+
 namespace DotNetProjectFile.MsBuild;
 
 public abstract class PackageReferenceBase(XElement element, Node parent, MsBuildProject project)
@@ -10,4 +12,48 @@ public abstract class PackageReferenceBase(XElement element, Node parent, MsBuil
     public string? Version => Attribute();
 
     public string IncludeOrUpdate => Include ?? Update ?? string.Empty;
+
+    public (Node Node, string Version)? ResolveVersionVerbose()
+    {
+        if (Project.ManagePackageVersionsCentrally() is true)
+        {
+            if (this is PackageReference { VersionOverride: { Length: > 0 } selfVersionOverride})
+            {
+                return (this, selfVersionOverride);
+            }
+
+            var versionOverrideNode = Project
+                .WalkBackward()
+                .OfType<PackageReference>()
+                .FirstOrDefault(p => p.IncludeOrUpdate == IncludeOrUpdate);
+
+            if (versionOverrideNode?.VersionOverride is { Length: > 0 } versionOverride)
+            {
+                return (versionOverrideNode, versionOverride);
+            }
+
+            var versionNode = Project
+                .WalkBackward()
+                .OfType<PackageVersion>()
+                .FirstOrDefault(v => v.Include == IncludeOrUpdate);
+
+            if (versionNode?.Version is { Length: > 0 } version)
+            {
+                return (versionNode, version);
+            }
+        }
+        else if (Version is { Length: > 0 })
+        {
+            return (this, Version);
+        }
+
+        return null;
+    }
+
+    /// <summary>Resolves the version taking CPM into account.</summary>
+    public string? ResolveVersion()
+        => ResolveVersionVerbose()?.Version;
+
+    public CachedPackage? ResolveCachedPackage()
+        => PackageCache.GetPackage(IncludeOrUpdate, ResolveVersion());
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/Analyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Analyzer.cs
@@ -15,6 +15,9 @@ public sealed record Analyzer : Package
     public bool IsAnalyzerFor(AssemblyIdentity assembly)
         => IsAnalyzerFor(assembly.Name);
 
+    public bool IsAnalyzerFor(CachedPackage pkg)
+        => IsAnalyzerFor(pkg.Name);
+
     public bool IsAnalyzerFor(PackageReferenceBase reference)
         => IsAnalyzerFor(reference.IncludeOrUpdate);
 

--- a/src/DotNetProjectFile.Analyzers/NuGet/Analyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Analyzer.cs
@@ -12,8 +12,14 @@ public sealed record Analyzer : Package
     public bool IsApplicable(string compilationLanguage)
         => Language is null || Language == compilationLanguage;
 
-    public bool IsMatch(AssemblyIdentity assembly)
-        => assembly.Name.StartsWith(Match, StringComparison.OrdinalIgnoreCase)
-        && (assembly.Name.Length == Match.Length
-            || assembly.Name[Match.Length] == '.');
+    public bool IsAnalyzerFor(AssemblyIdentity assembly)
+        => IsAnalyzerFor(assembly.Name);
+
+    public bool IsAnalyzerFor(PackageReferenceBase reference)
+        => IsAnalyzerFor(reference.IncludeOrUpdate);
+
+    public bool IsAnalyzerFor(string name)
+        => name.StartsWith(Match, StringComparison.OrdinalIgnoreCase)
+        && (name.Length == Match.Length
+            || name[Match.Length] == '.');
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/CachedPackage.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/CachedPackage.cs
@@ -1,4 +1,5 @@
 using DotNetProjectFile.Licensing;
+using DotNetProjectFile.NuGet.Packaging;
 
 namespace DotNetProjectFile.NuGet;
 
@@ -25,4 +26,6 @@ public sealed record CachedPackage
     public required string? LicenseUrl { get; init; }
 
     public required LicenseExpression License { get; init; }
+
+    public required NuSpecFile? NuSpec { get; init; }
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
@@ -124,7 +124,7 @@ public static class PackageCache
             Directory = versionDir,
             HasAnalyzerDll = HasDllFiles("analyzers"),
             HasRuntimeDll = HasDllFiles("lib") || HasDllFiles("runtimes"),
-            HasDependencies = nuspec?.Metadata?.Depedencies?.SelectMany(d => d.Dependencies ?? [])?.Any() ?? false,
+            HasDependencies = nuspec?.Metadata?.Depedencies?.SelectMany(d => d.Dependencies ?? [])?.Any() is true,
             IsDevelopmentDependency = nuspec?.Metadata?.DevelopmentDependency,
             LicenseExpression = licenseExpression,
             LicenseFile = licenseFile,

--- a/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
@@ -124,12 +124,13 @@ public static class PackageCache
             Directory = versionDir,
             HasAnalyzerDll = HasDllFiles("analyzers"),
             HasRuntimeDll = HasDllFiles("lib") || HasDllFiles("runtimes"),
-            HasDependencies = nuspec?.Metadata.Depedencies.Length > 0,
-            IsDevelopmentDependency = nuspec?.Metadata.DevelopmentDependency,
+            HasDependencies = nuspec?.Metadata?.Depedencies?.SelectMany(d => d.Dependencies ?? [])?.Any() ?? false,
+            IsDevelopmentDependency = nuspec?.Metadata?.DevelopmentDependency,
             LicenseExpression = licenseExpression,
             LicenseFile = licenseFile,
-            LicenseUrl = nuspec?.Metadata.LicenseUrl,
+            LicenseUrl = nuspec?.Metadata?.LicenseUrl,
             License = license,
+            NuSpec = nuspec,
         };
 
         bool HasDllFiles(string subDir)

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
@@ -57,6 +57,7 @@ public sealed class Packages : IReadOnlyCollection<Package>
         new Analyzer("WpfAnalyzers"),
 
         // Specific analyzers
+        new Analyzer("AwesomeAssertions.Analyzers", "AwesomeAssertions"),
         new Analyzer("Ardalis.ApiEndpoints.CodeAnalyzers", "Ardalis.ApiEndpoints"),
         new Analyzer("FakeItEasy.Analyzer.CSharp", "FakeItEasy", LanguageNames.CSharp),
         new Analyzer("FakeItEasy.Analyzer.VisualBasic", "FakeItEasy", LanguageNames.VisualBasic),
@@ -66,7 +67,7 @@ public sealed class Packages : IReadOnlyCollection<Package>
         new Analyzer("MassTransit.Analyzers", "MassTransit"),
         new Analyzer("MessagePackAnalyzer", "MessagePack"),
         new Analyzer("MessagePipe.Analyzer", "MessagePipe"),
-        new Analyzer("Microsoft.AspNetCore.Components.Analyzers", "Microsoft.AspNetCore"),
+        new Analyzer("Microsoft.AspNetCore.Components.Analyzers", "Microsoft.AspNetCore.Components"),
         new Analyzer("Microsoft.Azure.Functions.Analyzers", "Microsoft.Azure.Functions"),
         new Analyzer("Microsoft.CodeAnalysis.Analyzers", "Microsoft.CodeAnalysis"),
         new Analyzer("Microsoft.EntityFrameworkCore.Analyzers", "Microsoft.EntityFrameworkCore"),

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
@@ -76,10 +76,10 @@ public sealed class Packages : IReadOnlyCollection<Package>
         new Analyzer("Moq.Analyzers", "Moq"),
         new Analyzer("NSubstitute.Analyzers.CSharp", "NSubstitute", LanguageNames.CSharp),
         new Analyzer("NSubstitute.Analyzers.VisualBasic", "NSubstitute", LanguageNames.VisualBasic),
-        new Analyzer("NUnit.Analyzers", "NUnit"),
+        new Analyzer("NUnit.Analyzers", "nunit.framework"),
         new Analyzer("RuntimeContracts.Analyzer", "RuntimeContracts"),
         new Analyzer("SerilogAnalyzer", "Serilog"),
-        new Analyzer("xunit.analyzers", "xunit"),
+        new Analyzer("xunit.analyzers", "xunit.core"),
         new Analyzer("ZeroFormatter.Analyzer", "ZeroFormatter"),
 
         // Source generators

--- a/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Packages.cs
@@ -76,10 +76,10 @@ public sealed class Packages : IReadOnlyCollection<Package>
         new Analyzer("Moq.Analyzers", "Moq"),
         new Analyzer("NSubstitute.Analyzers.CSharp", "NSubstitute", LanguageNames.CSharp),
         new Analyzer("NSubstitute.Analyzers.VisualBasic", "NSubstitute", LanguageNames.VisualBasic),
-        new Analyzer("NUnit.Analyzers", "nunit.framework"),
+        new Analyzer("NUnit.Analyzers", "NUnit"),
         new Analyzer("RuntimeContracts.Analyzer", "RuntimeContracts"),
         new Analyzer("SerilogAnalyzer", "Serilog"),
-        new Analyzer("xunit.analyzers", "xunit.core"),
+        new Analyzer("xunit.analyzers", "xunit"),
         new Analyzer("ZeroFormatter.Analyzer", "ZeroFormatter"),
 
         // Source generators


### PR DESCRIPTION
Closes #391

Also includes logic to resolve transitive dependencies from package references, which can be used for extending the license analyzers later on.