### PR TITLE
Proj0039: Treat all warnings as errors is considered a bad practice

### DIFF
--- a/globalconfig.verified.txt
+++ b/globalconfig.verified.txt
@@ -36,6 +36,7 @@ dotnet_diagnostic.Proj0035.severity = warning    # Remove deprecated RestoreProj
 dotnet_diagnostic.Proj0036.severity = warning    # Remove None when redundant
 dotnet_diagnostic.Proj0037.severity = none       # Exclude runtime when all assets are private
 dotnet_diagnostic.Proj0038.severity = warning    # Fully specify NoWarn rule IDs
+dotnet_diagnostic.Proj0039.severity = warning    # Treat all warnings as errors is considered a bad practice
 dotnet_diagnostic.Proj0200.severity = warning    # Define the project packability explicitly
 dotnet_diagnostic.Proj0201.severity = warning    # Define the project version explicitly
 dotnet_diagnostic.Proj0202.severity = warning    # Define the project description explicitly

--- a/projects/ProjectReferenceMissingInclude/ProjectReferenceMissingInclude.csproj
+++ b/projects/ProjectReferenceMissingInclude/ProjectReferenceMissingInclude.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/specs/Benchmarks/Benchmarks.csproj
+++ b/specs/Benchmarks/Benchmarks.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.10.0" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.3" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -27,14 +27,14 @@
   </ItemGroup>
 
   <ItemGroup Label="Test tools">
-    <PackageReference Include="AwesomeAssertions" Version="8.0.1" />
+    <PackageReference Include="AwesomeAssertions" Version="8.0.2" />
     <PackageReference Include="CodeAnalysis.TestTools" Version="3.0.1" />
-    <PackageReference Include="NuGet.Common" Version="6.12.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.12.1" />
-    <PackageReference Include="NuGet.Packaging" Version="6.12.1" />
+    <PackageReference Include="NuGet.Common" Version="6.13.2" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.13.2" />
+    <PackageReference Include="NuGet.Packaging" Version="6.13.2" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="Verify" Version="28.13.0" />
-    <PackageReference Include="Verify.NUnit" Version="28.13.0" />
+    <PackageReference Include="Verify" Version="28.16.0" />
+    <PackageReference Include="Verify.NUnit" Version="28.16.0" />
   </ItemGroup>
 
   <ItemGroup Label="Build tools">

