### PR TITLE
Add testcase for assumed FP

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Global_package_references_are_meant_fo_private_assets_only.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Global_package_references_are_meant_fo_private_assets_only.cs
@@ -3,8 +3,7 @@ namespace Rules.MS_Build.Global_package_references_are_meant_fo_private_assets_o
 public class Reports
 {
     [Test]
-    public void global_package_reference_with_runtime_dependency()
-        => new GlobalPackageReferencesAreMeantForPrivateAssetsOnly()
+    public void global_package_reference_with_runtime_dependency() => new GlobalPackageReferencesAreMeantForPrivateAssetsOnly()
         .ForProject("GlobalPackageReferenceRuntimeDependency.cs")
         .HasIssues(
             Issue.WRN("Proj0809", @"The global package reference 'Qowaiv' is not supposed to be a private asset")

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Remove_IncludeAssets_when_redundant.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Remove_IncludeAssets_when_redundant.cs
@@ -8,6 +8,28 @@ public class Reports
        .HasIssues(
            Issue.WRN("Proj0026", "Remove <IncludeAssets> as it is redundant when all assets are private" /*.*/).WithSpan(20, 04, 23, 23),
            Issue.WRN("Proj0026", "Remove IncludeAssets as it is redundant when all assets are private" /*...*/).WithSpan(24, 04, 24, 187));
+
+
+    [Test]
+    public void previously_reported_NuGet_Protocol() => new ValidatePrivateAssets()
+       .ForInlineCsproj(@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Update=""SonarAnalyzer.CSharp"">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>")
+       .HasIssues(
+           Issue.WRN("Proj0026", "Remove <IncludeAssets> as it is redundant when all assets are private").WithSpan(07, 04, 10, 23),
+           Issue.WRN("Proj0037", "ExcludeAssets should contain runtime when PrivateAssets=\"all\"" /*.*/).WithSpan(07, 04, 10, 23));
 }
 
 public class Guards


### PR DESCRIPTION
I started #477 because I thought that

``` xml
<PackageReference Update="SonarAnalyzer.CSharp">
  <PrivateAssets>all</PrivateAssets>
  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
</PackageReference>
 ```
 
 was not reported on. I was wrong. Nevertheless, I added the testcase.