### PR TITLE
Include Directory.build.* based on MSBuild variables

### DIFF
--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />
 

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />
 
@@ -48,6 +48,9 @@
       <![CDATA[
 v1.12.0
 - Set <IncludeBuildOutput>false</IncludeBuildOutput>.
+- Include Directory.Build.props from ancestor paths.
+- Include Directory.Build.targets from ancestor paths.
+- Include Directory.Packages.props from ancestor paths.
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
@@ -23,8 +23,6 @@
   <ItemGroup Label="Add without showing">
     <AdditionalFiles Visible="false" Include="$(MSBuildProjectFile)" />
     <AdditionalFiles Visible="false" Include="**/*.csproj" />
-    <AdditionalFiles Visible="false" Include="**/*.props" />
-    <AdditionalFiles Visible="false" Include="**/*.targets" />
     <AdditionalFiles Visible="false" Include="**/*.slnx" />
     <AdditionalFiles Visible="false" Include="**/*.vbproj" />
     <AdditionalFiles Visible="false" Include="**/*.fsproj" />
@@ -36,6 +34,19 @@
     <AdditionalFiles Remove="**/obj/**" />
   </ItemGroup>
 
+
+  <ItemGroup Condition="'$(ImportDirectoryBuildProps)' == 'true'">
+    <AdditionalFiles Update="$(DirectoryBuildPropsPath)" Link="$(_DirectoryBuildPropsFile)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true'">
+    <AdditionalFiles Update="$(DirectoryBuildTargetsPath)" Link="$(_DirectoryBuildTargetsFile)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
+    <AdditionalFiles Update="$(DirectoryPackagesPropsPath)"  Link="$(_DirectoryPackagesPropsFile)" />
+  </ItemGroup>
+
   <ItemGroup>
     <AdditionalFiles Include=".*config" />
     <AdditionalFiles Include=".git*" />
@@ -44,8 +55,6 @@
     <AdditionalFiles Include="*.ini" />
     <AdditionalFiles Include="*.json" />
     <AdditionalFiles Include="*.md" />
-    <AdditionalFiles Include="*.props" />
-    <AdditionalFiles Include="*.targets" />
     <AdditionalFiles Include="*.txt" />
     <AdditionalFiles Include="*.yaml" />
     <AdditionalFiles Include="*.yml" />

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
@@ -46,7 +46,7 @@
   
   <!-- Directory.Packages.props -->
   <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
-    <AdditionalFiles Update="$(DirectoryPackagesPropsPath)"  Link="$(_DirectoryPackagesPropsFile)" />
+    <AdditionalFiles Update="$(DirectoryPackagesPropsPath)" Link="$(_DirectoryPackagesPropsFile)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.props
@@ -34,15 +34,17 @@
     <AdditionalFiles Remove="**/obj/**" />
   </ItemGroup>
 
-
+  <!-- Directory.Build.props -->
   <ItemGroup Condition="'$(ImportDirectoryBuildProps)' == 'true'">
     <AdditionalFiles Update="$(DirectoryBuildPropsPath)" Link="$(_DirectoryBuildPropsFile)" />
   </ItemGroup>
 
+  <!-- Directory.Build.targets -->
   <ItemGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true'">
     <AdditionalFiles Update="$(DirectoryBuildTargetsPath)" Link="$(_DirectoryBuildTargetsFile)" />
   </ItemGroup>
-
+  
+  <!-- Directory.Packages.props -->
   <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
     <AdditionalFiles Update="$(DirectoryPackagesPropsPath)"  Link="$(_DirectoryPackagesPropsFile)" />
   </ItemGroup>

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
@@ -14,6 +14,8 @@
   <!-- Non-compiling files to analyze. -->
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildProjectFile)" Visible="false" />
+    <AdditionalFiles Include="**/*.props" />
+    <AdditionalFiles Include="**/*.targets" />
     <AdditionalFiles Include="**/*.resx" />
     <AdditionalFiles Include="**/NuGet.config" />
     <AdditionalFiles Include="**/Nuget.config" />
@@ -22,19 +24,28 @@
 
   <!-- Directory.Build.props -->
   <ItemGroup Condition="'$(ImportDirectoryBuildProps)' == 'true'">
-    <AdditionalFiles Include="$(DirectoryBuildPropsPath)" Visible="false" />
+    <AdditionalFiles
+      Include="$(DirectoryBuildPropsPath)"
+      Exclude="$(AdditionalFiles)"
+      Visible="false" />
     <CompilerVisibleProperty Include="DirectoryBuildPropsPath" />
   </ItemGroup>
 
   <!-- Directory.Build.targets -->
   <ItemGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true'">
-    <AdditionalFiles Include="$(DirectoryBuildTargetsPath)" Visible="false" />
+    <AdditionalFiles
+      Include="$(DirectoryBuildTargetsPath)"
+      Exclude="$(AdditionalFiles)"
+      Visible="false" />
     <CompilerVisibleProperty Include="DirectoryBuildTargetsPath" />
   </ItemGroup>
 
   <!-- Directory.Packages.props -->
   <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
-    <AdditionalFiles Include="$(DirectoryPackagesPropsPath)" />
+    <AdditionalFiles
+      Include="$(DirectoryPackagesPropsPath)"
+      Exclude="$(AdditionalFiles)"
+      Visible="false" />
     <CompilerVisibleProperty Include="DirectoryPackagesPropsPath" />
   </ItemGroup>
 

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
@@ -20,6 +20,22 @@
     <AdditionalFiles Include="**/nuget.config" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(ImportDirectoryBuildProps)' == 'true'">
+    <AdditionalFiles Include="$(DirectoryBuildPropsPath)" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true'">
+    <AdditionalFiles Include="$(DirectoryBuildTargetsPath)" Visible="false" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
+    <AdditionalFiles Include="$(DirectoryPackagesPropsPath)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNetProjectFile.Analyzers.Sdk" PrivateAssets="all" />
+  </ItemGroup>
+
   <!-- Common variable that should be resolvable. -->
   <ItemGroup>
     <CompilerVisibleProperty Include="Configuration" />

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
@@ -20,14 +20,17 @@
     <AdditionalFiles Include="**/nuget.config" />
   </ItemGroup>
 
+  <!-- Directory.Build.props -->
   <ItemGroup Condition="'$(ImportDirectoryBuildProps)' == 'true'">
     <AdditionalFiles Include="$(DirectoryBuildPropsPath)" Visible="false" />
   </ItemGroup>
 
+  <!-- Directory.Build.targets -->
   <ItemGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true'">
     <AdditionalFiles Include="$(DirectoryBuildTargetsPath)" Visible="false" />
   </ItemGroup>
-  
+
+  <!-- Directory.Packages.props -->
   <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
     <AdditionalFiles Include="$(DirectoryPackagesPropsPath)" />
   </ItemGroup>

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
@@ -23,20 +23,19 @@
   <!-- Directory.Build.props -->
   <ItemGroup Condition="'$(ImportDirectoryBuildProps)' == 'true'">
     <AdditionalFiles Include="$(DirectoryBuildPropsPath)" Visible="false" />
+    <CompilerVisibleProperty Include="DirectoryBuildPropsPath" />
   </ItemGroup>
 
   <!-- Directory.Build.targets -->
   <ItemGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true'">
     <AdditionalFiles Include="$(DirectoryBuildTargetsPath)" Visible="false" />
+    <CompilerVisibleProperty Include="DirectoryBuildTargetsPath" />
   </ItemGroup>
 
   <!-- Directory.Packages.props -->
   <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
     <AdditionalFiles Include="$(DirectoryPackagesPropsPath)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="DotNetProjectFile.Analyzers.Sdk" PrivateAssets="all" />
+    <CompilerVisibleProperty Include="DirectoryPackagesPropsPath" />
   </ItemGroup>
 
   <!-- Common variable that should be resolvable. -->


### PR DESCRIPTION
To ensure that `Directory.build.*` files are always available as additional file, and are displayed in the `.net.csproj`. Note that this not change the way that those files are read while analyzing (yet).