### PR TITLE
Set <IncludeBuildOutput>false</IncludeBuildOutput> for .net.csproj

### DIFF
--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -46,7 +46,8 @@
     <Version>1.11.0</Version>
     <ToBeReleased>
       <![CDATA[
-v1.*
+v1.12.0
+- Set <IncludeBuildOutput>false</IncludeBuildOutput>.
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
@@ -13,8 +13,9 @@
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 
-  <!-- The bin is just noise here, so move it a temp location. -->
+  <!-- The DLL we compile has no meaning so leave it out. -->
   <PropertyGroup>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
     <OutputPath>$([System.IO.Path]::GetTempPath())/.net/bin</OutputPath>
     <IntermediateOutputPath>$([System.IO.Path]::GetTempPath())/.net/obj</IntermediateOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
Previously, we set `<OutputPath>` and `<IntermediateOutputPath>` to some temp location. However, this still created `bin` and `obj` folders in the directory of the `.net.csproj`. With `<IncludeBuildOutput>false</IncludeBuildOutput>` set, this does not longer occur.