### PR TITLE
Define <RepositoryUrl> is not needed for SDK's 8.0 and up

### DIFF
--- a/docs/rules/Proj0205.md
+++ b/docs/rules/Proj0205.md
@@ -14,7 +14,7 @@ defining the `<IsPackable>` node with value `false`.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -26,7 +26,7 @@ defining the `<IsPackable>` node with value `false`.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
   </PropertyGroup>
@@ -34,13 +34,15 @@ defining the `<IsPackable>` node with value `false`.
 </Project>
 ```
 
+Or use the [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+
 Or disable packability:
 
 ``` xml
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/projects/CompliantCSharp/packages.lock.json
+++ b/projects/CompliantCSharp/packages.lock.json
@@ -13,12 +13,6 @@
         "requested": "[1.2.2, )",
         "resolved": "1.2.2",
         "contentHash": "nibkccSVGPl5BiKrev2JjbzH6HqOsRFxKops4Z8k9BzngV+mEtjAPKaX/otFSKTVkFdrLnfhZgW3imip8UBJVw=="
-      },
-      "Qowaiv": {
-        "type": "Direct",
-        "requested": "[7.4.5, )",
-        "resolved": "7.4.5",
-        "contentHash": "i6mt4r93YjuPb7q5FOvcmBX+oHh/J4K/JAtZeHGG9qLLBqS7DiSMsV2n/2dDlRHyNFcljXf73C0Kn7nZM6NFXw=="
       }
     }
   }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
@@ -34,7 +34,11 @@ public sealed class DefinePackageInfo() : MsBuildProjectFileAnalyzer(
         Analyze(context, available, Rule.DefineDescription, typeof(Description), typeof(PackageDescription));
         Analyze(context, available, Rule.DefineAuthors, typeof(Authors));
         Analyze(context, available, Rule.DefineTags, typeof(PackageTags));
-        Analyze(context, available, Rule.DefineRepositoryUrl, typeof(RepositoryUrl));
+
+        if (!HasSourceLinkEnabled(context))
+        {
+            Analyze(context, available, Rule.DefineRepositoryUrl, typeof(RepositoryUrl));
+        }
         Analyze(context, available, Rule.DefineUrl, typeof(PackageProjectUrl));
         Analyze(context, available, Rule.DefineCopyright, typeof(Copyright));
         Analyze(context, available, Rule.DefineReleaseNotes, typeof(PackageReleaseNotes));
@@ -63,6 +67,9 @@ public sealed class DefinePackageInfo() : MsBuildProjectFileAnalyzer(
         .File.Walk()
         .OfType<PackageReference>()
         .Any(HasAlternativePackageVersioning);
+
+    private static bool HasSourceLinkEnabled(ProjectFileAnalysisContext context)
+        => context.Options.GetSdkVersion() >= SdkVersion.NET8;
 
     private static bool HasAlternativePackageVersioning(PackageReference reference)
         => reference.IncludeOrUpdate

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -81,6 +81,7 @@ ToBeDecided:
 v1.8.1
 - Trim MSBuild attribute values. (FP/FN)
 - Proj0201: <Version> is not required when using NuGet.Versioning or MinVer. (FP)
+- Proj0205: Define <RepositoryUrl> is not needed for SDK's 8.0 and up. (FP)
 - Proj0812: Remove redundant packages references that are globally referenced. (NEW RULE)
 * Proj3003: Trim whitespace. (NEW RULE)
 ]]>

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions.cs
@@ -9,4 +9,11 @@ internal static class AnalyzerOptionsExtensions
             .TryGetValue($"build_property.{propertyName}", out var value)
             ? value
             : null;
+
+    [Pure]
+    public static SdkVersion GetSdkVersion(this AnalyzerOptions options)
+    {
+        var version = options.GetMsBuildProperty("NETCoreSdkVersion");
+        return SdkVersion.Parse(version ?? string.Empty);
+    }
 }


### PR DESCRIPTION
Only checks [Proj0205](https://dotnet-project-file-analyzers.github.io/rules/Proj0205.html) when the SDK could not be detected, or predates .NET 8.0.

Closes #601 