### PR TITLE
FileCache gracefully handles gone and unparsable content

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -27,7 +27,7 @@
 
   <ItemGroup Label="Analyzers">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.22.0.136894" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.23.0.137933" PrivateAssets="all" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup Label="Custom licenses">

--- a/specs/DotNetProjectFile.Analyzers.Specs/Caching/FileCache_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Caching/FileCache_specs.cs
@@ -1,0 +1,78 @@
+using DotNetProjectFile.Caching;
+using DotNetProjectFile.IO;
+using System.IO;
+using VerifyTests;
+
+namespace Specs.Caching.FileCache_specs;
+
+public class TryGetOrUpdate
+{
+    [Test]
+    public async Task Adds_new_entry()
+    {
+        using var file = await TempFile.CreateText("Hello, World!");
+        var cache = new FileCache<Entry>();
+        cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => new Entry());
+        cache.Count.Should().Be(1);
+    }
+
+    [Test]
+    public void Skips_empty_paths()
+    {
+        var cache = new FileCache<Entry>();
+        cache.TryGetOrUpdate(IOFile.Empty, p => new Entry());
+        cache.Count.Should().Be(0);
+    }
+
+    [Test]
+    public async Task Keeps_existing_entry_when_file_has_same_LastWriteTimeUtc()
+    {
+        using var file = await TempFile.CreateText("Hello, World!");
+
+        var cache = new FileCache<Entry>();
+        cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => new Entry());
+        cache.Count.Should().Be(1);
+
+        var result = cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => new Entry(17));
+        cache.Count.Should().Be(1);
+        result.Should().Be(new Entry(42));
+    }
+
+    [Test]
+    public async Task Updates_existing_entry()
+    {
+        using var file = await TempFile.CreateText("Hello, World!");
+
+        var cache = new FileCache<Entry>();
+        cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => new Entry());
+        cache.Count.Should().Be(1);
+
+        using var writer = File.AppendText(file.Path);
+        await writer.WriteAsync('.');
+        await writer.FlushAsync();
+
+        var result = cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => new Entry(17));
+        cache.Count.Should().Be(1);
+        result.Should().Be(new Entry(17));
+    }
+
+    [Test]
+    public async Task Remove_existing_entry_when_transform_fails()
+    {
+        using var file = await TempFile.CreateText("Hello, World!");
+
+        var cache = new FileCache<Entry>();
+        cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => new Entry());
+        cache.Count.Should().Be(1);
+
+        using var writer = File.AppendText(file.Path);
+        await writer.WriteAsync('.');
+        await writer.FlushAsync();
+
+        var result = cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => null);
+        cache.Count.Should().Be(0);
+        result.Should().BeNull();
+    }
+}
+
+file record Entry(int Value = 42);

--- a/src/DotNetProjectFile.Analyzers/Caching/FileCache.cs
+++ b/src/DotNetProjectFile.Analyzers/Caching/FileCache.cs
@@ -18,22 +18,25 @@ public sealed class FileCache<T>() where T : class
     /// <remarks>
     /// Uses the cased version if possible, otherwise creates/updates the file.
     /// </remarks>
-    public T? TryGetOrUpdate(IOFile file, Func<IOFile, T> create)
+    public T? TryGetOrUpdate(IOFile path, Func<IOFile, T?> create) => path switch
     {
-        if (!file.HasValue || !file.Exists)
-        {
-            return default;
-        }
-        else if (Lookup.TryGetValue(file, out var entry) && entry.Version == file.LastWriteTimeUtc)
-        {
-            return entry.Value;
-        }
-        else
-        {
-            entry = new(file.LastWriteTimeUtc, create(file));
-            Lookup[file] = entry;
-            return entry.Value;
-        }
+        _ when !path.HasValue || !path.Exists => Remove(path),
+        _ when Lookup.TryGetValue(path, out var entry) && entry.Version == path.LastWriteTimeUtc => entry.Value,
+        _ when create(path) is { } file => Update(path, file),
+        _ => Remove(path),
+    };
+
+    private T Update(IOFile path, T file)
+    {
+        Lookup[path] = new(path.LastWriteTimeUtc, file);
+        return file;
+    }
+
+    /// <summary>Remove, as we can not longer resolve it.</summary>
+    private T? Remove(IOFile path)
+    {
+        Lookup.TryRemove(path, out _);
+        return default;
     }
 
     private readonly record struct Entry(DateTime? Version, T Value);

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
@@ -145,7 +145,7 @@ public sealed partial class ProjectFiles
     private static IniFile Create_IniFile(IOFile file)
         => new(IniFileSyntax.Parse(Syntax.SyntaxTree.Load(file.OpenRead())));
 
