### PR TITLE
Report issues on root node only on start element

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_attribute_checks.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_attribute_checks.cs
@@ -14,7 +14,8 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0251", "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 07, 22));
+        .HasIssues(Issue.WRN("Proj0251", "Define the <ApiCompatEnableRuleAttributesMustMatch> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'")
+        .WithSpan(00, 00, 00, 32));
 
     [Test]
     public void on_disabled_property() => new EnableApiCompatibilityAttributeChecks()

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_parameter_name_checks.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_api_compatibility_parameter_name_checks.cs
@@ -14,7 +14,8 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0252", "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 07, 22));
+        .HasIssues(Issue.WRN("Proj0252", "Define the <ApiCompatEnableRuleCannotChangeParameterName> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'")
+        .WithSpan(00, 00, 00, 32));
 
     [Test]
     public void on_disabled_property() => new EnableApiCompatibilityParameterNameChecks()

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_baseline_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_baseline_validation.cs
@@ -16,7 +16,8 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0247", "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 09, 22));
+        .HasIssues(Issue.WRN("Proj0247", "Define the <EnableStrictModeForBaselineValidation> node with value 'true' or remove the <PackageValidationBaselineVersion> node or remove the <EnablePackageValidation> node with value 'true'")
+        .WithSpan(00, 00, 00, 32));
 
     [Test]
     public void on_disabled_property() => new EnableStrictModeForPackageBaselineValidation()

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_framework_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_strict_mode_for_package_framework_validation.cs
@@ -14,7 +14,8 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 07, 22));
+        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'")
+        .WithSpan(00, 00, 00, 32));
 
     [Test]
     public void on_disabled_property() => new EnableStrictModeForPackageFrameworkCompatibilityValidation()
@@ -29,7 +30,8 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(05, 16, 05, 122));
+        .HasIssues(Issue.WRN("Proj0249", "Define the <EnableStrictModeForCompatibleFrameworksInPackage> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'")
+        .WithSpan(05, 16, 05, 122));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_SBOM.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_SBOM.cs
@@ -6,7 +6,7 @@ public class Reports
     public void on_missing_property() => new GenerateSbom()
         .ForProject("PackageWithoutSBOM.cs")
         .HasIssue(Issue.WRN("Proj0243", "Enable SBOM generation with <GenerateSBOM> is 'true' or define the <IsPackable> node with value 'false'")
-        .WithSpan(00, 00, 11, 10));
+        .WithSpan(00, 00, 00, 32));
 
 
     [Test]

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_api_compatibility_suppression_file.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_api_compatibility_suppression_file.cs
@@ -14,7 +14,8 @@ public class Reports
 
             </Project>
         ")
-        .HasIssues(Issue.WRN("Proj0250", "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'").WithSpan(00, 00, 07, 22));
+        .HasIssues(Issue.WRN("Proj0250", "Define the <ApiCompatGenerateSuppressionFile> node with value 'true' or remove the <EnablePackageValidation> node with value 'true'")
+        .WithSpan(00, 00, 00, 32));
 
     [Test]
     public void on_disabled_property() => new GenerateApiCompatibilitySuppressionFile()

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_documentation_file.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Generate_documentation_file.cs
@@ -6,7 +6,7 @@ public class Reports
     public void on_missing_property() => new EnableGenerateDocumentationFile()
         .ForProject("GenerateDocumentationFileMissing.cs")
         .HasIssue(Issue.WRN("Proj0244", "Define the <GenerateDocumentationFile> node with value 'true' or define the <DocumentationFile> node with a valid file path or define the <IsPackable> node with value 'false'")
-        .WithSpan(00, 00, 07, 10));
+        .WithSpan(00, 00, 00, 32));
 
 
     [Test]

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Require_SDK.cs
@@ -7,14 +7,14 @@ public class Reports
         => new TestProjectsRequireSdk()
         .ForProject("TestProjectWithoutSdk.cs")
         .HasIssue(Issue.WRN("Proj0452", @"Include <PackageReference Include=""Microsoft.NET.Test.Sdk"" PrivateAssets =""all"" />")
-        .WithSpan(00, 00, 11, 10));
+        .WithSpan(00, 00, 00, 32));
 
     [Test]
     public void SDK_without_test_project()
         => new TestProjectsRequireSdk()
         .ForProject("TestSdkOnly.cs")
         .HasIssue(Issue.WRN("Proj0453", "Set <IsTestProject> to true")
-        .WithSpan(00, 00, 14, 10));
+        .WithSpan(00, 00, 00, 32));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_packable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_packable.cs
@@ -14,7 +14,7 @@ public class Reports
         => new TestProjectShouldNotBePackable()
         .ForProject("ImplicitPackablePublishableTestProject.cs")
         .HasIssue(Issue.WRN("Proj0450", "Set <IsPackable> to false")
-        .WithSpan(00, 00, 15, 10));
+        .WithSpan(00, 00, 00, 32));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_publishable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/Should_not_be_publishable.cs
@@ -14,7 +14,7 @@ public class Reports
         => new TestProjectShouldNotBePublishable()
         .ForProject("ImplicitPackablePublishableTestProject.cs")
         .HasIssue(Issue.WRN("Proj0451", "Set <IsPublishable> to false")
-        .WithSpan(00, 00, 15, 10));
+        .WithSpan(00, 00, 00, 32));
 }
 
 public class Guards

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/TUnit_usage.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Test projects/TUnit_usage.cs
@@ -37,7 +37,7 @@ public class Reports
 
 </Project>")
         .HasIssue(Issue.WRN("Proj1103", "Set <OutputType> to exe to run the TUnit tests")
-        .WithSpan(00, 00, 11, 10));
+        .WithSpan(00, 00, 00, 32));
 
     [Test]
     public void on_projects_with_test_SDK() => new TUnitUsage()

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ProjectFileAnalysisContext.cs
@@ -35,7 +35,11 @@ public readonly struct ProjectFileAnalysisContext<TFile>(
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, XmlAnalysisNode node, params object?[]? messageArgs)
-        => ReportDiagnostic(descriptor, node.Locations.FullSpan, messageArgs);
+        => ReportDiagnostic(
+            descriptor,
+            node.Element.Parent is null ? node.Locations.StartElement : node.Locations.FullSpan,
+            messageArgs);
+
 
     /// <summary>Reports a diagnostic about the project file.</summary>
     public void ReportDiagnostic(DiagnosticDescriptor descriptor, ProjectFile file, LinePositionSpan span, params object?[]? messageArgs)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -65,6 +65,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
+- Report issues on root node only on start element.
 - Proj0036: Remove None when redundant. (NEW RULE)
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
 - Proj0214: Severity to INFO as it is considered too opinionated. (UPDATE)


### PR DESCRIPTION
With this change you'll only see issue wiggles for the start element, instead of the whole document when reporting on the root node. So:

``` XML
<Project>
^^^^^^^^^
  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
  </PropertyGroup>
</Project>
```

Instead of

``` XML
<Project>
^^^^^^^^^
  <PropertyGroup>
^^^^^^^^^^^^^^^^^
    <TargetFramework>net8.0</TargetFramework>
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  </PropertyGroup>
^^^^^^^^^^^^^^^^^^
</Project>
^^^^^^^^^^
```