### PR TITLE
Fix Proj0240 message incorrectly suggesting to disable DevelopmentDependency, rather than to enable it

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_package_validation.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Enable_package_validation.cs
@@ -7,14 +7,14 @@ public class Reports
        => new EnablePackageValidation()
        .ForProject("EmptyProject.cs")
        .HasIssue(
-           Issue.WRN("Proj0240", "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'"));
+           Issue.WRN("Proj0240", "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'true'"));
 
     [Test]
     public void on_disabled()
        => new EnablePackageValidation()
        .ForProject("PackageValidationDisabled.cs")
        .HasIssue(
-           Issue.WRN("Proj0240", "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'"));
+           Issue.WRN("Proj0240", "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'true'"));
 }
 
 public class Guards

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -81,6 +81,8 @@
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+v1.6.2
+- Proj0240: Fix message incorrectly suggesting to disable DevelopmentDependency, rather than to enable it. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -643,7 +643,7 @@ public static partial class Rule
     public static DiagnosticDescriptor EnablePackageValidation => New(
         id: 0240,
         title: "Enable package validation",
-        message: "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'false'",
+        message: "Define the <EnablePackageValidation> node with value 'true' or define the <IsPackable> node with value 'false' or define the <DevelopmentDependency> node with value 'true'",
         description:
             "To ensure the (backwards) compatibility " +
             "of the API surface of your package, it is advised " +


### PR DESCRIPTION
Development dependencies most likely don't need to have a consistent API, so that would make more sense. The analyzer implementation already behaves like this, so it was most likely a typo or copy-paste error in the message text.