### PR TITLE
Proj3000: Exclude *.user files

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/Generic/OnlyUseUTF8WithoutBom.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Generic/OnlyUseUTF8WithoutBom.cs
@@ -46,10 +46,11 @@ public sealed class OnlyUseUTF8WithoutBom() : ProjectFileAnalyzer<ProjectTextFil
     {
         var path = file.ToString("/");
 
-        return !path.Contains("/bin/")
-            && !path.Contains("/obj/")
-            && !path.Contains("/.vs/")
-            && !path.Contains("/.git/")
-            && !file.Name.IsMatch("CompatibilitySuppressions.xml");
+        return !(path.Contains("/bin/")
+            || path.Contains("/obj/")
+            || path.Contains("/.vs/")
+            || path.Contains("/.git/")
+            || file.Name.IsMatch("CompatibilitySuppressions.xml")
+            || file.Extension is ".user");
     }
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -80,6 +80,7 @@
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
 v1.*
+- Proj3000: Exclude *.user files. (FP)
 - FileCache gracefully handles gone and unparsable content. (BUG)
 ]]>
     </ToBeReleased>


### PR DESCRIPTION
The `*.user` files are (by default) excluded from the repo, and do not comply with the `.editorconfig`. Hence they lead to annoying FP's, and are therefor excluded.