### PR TITLE
Proj3000: Exclude .vs and .git

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/Generic/OnlyUseUTF8WithoutBom.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Generic/OnlyUseUTF8WithoutBom.cs
@@ -50,6 +50,8 @@ public sealed class OnlyUseUTF8WithoutBom() : ProjectFileAnalyzer<ProjectTextFil
 
         return !path.Contains("/bin/")
             && !path.Contains("/obj/")
+            && !path.Contains("/.vs/")
+            && !path.Contains("/.git/")
             && !file.Name.IsMatch("CompatibilitySuppressions.xml");
     }
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -86,6 +86,7 @@ v.1.8.0
 - Proj1300: Avoid project references to executables. (NEW RULE)
 - Proj1301: Project references of packable targets should be packable. (NEW RULE)
 - Proj1302: Avoid project references to test projects. (NEW RULE)
+- Proj3000: Exclude .vs and .git directories from BOM checking. (FP)
 - Proj5000: Use SLNX solution files. (NEW RULE)
 - Proj5001: Remove SLN solution files. (NEW RULE)
 - Proj5005: Omit Project ID's. (NEW RULE)


### PR DESCRIPTION
To reduce potential FP's while #541 has not been implemented, just exclude the `.vs` and `.git` directories.

Closes #461.