### PR TITLE
Proj5005: Omit Project ID's

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -217,6 +217,9 @@ reported a the [GibHub repository](https://github.com/dotnet-project-file-analyz
 * [**Proj4050** Header must be a GLOB](rules/Proj4050.md)
 * [**Proj4051** Use equals sign for key-value assignments](rules/Proj4051.md)
 
+## SLNX
+* [**Proj5005** Omit Project ID's](rules/Proj5005.md)
+
 ## Sonar integration
 By default, results by .NET project file analyzers are not added to Sonar's reporting. Read [here](general/sonar-integration.md) how to configure this correctly.
 

--- a/docs/navigation/editorconfig_rules.md
+++ b/docs/navigation/editorconfig_rules.md
@@ -1,6 +1,6 @@
 ---
 title: Editorconfig 
 parent: Rules
-nav_order: 4
+nav_order: 5
 permalink: /rules/editorconfig
 ---

--- a/docs/navigation/ini_rules.md
+++ b/docs/navigation/ini_rules.md
@@ -1,6 +1,6 @@
 ---
 title: INI 
 parent: Rules
-nav_order: 3
+nav_order: 4
 permalink: /rules/ini
 ---

--- a/docs/navigation/licensing.md
+++ b/docs/navigation/licensing.md
@@ -1,6 +1,6 @@
 ---
 title: Licensing
 parent: Rules
-nav_order: 4
+nav_order: 6
 permalink: /rules/licensing
 ---

--- a/docs/navigation/slnx_rules.md
+++ b/docs/navigation/slnx_rules.md
@@ -1,0 +1,6 @@
+---
+title: SLNX
+parent: Rules
+nav_order: 3
+permalink: /rules/slnx
+---

--- a/docs/rules/Proj5005.md
+++ b/docs/rules/Proj5005.md
@@ -1,0 +1,25 @@
+---
+parent: SLNX
+ancestor: Rules
+permalink: /rules/Proj5005
+---
+
+# Proj5005: Omit Project ID's
+Projects in the SLN file had an (unique) ID. In the SLNX file, this ID does not
+have any added value, and is considered noise.
+
+## Non-Compliant
+``` xml
+<Solution>
+  <Project Path=".net.csproj" />
+  <Project Path="src/MyProject/MyProject.csproj" Id="7B3656D1-98AD-45C8-826F-2E5A13BED71E" />
+</Solution>
+```
+
+## Compliant
+``` xml
+<Solution>
+  <Project Path=".net.csproj" />
+  <Project Path="src/MyProject/MyProject.csproj" />
+</Solution>
+```

--- a/docs/rules/Proj5005.md
+++ b/docs/rules/Proj5005.md
@@ -5,7 +5,7 @@ permalink: /rules/Proj5005
 ---
 
 # Proj5005: Omit Project ID's
-Projects in the SLN file had an (unique) ID. In the SLNX file, this ID does not
+Projects in the SLN file had a (unique) ID. In the SLNX file, this ID does not
 have any added value, and is considered noise.
 
 ## Non-Compliant

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Slnx/OmitProjectIds.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Slnx/OmitProjectIds.cs
@@ -1,0 +1,15 @@
+namespace DotNetProjectFile.Analyzers.Slnx;
+
+/// <summary>Implements <see cref="Rule.SLNX.OmitProjectIds"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class OmitProjectIds() : SolutionFileAnalyzer(Rule.SLNX.OmitProjectIds)
+{
+    /// <inheritdoc />
+    protected override void Register(SolutionFileAnalysisContext context)
+    {
+        foreach (var project in context.File.Projects.Where(p => p.Id is not null))
+        {
+            context.ReportDiagnostic(Descriptor, project);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -79,6 +79,7 @@ ToBeDecided:
 v.1.7.2
 - Proj0047: Label item groups that disable compilation items. (NEW RULE)
 - Proj0219: Packable projects should be libraries. (NEW RULE)
+- Proj5005: Omit Project ID's. (NEW RULE)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -166,3 +166,6 @@ The package contains analyzers that analyze .NET project files.
 ## .editorconfig
 * [**Proj4050** Header must be a GLOB](https://dotnet-project-file-analyzers.github.io/rules/Proj4050.html)
 * [**Proj4051** Use equals sign for key-value assignments](https://dotnet-project-file-analyzers.github.io/rules/Proj4051.html)
+
+## SLNX
+* [**Proj5005** Omit Project ID's](https://dotnet-project-file-analyzers.github.io/rules/Proj5005.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.SLNX.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.SLNX.cs
@@ -8,7 +8,7 @@ public static partial class Rule
             id: 5005,
             title: "Omit Project ID's",
             message: "Remove the Project ID",
-            description: "ID's are left-overs from the SLN format, and can safely be ommitted.",
+            description: "ID's are left-overs from the SLN format, and can safely be omitted.",
             tags: ["SLNX", "ID"],
             category: Category.Noise);
     }

--- a/src/DotNetProjectFile.Analyzers/Rule.SLNX.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.SLNX.cs
@@ -1,0 +1,15 @@
+namespace DotNetProjectFile;
+
+public static partial class Rule
+{
+    public static class SLNX
+    {
+        public static DiagnosticDescriptor OmitProjectIds => New(
+            id: 5005,
+            title: "Omit Project ID's",
+            message: "Remove the Project ID",
+            description: "ID's are left-overs from the SLN format, and can safely be ommitted.",
+            tags: ["SLNX", "ID"],
+            category: Category.Noise);
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Slnx/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/Slnx/Project.cs
@@ -1,4 +1,7 @@
 namespace DotNetProjectFile.Slnx;
 
 public sealed class Project(XElement element, Node parent, Solution solution)
-    : Node(element, parent, solution) { }
+    : Node(element, parent, solution)
+{
+    public string? Id => Attribute();
+}

--- a/src/DotNetProjectFile.Analyzers/Slnx/Solution.cs
+++ b/src/DotNetProjectFile.Analyzers/Slnx/Solution.cs
@@ -27,6 +27,8 @@ public sealed class Solution : Node, ProjectFile
 
     public WarningPragmas WarningPragmas { get; }
 
+    public IEnumerable<Project> Projects => Children.OfType<Project>();
+
     internal ProjectFiles ProjectFiles { get; }
 
     public static Solution Load(IOFile file, ProjectFiles projects)


### PR DESCRIPTION
Closes #425 

Creating tests for SLNX files should be as simple as creating tests for CS-Project files. Because that is not the case I left the unit test out for now, and created an issue to solve that issue (separately).