--- a/specs/DotNetProjectFile.Analyzers.Specs/Licensing/LicenseTexts/Manual/NET_Library_EULA_ENU/web_without_french.txt
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Licensing/LicenseTexts/Manual/NET_Library_EULA_ENU/web_without_french.txt
@@ -1,4 +1,4 @@
-﻿MICROSOFT SOFTWARE LICENSE TERMS
+MICROSOFT SOFTWARE LICENSE TERMS
 MICROSOFT .NET LIBRARY
 These license terms are an agreement between Microsoft Corporation (or based on where you live, one
 of its affiliates) and you. They apply to the software named above. The terms also apply to any Microsoft

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/ThirdPartyLicensence_compliance.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.MS_Build.ThirdPartyLicensence_compliance;
+namespace Rules.MS_Build.ThirdPartyLicensence_compliance;
 
 public class Reports
 {

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Treat_warnings_as_warnings.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Treat_warnings_as_warnings.cs
@@ -3,7 +3,7 @@ namespace Rules.MS_Build.Treat_warnings_as_warnings;
 public class Reports
 {
     [Test]
-    public void when_property_is_defined() => new TreatWarningsAsWarnings()
+    public void when_treat_all_warnings_is_enabled() => new TreatWarningsAsWarnings()
        .ForInlineCsproj(@"<Project Sdk=""Microsoft.NET.Sdk"">
 
   <PropertyGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Treat_warnings_as_warnings.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Treat_warnings_as_warnings.cs
@@ -1,0 +1,26 @@
+namespace Rules.MS_Build.Treat_warnings_as_warnings;
+
+public class Reports
+{
+    [Test]
+    public void when_property_is_defined() => new TreatWarningsAsWarnings()
+       .ForInlineCsproj(@"<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>")
+       .HasIssue(Issue.WRN("Proj0039", "Treat all warnings as errors is considered a bad practice")
+       .WithSpan(04, 04, 04, 55));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new TreatWarningsAsWarnings()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -63,7 +63,9 @@ v1.5.0
   </ItemGroup>
 
   <ItemGroup Label="Props and targets">
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.1" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Sbom.Targets" Version="3.1.0" PrivateAssets="all" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TreatWarningsAsWarnings.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/TreatWarningsAsWarnings.cs
@@ -1,0 +1,16 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+/// <summary>Implements <see cref="Rule.TreatWarningsAsWarnings"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class TreatWarningsAsWarnings() : MsBuildProjectFileAnalyzer(Rule.TreatWarningsAsWarnings)
+{
+    /// <inheritdoc />
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        foreach (var property in context.File.PropertyGroups
+            .Children<TreatWarningsAsErrors>().Where(p => p.Value is true))
+        {
+            context.ReportDiagnostic(Descriptor, property);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -62,17 +62,23 @@
 
   <PropertyGroup Label="Version and release notes">
     <Version>1.5.11</Version>
-    <PackageReleaseNotes>
+    <ToBeReleased>
       <![CDATA[
-ToBeReleased:
-- Proj0005: Fixed missing package name when reference was using Update instead of Include. (BUG)
+ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+v1.6.0
+- Proj0005: Fixed missing package name when reference was using Update instead of Include. (BUG)
+- Proj0039: Treat all warnings as errors is considered a bad practice. (NEW RULE)
 - Proj0502: Fixed missing package name when reference was using Update instead of Include. (BUG)
 - Proj0809: Fixed missing package name when reference was using Update instead of Include. (BUG)
 - Proj0810: Fixed missing package name when reference was using Update instead of Include. (BUG)
 - Proj0503: Package license is unknown. (NEW RULE)
 - Proj0504: Package license has changed. (NEW RULE)
 - Proj1200: Fixed missing package name when reference was using Update instead of Include. (BUG)
+      ]]>
+    </ToBeReleased>
+    <PackageReleaseNotes>
+      <![CDATA[
 v1.5.11
 - Report issues on root node only on start element.
 - Proj0026: Stop reporting on conditonal properties. (FP)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />
 

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />
 
@@ -31,6 +31,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
+
+  <ItemGroup Label="Not Used yet, so exclude">
+    <Compile Remove ="Antlr4/**/*.cs" />
+  </ItemGroup>
 
   <ItemGroup Label="Package files">
     <None Update="tools/*.ps1" Pack="true" PackagePath="/" />

--- a/src/DotNetProjectFile.Analyzers/MsBuild/TreatWarningsAsErrors.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/TreatWarningsAsErrors.cs
@@ -1,0 +1,5 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class TreatWarningsAsErrors(XElement element, Node parent, MsBuildProject project)
+    : Node<bool?>(element, parent, project)
+{ }

--- a/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
@@ -1,3 +1,5 @@
+#pragma warning disable RS1035 // Do not use APIs banned for analyzers
+// Environment is required to run this logic
 using DotNetProjectFile.Licensing;
 using DotNetProjectFile.NuGet.Packaging;
 using System.Collections.Concurrent;

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -40,6 +40,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0036** Remove None when redundant](https://dotnet-project-file-analyzers.github.io/rules/Proj0036.html)
 * [**Proj0037** Exclude runtime when all assets are private](https://dotnet-project-file-analyzers.github.io/rules/Proj0037.html)
 * [**Proj0038** Fully specify NoWarn rule IDs](https://dotnet-project-file-analyzers.github.io/rules/Proj0038.html)
+* [**Proj0039** Treat all warnings as errors is considered a bad practice](https://dotnet-project-file-analyzers.github.io/rules/Proj0039.html)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](https://dotnet-project-file-analyzers.github.io/rules/Proj0200.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -353,6 +353,17 @@ public static partial class Rule
         tags: ["ruleID"],
         category: Category.Clarity);
 
+    public static DiagnosticDescriptor TreatWarningsAsWarnings => New(
+        id: 0039,
+        title: "Treat all warnings as errors is considered a bad practice",
+        message: "Treat all warnings as errors is considered a bad practice",
+        description:
+            "How tempting this may feel to treat all warnings as erors, there " +
+            "are objections to consider. Because such a policy might be " +
+            "counterproductive.",
+        tags: ["error", "warning", "TreatWarningsAsErrors"],
+        category: Category.CodeQuality);
+
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,
         title: "Define the project packability explicitly",


### PR DESCRIPTION
Closes #405 

For documentation see: https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers.github.io/pull/109