### PR TITLE
Proj3000: Ignore packages.lock.json files

### DIFF
--- a/projects/MultipleEncodings/packages.lock.json
+++ b/projects/MultipleEncodings/packages.lock.json
@@ -1,0 +1,13 @@
+﻿{
+  "version": 2,
+  "dependencies": {
+    "net9.0": {
+      "SonarAnalyzer.CSharp": {
+        "type": "Direct",
+        "requested": "[10.12.0.118525, )",
+        "resolved": "10.12.0.118525",
+        "contentHash": "uP38bsYegQBk8WOM6LYIAht6hrA7tcJgep/WuifPJjhjtjysPUP/iM/c1+P2+llNIDmm1s8Xh86+WG3K71eycw=="
+      }
+    }
+  }
+}

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -43,13 +43,13 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <PackageReleaseNotes>
       <![CDATA[
 v1.5.10.1
 - Exclude generated stuff in /bin/ and /object/. (FP)
 v1.5.10
-- Automatically include props/*.props adn props/*.targets.
+- Automatically include props/*.props and props/*.targets.
 v1.5.7
 - Disable signing for .net.csproj file.
 - Include *.yml files too.

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -71,11 +71,15 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <ToBeReleased>
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+]]>
+    </ToBeReleased>
+    <PackageReleaseNotes>
+      <![CDATA[
 v1.7.1
 - Proj0045: Convention-based MSBuild file names should use correct casing. (NEW RULE)
 - Proj0046: Update statements should change state. (NEW RULE)
@@ -83,10 +87,6 @@ v1.7.1
 - Proj3000: Ignore package.lock.json files. (FP)
 - Analysis on project files (.csproj, .vbproj) are not longer executed for the SDK. (Performance)
 - Add parent package to message for issues with transitive licenses.
-]]>
-    </ToBeReleased>
-    <PackageReleaseNotes>
-      <![CDATA[
 v1.7.0
 - Proj0218: Symbol package format snupkg requires debug type portable. (NEW RULE)
 - Proj0240: Fix message incorrectly suggesting to disable DevelopmentDependency, rather than to enable it. (BUG)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -80,6 +80,7 @@ v1.7.1
 - Proj0045: Convention-based MSBuild file names should use correct casing. (NEW RULE)
 - Proj0046: Update statements should change state. (NEW RULE)
 - Proj0509: NuGet package cache could not be resolved. (NEW RULE)
+- Proj3000: Ignore package.lock.json files. (FP)
 - Analysis on project files (.csproj, .vbproj) are not longer executed for the SDK. (Performance)
 - Add parent package to message for issues with transitive licenses.
 ]]>


### PR DESCRIPTION
When generating lock files (`packages.lock.json`), Microsoft ignores preferences defined in the `.editorconfig`, hence on every new build those file get an UTF-8 BOM header (back). Reporting on this file is therefor considered a false positive and excluded as a result.