### PR TITLE
Inline any set of files as an analyzable project

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Remove_unused_package_versions.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/CPM/Remove_unused_package_versions.cs
@@ -4,7 +4,7 @@ public class Reports
 {
     [Test]
     public void project_with_unused_package_versions() => new RemoveUnusedPackageVersions()
-        .ForSDkProject("CPMWithUnusedPackageVersions")
+        .ForSdkProject("CPMWithUnusedPackageVersions")
         .HasIssues(
             Issue.WRN("Proj0810", "Remove unused <PackageVersion> 'Newtonsoft.Json'" /*.*/).WithSpan(09, 04, 09, 65),
             Issue.WRN("Proj0810", "Remove unused <PackageVersion> 'Serilog'" /*.........*/).WithSpan(11, 04, 11, 56),

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Convention_based_MsBuild_files_names_should_have_corect_casing.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Convention_based_MsBuild_files_names_should_have_corect_casing.cs
@@ -4,7 +4,7 @@ public class Reports
 {
     [Test]
     public void Faulty_casing() => new ConventionBasedMsBuildFilesNamesShouldHaveCorrectCasing()
-        .ForSDkProject("MSBuildFileNameConvention")
+        .ForSdkProject("MSBuildFileNameConvention")
         .HasIssues(
             Issue.WRN("Proj0045", "The file .editorconFIG should be named .editorconfig"/*............................*/).WithPath(".editorconFIG"),
             Issue.WRN("Proj0045", "The file .Globalconfig should be named .globalconfig"/*............................*/).WithPath(".Globalconfig"),

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/SDK/Avoid_compile_items.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/SDK/Avoid_compile_items.cs
@@ -4,7 +4,7 @@ public class Reports
 {
     [Test]
     public void SDK_with_compile_items() => new AvoidCompileItemInSdk()
-        .ForSDkProject("SdkWithCompileItems")
+        .ForSdkProject("SdkWithCompileItems")
         .HasIssue(Issue.WRN("Proj0700", "The .net.csproj SDK project should not contain <Compile> items").WithSpan(5, 04, 5, 43));
 }
 

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/SDK/Does_not_report.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/SDK/Does_not_report.cs
@@ -4,19 +4,19 @@ public class On
 {
     [Test]
     public void Missing_OutputType() => new DefineOutputType()
-        .ForSDkProject("DotnetProjectFilesSdk")
+        .ForSdkProject("DotnetProjectFilesSdk")
         .HasNoIssues();
 
     /// <remarks>Imported files can be ignored.</remarks>>
     [Test]
     public void Project_not_available_as_additional() => new AddAdditionalFile()
-        .ForSDkProject("DotnetProjectFilesSdk")
+        .ForSdkProject("DotnetProjectFilesSdk")
         .HasIssues(
             Issue.WRN("Proj0006", "Add 'DotNetProjectFile.Analyzers.Sdk.props' to the additional files"),
             Issue.WRN("Proj0006", "Add 'DotNetProjectFile.Analyzers.Sdk.targets' to the additional files"));
 
     [Test]
     public void Unresolved_Project() => new GuardUnsupported()
-        .ForSDkProject("DotnetProjectFilesSdk")
+        .ForSdkProject("DotnetProjectFilesSdk")
         .HasNoIssues();
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/SLNX/Indent_SLNX.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/SLNX/Indent_SLNX.cs
@@ -4,8 +4,21 @@ public class Reports
 {
     [Test]
     public void Faulty_indented() => new Slnx.IndentXml()
-        .ForSDkProject("SolutionFile")
+        .ForSdkProject("SolutionFile")
         .HasIssue(Issue.WRN("Proj1700", "The element <Project> has not been properly indented")
             .WithSpan(04, 00, 04, 42)
             .WithPath("faulty-indented.slnx"));
+
+    [Test]
+    public void Faulty_indented_inline() => new Slnx.IndentXml()
+        .ForInlineSlnx("""
+<Solution>
+  <Folder Name="/Solution Items/">
+    <File Path=".net.csproj" />
+  </Folder>
+<Project Path="src/SolutionFile.csproj" />
+</Solution>
+""")
+        .HasIssue(Issue.WRN("Proj1700", "The element <Project> has not been properly indented")
+            .WithSpan(04, 00, 04, 42));
 }

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/SLNX/Omit_XML_declaration.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/SLNX/Omit_XML_declaration.cs
@@ -4,7 +4,7 @@ public class Reports
 {
     [Test]
     public void XML_declaration() => new Slnx.OmitXmlDeclarations()
-       .ForSDkProject("SolutionFile")
+       .ForSdkProject("SolutionFile")
        .HasIssue(Issue.WRN("Proj1702", "Remove the XML declaration as it is redundant")
            .WithSpan(01, 00, 01, 09)
            .WithPath("with-xml-declaration.slnx"));

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/SLNX/Remove_commented_out_code.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/SLNX/Remove_commented_out_code.cs
@@ -4,7 +4,7 @@ public class Reports
 {
     [Test]
     public void commented_out_XML() => new Slnx.RemoveCommentedOutCode()
-        .ForSDkProject("SolutionFile")
+        .ForSdkProject("SolutionFile")
         .HasIssue(Issue.WRN("Proj3002", "Remove the commented-out code")
             .WithSpan(03, 06, 03, 47)
             .WithPath("with-comment.slnx"));

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/SLNX/Track_TODO_tags.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/SLNX/Track_TODO_tags.cs
@@ -4,7 +4,7 @@ public class Reports
 {
     [Test]
     public void TODO_tags() => new Slnx.TrackToDoTags()
-        .ForSDkProject("SolutionFile")
+        .ForSdkProject("SolutionFile")
         .HasIssue(Issue.WRN("Proj3001", "Complete the task associated to this \"TODO\" comment")
             .WithSpan(02, 08, 02, 34)
             .WithPath("with-todo.slnx"));

--- a/specs/DotNetProjectFile.Analyzers.Specs/TestTools/InlineProjectAnalyzerVerifyContextBuilder.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/TestTools/InlineProjectAnalyzerVerifyContextBuilder.cs
@@ -1,0 +1,133 @@
+using CodeAnalysis.TestTools.Contexts;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Specs.TestTools;
+
+internal sealed class InlineProjectAnalyzerVerifyContextBuilder
+{
+    private readonly DiagnosticAnalyzer analyzer;
+    private readonly ImmutableArray<FileDefinition> files;
+    private readonly Lazy<string> hash;
+    private readonly Lazy<ProjectAnalyzerVerifyContext> ctx;
+
+    public InlineProjectAnalyzerVerifyContextBuilder(
+        DiagnosticAnalyzer analyzer,
+        string file,
+        string? content)
+        : this(analyzer, [ToFile(file, content)])
+    {
+    }
+
+    private InlineProjectAnalyzerVerifyContextBuilder(
+        DiagnosticAnalyzer analyzer,
+        ImmutableArray<FileDefinition> files)
+    {
+        this.analyzer = analyzer;
+        this.files = files;
+        this.hash = new(() =>
+        {
+            var sb = new StringBuilder();
+            for (var i = 0; i < files.Length; i++)
+            {
+                var file = files[i];
+
+                sb.AppendLine(i.ToString(CultureInfo.InvariantCulture));
+                sb.AppendLine(file.Name);
+                sb.AppendLine(file.Content);
+                sb.AppendLine();
+            }
+            var content = sb.ToString();
+            var h = GetHash(content);
+            return h;
+        });
+        this.ctx = new(BuildInternal);
+    }
+
+    private static string GetHash(string content)
+    {
+        var input = Encoding.UTF8.GetBytes(content);
+        using var md5 = MD5.Create();
+        var output = md5.ComputeHash(input);
+        var str = Convert.ToHexString(output);
+        return str;
+    }
+
+    public InlineProjectAnalyzerVerifyContextBuilder WithFile(string name, string? content = null)
+    {
+        var file = ToFile(name, content);
+        return new(analyzer, files.Add(file));
+    }
+
+    private static FileDefinition ToFile(string name, string? content)
+    {
+        var trimmed = content?.Trim() ?? string.Empty;
+
+        var file = new FileDefinition
+        {
+            Name = name,
+            Content = trimmed,
+            Hash = GetHash(trimmed),
+        };
+        return file;
+    }
+
+    public ProjectAnalyzerVerifyContext Build()
+        => ctx.Value;
+
+    private ProjectAnalyzerVerifyContext BuildInternal()
+    {
+        if (files.Length <= 0)
+        {
+            throw new InvalidOperationException("Requires at least 1 file.");
+        }
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "dotnet-project-file-analyzer/tests");
+        var dir = Path.Combine(tempDir, hash.Value);
+        Directory.CreateDirectory(dir);
+
+        foreach (var file in files)
+        {
+            var fileName = Path.Combine(dir, file.Name);
+            var fileDir = Path.GetDirectoryName(fileName);
+            Directory.CreateDirectory(fileDir!);
+
+            if (!File.Exists(fileName) || GetHash(File.ReadAllText(fileName).Trim()) != file.Hash)
+            {
+                File.WriteAllText(fileName, file.Content);
+            }
+        }
+
+        var firstFileName = Path.Combine(dir, files[0].Name);
+        var fileInfo = new FileInfo(firstFileName);
+        
+        return ProjectFileAnalyzersDiagnosticAnalyzerExtensions.ForTestProject(analyzer, fileInfo);
+    }
+
+    private sealed record FileDefinition
+    {
+        public required string Name { get; init; }
+
+        public required string Content { get; init; }
+
+        public required string Hash { get; init; }
+    }
+}
+
+internal static class InlineProjectAnalyzerVerifyContextBuilderExtensions
+{
+    public static void HasNoIssues(this InlineProjectAnalyzerVerifyContextBuilder builder)
+        => builder.Build().HasNoIssues();
+
+    public static void HasIssue(
+        this InlineProjectAnalyzerVerifyContextBuilder builder,
+        Issue issue)
+        => builder.Build().HasIssue(issue);
+
+    public static void HasIssues(
+        this InlineProjectAnalyzerVerifyContextBuilder builder,
+        params Issue[] issues)
+        => builder.Build().HasIssues(issues);
+}


### PR DESCRIPTION
Closes #498

- Adds a builder for inline projects that allows attaching any files to it that will also be included in the analysis.
- Rewritten `AddInlineCsproj` to use new builder under the hood
- Added `AddInlineSdkProject` to quickly setup a builder with a valid sdk project.
- Added `AddInlineSlnx` to quickly setup an sdk project and include the given slnx content.

Included 1 redundant test case for slnx indentation to demonstrate the syntax.