### PR TITLE
Fix missing package names in warnings when reference is an update instead of include

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageReferenceAssetsAsAttributes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageReferenceAssetsAsAttributes.cs
@@ -12,7 +12,7 @@ public sealed class DefinePackageReferenceAssetsAsAttributes() : MsBuildProjectF
         foreach (var reference in context.File.ItemGroups
             .Children<PackageReference>(HasAssetsElement))
         {
-            context.ReportDiagnostic(Descriptor, reference, reference.Include);
+            context.ReportDiagnostic(Descriptor, reference, reference.IncludeOrUpdate);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ExcludePrivateAssetDependencies.cs
@@ -18,7 +18,7 @@ public sealed class ExcludePrivateAssetDependencies() : MsBuildProjectFileAnalyz
         foreach (var reference in context.File.ItemGroups
             .Children<PackageReference>(ShoudBePrivateAssets))
         {
-            context.ReportDiagnostic(Descriptor, reference, reference.Include);
+            context.ReportDiagnostic(Descriptor, reference, reference.IncludeOrUpdate);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/GlobalPackageReferencesAreMeantForPrivateAssetsOnly.cs
@@ -16,7 +16,7 @@ public sealed class GlobalPackageReferencesAreMeantForPrivateAssetsOnly()
         foreach (var reference in context.File.ItemGroups
             .Children<GlobalPackageReference>(NoPrivateAsset))
         {
-            context.ReportDiagnostic(Descriptor, reference, reference.Include);
+            context.ReportDiagnostic(Descriptor, reference, reference.IncludeOrUpdate);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveUnusedPackageVersions.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveUnusedPackageVersions.cs
@@ -23,7 +23,7 @@ public sealed class RemoveUnusedPackageVersions() : MsBuildProjectFileAnalyzer(R
         foreach (var version in packages.ItemGroups
             .Children<PackageVersion>(i => i.Include is { Length: > 0 } && !usages.Contains(i.Include)))
         {
-            context.ReportDiagnostic(Descriptor, version, version.Include);
+            context.ReportDiagnostic(Descriptor, version, version.IncludeOrUpdate);
         }
     }
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
@@ -49,11 +49,11 @@ public sealed class ThirdPartyLicenseResolver() : MsBuildProjectFileAnalyzer(
         {
             if (licenses.FirstOrDefault(l => l.IsMatch(reference)) is not { } license)
             {
-                context.ReportDiagnostic(Rule.CustomPackageLicenseUnknown, reference, reference.Include, customLicense.Hash);
+                context.ReportDiagnostic(Rule.CustomPackageLicenseUnknown, reference, reference.IncludeOrUpdate, customLicense.Hash);
             }
             else if (license.Hash != customLicense.Hash)
             {
-                context.ReportDiagnostic(Rule.CustomPackageLicenseHasChanged, license, reference.Include, customLicense.Hash);
+                context.ReportDiagnostic(Rule.CustomPackageLicenseHasChanged, license, reference.IncludeOrUpdate, customLicense.Hash);
             }
         }
         else if (!packageLicense.CompatibleWith(projectLicense))

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -65,9 +65,14 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
+- Proj0005: Fixed missing package name when reference was using Update instead of Include. (BUG)
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+- Proj0502: Fixed missing package name when reference was using Update instead of Include. (BUG)
+- Proj0809: Fixed missing package name when reference was using Update instead of Include. (BUG)
+- Proj0810: Fixed missing package name when reference was using Update instead of Include. (BUG)
 - Proj0503: Package license is unknown. (NEW RULE)
 - Proj0504: Package license has changed. (NEW RULE)
+- Proj1200: Fixed missing package name when reference was using Update instead of Include. (BUG)
 v1.5.11
 - Report issues on root node only on start element.
 - Proj0026: Stop reporting on conditonal properties. (FP)


### PR DESCRIPTION
Closes #412 