### PR TITLE
Verify third-party licenses on package info

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Third_Party_license_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Third_Party_license_compliance.cs
@@ -181,12 +181,34 @@ public class Reports
 </Project>")
        .HasIssue(Issue.WRN("Proj0507", "The <ThirdPartyLicense> can not be conditional")
        .WithSpan(07, 04, 07, 72));
-
 }
 
 public class Guards
 {
-     [Test]
+    [Test]
+    public void transient_dependencies_with_custom_license() => new ThirdPartyLicenseResolver()
+    .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+    <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""MongoDB.Driver.Core"" Version=""2.30.0"" />
+  </ItemGroup>
+
+  <ItemGroup Label=""Custom licenses"">
+    <ThirdPartyLicense Include=""MongoDB.Libmongocrypt"" Hash=""H+71D1Qif9a+jKUWZKrMdQ"" />
+    <ThirdPartyLicense Include=""Snappier"" Hash=""v2I091CLKicpyApWDF77iQ"" />
+  </ItemGroup>
+
+</Project>")
+    .HasIssues(
+        Issue.WRN("Proj0500", "The SharpCompress (0.30.1) transitive package is shipped without an explicitly defined license"),
+        Issue.WRN("Proj0501", "The AWSSDK.SecurityToken (3.7.100.14) transitive package only contains a deprecated 'http://aws.amazon.com/apache2.0/' license URL"));
+
+    [Test]
     public void license_urls() => new ThirdPartyLicenseResolver()
       .ForInlineCsproj(@"
 <Project Sdk=""Microsoft.NET.Sdk"">

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Third_Party_license_compliance.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Third_Party_license_compliance.cs
@@ -186,7 +186,7 @@ public class Reports
 
 public class Guards
 {
-    [Test]
+     [Test]
     public void license_urls() => new ThirdPartyLicenseResolver()
       .ForInlineCsproj(@"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -237,7 +237,6 @@ public class Guards
 
 </Project>")
         .HasNoIssues();
-
 
     [TestCase("CompliantCSharp.cs")]
     [TestCase("CompliantCSharpPackage.cs")]

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <PackageReleaseNotes>
       <![CDATA[
 v1.5.10.1

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ThirdPartyLicenseResolver.cs
@@ -84,7 +84,7 @@ public sealed class ThirdPartyLicenseResolver() : MsBuildProjectFileAnalyzer(
         }
         else if (package.License is CustomLicense customLicense)
         {
-            if (licenses.FirstOrDefault(l => l.IsMatch(dependency.Node)) is not { } license)
+            if (licenses.FirstOrDefault(l => l.IsMatch(dependency.Info)) is not { } license)
             {
                 context.ReportDiagnostic(
                     Rule.CustomPackageLicenseUnknown,

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -76,11 +76,15 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <ToBeReleased>
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+]]>
+    </ToBeReleased>
+    <PackageReleaseNotes>
+      <![CDATA[
 v1.6.1
 - Proj0040: Fix capitalization of <NuGetAuditMode> in message. (BUG)
 - Proj0044: Allow build agent specific conditions for setting RestorePackagesWithLockFile. (FP)
@@ -88,10 +92,6 @@ v1.6.1
 - Proj0504: Verify third-party licenses on package info, not on the package reference node. (FP)
 - Proj0508: Order third-party licenses alphabetically. (NEW RULE)
 - Proj0807: <TrirdPartyLicense> is allowed in Directory.Packages.props. (FP)
-]]>
-    </ToBeReleased>
-    <PackageReleaseNotes>
-      <![CDATA[
 v1.6.0
 - Proj0502: Fixed missing package name when reference was using Update instead of Include. (BUG)
 - Proj0503: Package license is unknown. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -85,6 +85,7 @@ v1.6.1
 - Proj0040: Fix capitalization of <NuGetAuditMode> in message. (BUG)
 - Proj0044: Allow build agent specific conditions for setting RestorePackagesWithLockFile. (FP)
 - Proj050*: Only report on project files, not props. (FP)
+- Proj0504: Verify third-party licenses on package info, not an the package reference node. (FP)
 - Proj0508: Order third-party licenses alphabetically. (NEW RULE)
 - Proj0807: <TrirdPartyLicense> is allowed in Directory.Packages.props. (FP)
 ]]>

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -85,7 +85,7 @@ v1.6.1
 - Proj0040: Fix capitalization of <NuGetAuditMode> in message. (BUG)
 - Proj0044: Allow build agent specific conditions for setting RestorePackagesWithLockFile. (FP)
 - Proj050*: Only report on project files, not props. (FP)
-- Proj0504: Verify third-party licenses on package info, not an the package reference node. (FP)
+- Proj0504: Verify third-party licenses on package info, not on the package reference node. (FP)
 - Proj0508: Order third-party licenses alphabetically. (NEW RULE)
 - Proj0807: <TrirdPartyLicense> is allowed in Directory.Packages.props. (FP)
 ]]>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ThirdPartyLicense.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ThirdPartyLicense.cs
@@ -1,3 +1,4 @@
+using DotNetProjectFile.NuGet;
 using DotNetProjectFile.Text;
 
 namespace DotNetProjectFile.MsBuild;
@@ -11,14 +12,12 @@ public sealed class ThirdPartyLicense(XElement element, Node parent, MsBuildProj
 
     public string? Hash => Attribute();
 
-    public bool IsMatch(PackageReferenceBase refererence)
+    public bool IsMatch(PackageVersionInfo info)
         => Glob.TryParse(Include) is { } glob
-        && glob.IsMatch(refererence.Include!)
-        && VersionMatch(refererence);
+        && glob.IsMatch(info.Name)
+        && VersionMatch(info);
 
-    private bool VersionMatch(PackageReferenceBase refererence)
+    private bool VersionMatch(PackageVersionInfo info)
         => Version is null
-        || (refererence.Version == Version
-        || (refererence is PackageReference { VersionOverride.Length: > 0 } package
-        && package.VersionOverride == Version));
+        || info.Version == Version;
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/PackageCache.cs
@@ -56,11 +56,6 @@ public static class PackageCache
         var name = info.Name.ToLowerInvariant();
         var version = info.Version?.ToLowerInvariant();
 
-        if(name == "system.diagnostics.tools")
-        {
-
-        }
-
         if (cache.TryGetValue(info, out var result))
         {
             return result;


### PR DESCRIPTION
To check if there is a matching third-party license the code checked for the `<PackageReference>` info, which should match the reference, but logically *not* the transient dependency.

Closes #455 