-    private MsBuildProject Create_MsBuildProject(IOFile file)
+    private MsBuildProject? Create_MsBuildProject(IOFile file)
        => MsBuild.MsBuildProject.Load(file, this);
 
     private static NuGet.Configuration.NuGetConfigFile Create_NuGetConfigFile(IOFile file)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -79,6 +79,8 @@
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+v1.*
+- FileCache gracefully handles gone and unparsable content. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildProject.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildProject.cs
@@ -1,5 +1,6 @@
 using DotNetProjectFile.Ini;
 using Microsoft.CodeAnalysis.Text;
+using System.Xml;
 
 namespace DotNetProjectFile.MsBuild;
 
@@ -108,22 +109,48 @@ public sealed partial class MsBuildProject : Node, ProjectFile
         }
     }
 
-    public static MsBuildProject Load(IOFile file, ProjectFiles projects)
+    /// <summary>Loads an MSBuild project from file.</summary>
+    /// <remarks>
+    /// Returns null if the files does not contain valid XML.
+    /// </remarks>
+    [Pure]
+    public static MsBuildProject? Load(IOFile file, ProjectFiles projects)
     {
-        using var reader = file.TryOpenText();
-        return new(
-            path: file,
-            text: SourceText.From(reader.ReadToEnd()),
-            projectFiles: projects,
-            additionalText: null);
+        try
+        {
+            using var reader = file.TryOpenText();
+            return new(
+                path: file,
+                text: SourceText.From(reader.ReadToEnd()),
+                projectFiles: projects,
+                additionalText: null);
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
     }
 
-    public static MsBuildProject Load(AdditionalText text, ProjectFiles projects)
-        => new(
-            path: IOFile.Parse(text.Path),
-            text: text.GetText()!,
-            projectFiles: projects,
-            additionalText: text);
+    /// <summary>Loads an MSBuild project from file.</summary>
+    /// <remarks>
+    /// Returns null if the files does not contain valid XML.
+    /// </remarks>
+    [Pure]
+    public static MsBuildProject? Load(AdditionalText text, ProjectFiles projects)
+    {
+        try
+        {
+            return new(
+                path: IOFile.Parse(text.Path),
+                text: text.GetText()!,
+                projectFiles: projects,
+                additionalText: text);
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+    }
 
     private static readonly LoadOptions LoadOptions = LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo;
 }

--- a/src/DotNetProjectFile.Fixers/packages.lock.json
+++ b/src/DotNetProjectFile.Fixers/packages.lock.json
@@ -37,6 +37,47 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Direct",
+        "requested": "[4.10.0, )",
+        "resolved": "4.10.0",
+        "contentHash": "iifqKy3KvCgPABHFbFlSxjEoE+OItZGuZ191NM/TWV750m1jMypr7BtrP65ET+OK2KNVupO8S8xCtxbNqw056A==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "Microsoft.CodeAnalysis.Common": "[4.10.0]",
+          "System.Buffers": "4.5.1",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Memory": "4.5.5",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Reflection.Metadata": "8.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encoding.CodePages": "7.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Direct",
+        "requested": "[4.10.0, )",
+        "resolved": "4.10.0",
+        "contentHash": "lSMNGNeROSbxvbgzJyQfJpLJM0BFRrSgxYs4BZuZvpL8TuyUorEYa/HCJDcclhSRhr76LGiTT5lfLu5QFoFF6A==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "Microsoft.CodeAnalysis.Common": "[4.10.0]",
+          "System.Buffers": "4.5.1",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Composition": "8.0.0",
+          "System.IO.Pipelines": "8.0.0",
+          "System.Memory": "4.5.5",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Reflection.Metadata": "8.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encoding.CodePages": "7.0.0",
+          "System.Threading.Channels": "7.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "Microsoft.Sbom.Targets": {
         "type": "Direct",
         "requested": "[4.1.5, )",
@@ -60,21 +101,34 @@
       },
       "Qowaiv.Analyzers.CSharp": {
         "type": "Direct",
-        "requested": "[2.3.0, )",
-        "resolved": "2.3.0",
-        "contentHash": "sgGlYi9MVHRZnCr9hE3FSk7MEcFqiR9Wz5Y9mzMRX0fRMOjdIPv1n+KxwJJDL/KwYsHpfaobpVrB+Og+s5hVpQ=="
+        "requested": "[2.2.0, )",
+        "resolved": "2.2.0",
+        "contentHash": "hKjZHbh1Eijq2iKe7tPJKyOXOhCvPbDs4DfJKNMUuebS/xuoKMQdbqRKaXxUK4ErTSAGxO3qD+C5whSck9c0SQ=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[10.23.0.137933, )",
-        "resolved": "10.23.0.137933",
-        "contentHash": "K8CwUkB4PlUcMfLqGCj1aviVfW9AufZH2K/TjgPGYdj4gosV/kcyxpBR0jaCG8argC6dfxJBbSS6xXJ59lFWgA=="
+        "requested": "[10.22.0.136894, )",
+        "resolved": "10.22.0.136894",
+        "contentHash": "6fI0XUWHvFIa/cvo1HuopV1Gh1hnKJq+XlTMJ2q71+6D3uVkl6Vxza3fFKQ9C4Bc7KFUFtukzRPmiH1be0JxOA=="
       },
       "StyleCop.Analyzers.Unstable": {
         "type": "Direct",
         "requested": "[1.2.0.556, )",
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3WA9q9yVqJp222P3x1wYIGDAkpjAku0TMUaaQV22g6L67AI0LdOIrVS7Ht2vJfLHGSPVuqN94vIr15qn+HEkHw==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
@@ -93,6 +147,64 @@
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "E9oO9olNNxA39J8CxQwf7ceIPm+j/B/PhYpyK9M4LhN/OLLRw6u5fNInkhVqaWueMB9iXxYqnwqwgz+W91loIA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "8.0.0",
+          "System.Composition.Convention": "8.0.0",
+          "System.Composition.Hosting": "8.0.0",
+          "System.Composition.Runtime": "8.0.0",
+          "System.Composition.TypedParts": "8.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "NyElSuvmBMYdn2iPG0n29i7Igu0bq99izOP3MAtEwskY3OP9jqsavvVmPn9lesVaj/KT/o/QkNjA43dOJTsDQw=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "UuVkc1B3vQU/LzEbWLMZ1aYVssv4rpShzf8wPEyrUqoGNqdYKREmB8bXR73heOMKkwS6ZnPz3PjGODT2MenukQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "8.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "qwbONqoxlazxcbiohvb3t1JWZgKIKcRdXS5uEeLbo5wtuBupIbAvdC3PYTAeBCZrZeERvrtAbhYHuuS43Zr1bQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "8.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "G+kRyB5/6+3ucRRQz+DF4uSHGqpkK8Q4ilVdbt4zvxpmvLVZNmSkyFAQpJLcbOyVF85aomJx0m+TGMDVlwx7ZQ=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "DsSklhuA+Dsgo3ZZrar8hjBFvq1wa1grrkNCTt+6SoX3vq0Vy+HXJnVXrU/nNH1BjlGH684A7h4hJQHZd/u5mA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "8.0.0",
+          "System.Composition.Hosting": "8.0.0",
+          "System.Composition.Runtime": "8.0.0"
+        }
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "System.Memory": {
@@ -131,6 +243,14 @@
         "dependencies": {
           "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Channels": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "qmeeYNROMsONF6ndEZcIQ+VxR4Q/TX/7uIVLJqtwIWL7dDWeh0l1UIqgo4wYyjG//5lUNhwkLDSFl+pAWO6oiA==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "System.Threading.Tasks.Extensions": {


### PR DESCRIPTION
When an XML-file is not longer valid XML, analyzers (such as those on the .net.csproj) would crash on loading those files/AdditionalText. With this change, this is handled gracefully. As a result: files that do not longer exist are remove from the cache.

Closes #723 