### PR TITLE
Project File Analyzers casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/LICENSE.md)
 [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/Corniel/dotnet-project-files-analyzers/blob/main/CODE_OF_CONDUCT.md)
 
-![.NET project file analyzers logo](design/logo_128x128.png)
-# .NET project file analyzers
+![.NET Project File Analyzers logo](design/logo_128x128.png)
+# .NET Project File Analyzers
 Contains 150+ [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 (static code) [diagnostic analyzers](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.diagnostics.diagnosticanalyzer)
 that report issues on .NET project files.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-![.NET Project File aAalyzers logo](design/logo_128x128.png)
+![.NET Project File Analyzers logo](design/logo_128x128.png)
 # .NET Project File Analyzers
 is a [NuGet](https://www.nuget.org/packages/DotNetProjectFile.Analyzers/) package
 containing [Roslyn](https://docs.microsoft.com/dotnet/csharp/roslyn-sdk/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
-![.NET project file analyzers logo](design/logo_128x128.png)
-# .NET project file analyzers
+![.NET Project File aAalyzers logo](design/logo_128x128.png)
+# .NET Project File Analyzers
 is a [NuGet](https://www.nuget.org/packages/DotNetProjectFile.Analyzers/) package
 containing [Roslyn](https://docs.microsoft.com/dotnet/csharp/roslyn-sdk/)
 (static code) [analyzers](https://docs.microsoft.com/dotnet/api/microsoft.codeanalysis.diagnostics.diagnosticanalyzer)
@@ -162,7 +162,7 @@ reported to the [GitHub repository](https://github.com/dotnet-project-file-analy
 * [**Proj0508** Order third-party licenses alphabetically](rules/Proj0508.md)
 * [**Proj0509** NuGet package cache could not be resolved](rules/Proj0509.md)
 
-### .NET project file analyzers SDK
+### .NET Project File Analyzers SDK
 * [**Proj0700** Avoid defining &lt;Compile&gt; items in SDK project](rules/Proj0700.md)
 
 ### Central Package Management
@@ -244,8 +244,9 @@ reported to the [GitHub repository](https://github.com/dotnet-project-file-analy
 * [**Proj5001** Remove SLN solution files](rules/Proj5001.md)
 * [**Proj5005** Omit Project ID's](rules/Proj5005.md)
 
-## Sonar integration
-By default, results by .NET project file analyzers are not added to Sonar's reporting. Read [here](general/sonar-integration.md) how to configure this correctly.
+## SonarCube integration
+By default, results by .NET project file analyzers are included in SonarCube
+reports. Read [here](general/sonar-integration.md) more about how this works.
 
 ## License
-.NET project file analyzers is licensed under [MIT](LICENSE.MD).
+.NET Project File Analyzers is licensed under [MIT](LICENSE.MD).

--- a/docs/general/configuration.md
+++ b/docs/general/configuration.md
@@ -4,7 +4,7 @@ nav_order: 1
 ---
 
 # Configuration of .NET project file analyzers
-Although all **.NET project file analyzers** should work like a charm,
+Although all .NET project file analyzers should work like a charm,
 there might be reasons to do some adjustments: disabling a specific rule or
 changing its severity. The good news is: this can be done.
 

--- a/docs/general/nuget-packages.md
+++ b/docs/general/nuget-packages.md
@@ -8,7 +8,7 @@ Microsoft provides [best practices](https://learn.microsoft.com/nuget/create-pac
 to give NuGet package authors a reference to create and publish high-quality
 packages.
 
-.NET project file analyzers provides rules for most of them:
+.NET project File Analyzers provides rules for most of them:
 
 | Rule                             | Recommendation
 |:--------------------------------:|----------------------------------------------

--- a/docs/general/sdk.md
+++ b/docs/general/sdk.md
@@ -3,13 +3,13 @@ permalink: /sdk
 nav_order: 2
 ---
 
-# .NET project file analyzers SDK
+# .NET Project File Analyzers SDK
 [![DotNetProjectFile.Analyzers.Sdk](https://img.shields.io/nuget/v/DotNetProjectFile.Analyzers.Sdk)![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/dt/DotNetProjectFile.Analyzers.Sdk)](https://www.nuget.org/packages/DotNetProjectFile.Analyzers.Sdk)
 .NET project file analyzers ships with its own SDK.
 
-## Why the .NET project file analyzers SDK?
-The .NET project file analyzers work by linking files to a project (most
-commonly a `*.csproj` file), and hook on to Roslyn when that project is built.
+## Why the .NET Project File Analyzers SDK?
+.NET project file analyzers work by linking files to a project (most commonly
+a `*.csproj` file), and hook on to Roslyn when that project is built.
 
 For files that can not be linked to a single project to build, this approach
 does not work, and that is where the `.net.csproj` project comes in handy.
@@ -25,7 +25,8 @@ It obtains its powers because it is a little different from normal projects:
    works for you. The needs of a large [monorepo](https://en.wikipedia.org/wiki/Monorepo) with many solutions and projects differ from those of a small repository with a single solution and just a few projects.
 2. The `.net.csproj` project has a PackageReference to [![DotNetProjectFile.Analyzers.Sdk](https://img.shields.io/nuget/v/DotNetProjectFile.Analyzers.Sdk)![DotNetProjectFile.Analyzers](https://img.shields.io/nuget/dt/DotNetProjectFile.Analyzers.Sdk)](https://www.nuget.org/packages/DotNetProjectFile.Analyzers.Sdk).
    It automatically includes files it can analyze. Those, and files included as
-   `<AdditionalFiles>` are analyzed by the appropriate .NET project file analyzers.
+   `<AdditionalFiles>` are analyzed by the appropriate .NET project file
+   analyzers.
  
  Although the `.net.csproj` is not supposed to contain `<Compile>` items, the
  compiler still generates output. Since that output is useless, it is hidden.
@@ -52,7 +53,7 @@ A `.net.csproj` project file looks like this:
 *Download this example [`.net.csproj`](./.net.csproj)*
 
 ## Enable analyzers for .net.csproj
-The .NET project file analyzers can be included to the `.net.csproj` by adding
+.NET project file analyzers can be included to the `.net.csproj` by adding
 
 ``` xml
 <ItemGroup>

--- a/docs/general/sonar-integration.md
+++ b/docs/general/sonar-integration.md
@@ -26,7 +26,7 @@ analyzers for, such as `.csproj` and `.props` files. As a result:
 ## Workaround: Register files as `<Content>`
 What does work, is registering all files that are analyzed as `<Content>` for
 MSBuild. By doing so, SonarQube will report analysis on these files. To make
-life easier, the .NET Project File Analyzers do this automatically for:
+life easier, the .NET Project File Analyzers package does this automatically for:
 - `**/*.??proj`
 - `**/*.config`
 - `**/*.props`

--- a/docs/rules/Proj0006.md
+++ b/docs/rules/Proj0006.md
@@ -5,9 +5,9 @@ permalink: /rules/Proj0006
 ---
 
 # Proj0006: Add additional files to improve static code analysis
-The .NET project file analyzers need access to files that are not available
-via the analyzer context. By adding additional non-compiling files, those
-files become available in the analyzer context too.
+.NET project file analyzers need access to files that are not available via the
+analyzer context. By adding additional non-compiling files, those files become
+available in the analyzer context too.
 
 See: [Using Additional Files](https://github.com/dotnet/roslyn/blob/main/docs/analyzers/Using%20Additional%20Files.md)
 

--- a/docs/rules/Proj0505.md
+++ b/docs/rules/Proj0505.md
@@ -9,8 +9,7 @@ Using a [NuGet](https://www.nuget.org) package implies that you
 and/or your company explicitly agree with the legally binding conditions of the
 license and the copyright of the owner of the package.
 
-The .NET project file analyzers require a `<ThirdPartyLicense>` to define an
-`Include` to work properly.
+`<ThirdPartyLicense>` requires a definded `Include` to work properly.
 
 ## Non-compliant
 ``` xml

--- a/docs/rules/Proj0506.md
+++ b/docs/rules/Proj0506.md
@@ -9,8 +9,7 @@ Using a [NuGet](https://www.nuget.org) package implies that you
 and/or your company explicitly agree with the legally binding conditions of the
 license and the copyright of the owner of the package.
 
-The .NET project file analyzers require a `<ThirdPartyLicense>` to define a
-`Hash` to work properly.
+`<ThirdPartyLicense>` requires a defined `Hash` to work properly.
 
 ## Non-compliant
 ``` xml

--- a/props/common.props
+++ b/props/common.props
@@ -17,7 +17,7 @@
   <PropertyGroup Label="Package">
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
-    <ProductName>.NET project file analyzers</ProductName>
+    <ProductName>.NET project File Analyzers</ProductName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
+++ b/src/DotNetProjectFile.Analyzers.Sdk/DotNetProjectFile.Analyzers.Sdk.csproj
@@ -22,7 +22,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
-    <Description>.NET project file analyzers SDK</Description>
+    <Description>.NET Project File Analyzers SDK</Description>
     <PackageTags>SDK;Code Analysis;Project files;project file;csproj;vbproj;resx;MS Build;resources;analyzer;analyzer;analysis</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>logo_128x128.png</PackageIcon>

--- a/src/DotNetProjectFile.Analyzers.Sdk/README.md
+++ b/src/DotNetProjectFile.Analyzers.Sdk/README.md
@@ -1,1 +1,1 @@
-# .NET project file analyzers SDK
+# .NET Project File Analyzers SDK

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/Language.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/Language.cs
@@ -3,9 +3,7 @@ using System.ComponentModel;
 
 namespace DotNetProjectFile.CodeAnalysis;
 
-/// <summary>
-/// Represents a language that is supported by the .NET project file analyzers.
-/// </summary>
+/// <summary>Represents a language that is supported by the .NET project file analyzers.</summary>
 [TypeConverter(typeof(LanguageTypeConverter))]
 public readonly struct Language : IEquatable<Language>
 {
@@ -76,7 +74,7 @@ public readonly struct Language : IEquatable<Language>
     public bool Equals(Language other) => Id == other.Id;
 
     /// <inheritdoc />
-    public override int GetHashCode() => Id is null ? 0 : Id.GetHashCode();
+    public override int GetHashCode() => Id?.GetHashCode() ?? 0;
 
     /// <summary>Return true when the languages are equal.</summary>
     public static bool operator ==(Language left, Language right) => left.Equals(right);

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -32,7 +32,7 @@
     <PackageId>DotNetProjectFile.Analyzers</PackageId>
     <PackageProjectUrl>https://dotnet-project-file-analyzers.github.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
-    <Description>.NET project file analyzers</Description>
+    <Description>.NET Project File Analyzers</Description>
     <PackageTags>Code Analysis;Project files;project file;dotnet;csproj;vbproj;resx;fsproj;cblproj;MS Build;resources;analyzer;analyzer;analysis</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>logo_128x128.png</PackageIcon>


### PR DESCRIPTION
Revisited all places where `"project file analyzers"` was used, and applied @Sjaaky 's [suggestion](https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/issues/664#issuecomment-3846983440)

Closes #664 