### PR TITLE
New Rule: SymbolPackageFormat snupkg requires DebugType to be portable

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/SymbolPackageFormat_snupkg_requires_DebugType_portable.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/SymbolPackageFormat_snupkg_requires_DebugType_portable.cs
@@ -1,0 +1,57 @@
+namespace Rules.MS_Build.SymbolPackageFormat_snupkg_requires_DebugType_portable;
+
+public class Reports
+{
+    [Test]
+    public void on_not_defined_debug_type() => new SymbolPackageFormatSNupkgRequiresDebugTypePortable()
+        .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+</Project>")
+        .HasIssues(Issue.WRN("Proj0218", "The <SymbolPackageFormat> 'snupkg' requires <DebugType> to have the value 'portable'")
+        .WithSpan(04, 04, 04, 53));
+
+    [Test]
+    public void on_different_debug_type() => new SymbolPackageFormatSNupkgRequiresDebugTypePortable()
+        .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+</Project>")
+        .HasIssues(Issue.WRN("Proj0218", "The <SymbolPackageFormat> 'snupkg' requires <DebugType> to have the value 'portable'")
+        .WithSpan(05, 04, 05, 35));
+}
+
+public class Guards
+{
+    [TestCase("TestProject.cs")]
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project) => new SymbolPackageFormatSNupkgRequiresDebugTypePortable()
+        .ForProject(project)
+        .HasNoIssues();
+
+    [Test]
+    public void on_enabled_property() => new SymbolPackageFormatSNupkgRequiresDebugTypePortable()
+        .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+</Project>")
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/SymbolPackageFormatSNupkgRequiresDebugTypePortable.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/SymbolPackageFormatSNupkgRequiresDebugTypePortable.cs
@@ -1,0 +1,22 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+/// <summary>Implements <see cref="Rule.SymbolPackageFormatSNupkgRequiresDebugTypePortable"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class SymbolPackageFormatSNupkgRequiresDebugTypePortable()
+    : MsBuildProjectFileAnalyzer(Rule.SymbolPackageFormatSNupkgRequiresDebugTypePortable)
+{
+    public override IReadOnlyCollection<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        if (context.File.Property<SymbolPackageFormat>() is { Value: SymbolPackageFormat.Kind.snupkg } format)
+        {
+            var debugType = context.File.Property<DebugType>();
+
+            if (debugType?.Value is not DebugType.Kind.portable)
+            {
+                context.ReportDiagnostic(Descriptor, (XmlAnalysisNode?)debugType ?? format);
+            }
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -82,6 +82,7 @@
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
 v1.6.2
+- Proj0218: Symbol package format snupkg requires debug type portable. (NEW RULE)
 - Proj0240: Fix message incorrectly suggesting to disable DevelopmentDependency, rather than to enable it. (BUG)
 - Proj1001: No longer suggests to use 'Microsoft.CodeAnalysis.Analyzers' for anything in 'Microsoft.CodeAnalysis' namespace, since it's only supposed to be used for analyzing analyzers. (FP)
 - Proj1001: No longer suggests to include analyzers for analyzing other analyzers. (FP)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/DebugType.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/DebugType.cs
@@ -1,0 +1,14 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class DebugType(XElement element, Node parent, MsBuildProject project)
+    : Node<DebugType.Kind?>(element, parent, project)
+{
+    public enum Kind
+    {
+        none,
+        embedded,
+        pdbonly,
+        portable,
+        full,
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/MsBuild/SymbolPackageFormat.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/SymbolPackageFormat.cs
@@ -1,0 +1,10 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class SymbolPackageFormat(XElement element, Node parent, MsBuildProject project)
+    : Node<SymbolPackageFormat.Kind?>(element, parent, project)
+{
+    public enum Kind
+    {
+        snupkg,
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -66,6 +66,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0215** Provide a compliant NuGet package icon](https://dotnet-project-file-analyzers.github.io/rules/Proj0215.html)
 * [**Proj0216** Define the product name ID explicitly](https://dotnet-project-file-analyzers.github.io/rules/Proj0216.html)
 * [**Proj0217** Define requiring license acceptance explicitly](https://dotnet-project-file-analyzers.github.io/rules/Proj0217.html)
+* [**Proj0218** Symbol package format snupkg requires debug type portable](https://dotnet-project-file-analyzers.github.io/rules/Proj0218.html)
 * [**Proj0240** Enable package validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0240.html)
 * [**Proj0241** Enable package baseline validation](https://dotnet-project-file-analyzers.github.io/rules/Proj0241.html)
 * [**Proj0242** Generate NuGet packages conditionally](https://dotnet-project-file-analyzers.github.io/rules/Proj0242.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -640,6 +640,16 @@ public static partial class Rule
         tags: ["Configuration", "NuGet", "package", "license"],
         category: Category.Configuration);
 
+    public static DiagnosticDescriptor SymbolPackageFormatSNupkgRequiresDebugTypePortable => New(
+        id: 0218,
+        title: "Symbol package format snupkg requires debug type portable",
+        message: "The <SymbolPackageFormat> 'snupkg' requires <DebugType> to have the value 'portable'",
+        description:
+            "To ensure that symbol packages are created in the correct format, " +
+            "the DebugType should be set to 'portable'.",
+        tags: ["Configuration", "NuGet", "package", "symbols"],
+        category: Category.Configuration);
+
     public static DiagnosticDescriptor EnablePackageValidation => New(
         id: 0240,
         title: "Enable package validation",


### PR DESCRIPTION
Closes #460 