### PR TITLE
Analysis on project files are not longer executed for the SDK

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuildProjectFileAnalyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuildProjectFileAnalyzer.cs
@@ -23,9 +23,21 @@ public abstract class MsBuildProjectFileAnalyzer(
     protected override void Register(AnalysisContext context)
         => context.RegisterProjectFileAction(c =>
         {
-            if (ApplicableTo.Contains(c.File.FileType) && !(c.File.HasFailingImport && DisableOnFailingImport))
+            if (ApplicableTo.Contains(c.File.FileType)
+                && !(c.File.HasFailingImport && DisableOnFailingImport)
+                && !IsProjectFileWithinSdk(c))
             {
                 Register(c);
             }
         });
+
+    /// <remarks>
+    /// We do not want to analyze the project files witin the context of the SDK
+    /// as that is that would lead pt projects being analyzed multiple times and
+    /// potentially even to projects being analyzed that are not part of the
+    /// solution.
+    /// </remarks>
+    private static bool IsProjectFileWithinSdk(ProjectFileAnalysisContext context)
+        => context.File.FileType == ProjectFileType.ProjectFile
+        && context.Compilation.AssemblyName == ".net";
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -81,6 +81,8 @@
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+v1.7.1
+- Analysis on project files (.csproj, .vbproj) are not longer executed for the SDK. (Perfromance)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>


### PR DESCRIPTION
To be able to meta analysis on project files, all child project files (`*.csproj` and `*.vbproj`) are available as additional files, for the .net.csproj SDK.

This will trigger code to validate project files both via the build of that project file itself, as via the build of the .net.csproj SDK. The latter is undesirable, as is could potentially lead to rules evaluating incorrectly, and it also is done twice.