### PR TITLE
Report license isssues only via project files

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
@@ -13,6 +13,9 @@ public sealed class ThirdPartyLicenseResolver() : MsBuildProjectFileAnalyzer(
     Rule.CustomPackageLicenseHasChanged)
 {
     /// <inheritdoc />
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    /// <inheritdoc />
     public override bool DisableOnFailingImport => false;
 
     /// <inheritdoc />

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -83,6 +83,7 @@ ToBeDecided:
 v1.6.1
 - Proj0040: Fix capitalization of <NuGetAuditMode> in message. (BUG)
 - Proj0044: Allow build agent specific conditions for setting RestorePackagesWithLockFile. (FP)
+- Proj050*: Only report on project files, not props. (FP)
 - Proj0508: Order third-party licenses alphabetically. (NEW RULE)
 - Proj0807: <TrirdPartyLicense> is allowed in Directory.Packages.props. (FP)
 ]]>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ProjectFileType.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ProjectFileType.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 namespace DotNetProjectFile.MsBuild;
 
 public enum ProjectFileType


### PR DESCRIPTION
By doing so, it reduces the number of issues that is reported multiple times.