### PR TITLE
Implement SemVer

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/SemVer_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/SemVer_specs.cs
@@ -1,0 +1,36 @@
+using DotNetProjectFile;
+
+namespace Specs.SemVer_specs;
+
+public class Parses
+{
+    [TestCase(null)]
+    [TestCase("")]
+    public void Empty(string? str)
+        => SemVer.TryParse(str).Should().BeNull();
+
+    [TestCase("1.2.0", 1, 2, 0)]
+    [TestCase("1.2.9", 1, 2, 9)]
+    [TestCase("2.71828.182845904", 2, 71828, 182845904)]
+    public void Major_Minor_Patch(string str, int major, int minor,  int patch)
+        => SemVer.TryParse(str).Should().Be(new SemVer(major, minor, patch));
+
+    [Test]
+    public void PreRelease_suffix()
+        => SemVer.TryParse("1.1.0-rc.1").Should().Be(new SemVer(1, 1, 0, preRelease: "rc.1"));
+
+    [Test]
+    public void Metadata_suffix()
+      => SemVer.TryParse("1.1.0+e471d15").Should().Be(new SemVer(1, 1, 0, buildMetadata: "e471d15"));
+
+    [Test]
+    public void PreRelease_and_metadata_suffix()
+       => SemVer.TryParse("1.1.0-rc.1+e471d15").Should().Be(new SemVer(1, 1, 0, "rc.1", "e471d15"));
+
+    [TestCase("a1.3.3", "Major contains non-digit")]
+    [TestCase("01.3.3", "Leading zero for major")]
+    [TestCase("1.03.3", "Leading zero for minor")]
+    [TestCase("1.3.03", "Leading zero for path")]
+    public void Unsucessfully(string str, string because) 
+        => SemVer.TryParse(str).Should().BeNull(because);
+}

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.String.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.String.cs
@@ -4,48 +4,56 @@ namespace System;
 
 internal static class StringExtensions
 {
-    public static bool Contains(this string? str, string value, StringComparison comparisonType)
-        => str is { } && str.IndexOf(value, comparisonType) != -1;
-
-    /// <summary>Matches both strings ignoring casting.</summary>
-    public static bool IsMatch(this string? str, string? other)
-        => string.Equals(str, other, StringComparison.OrdinalIgnoreCase);
-
-    public static string TrimStart(this string str, string? other)
+    extension(string? str)
     {
-        if (other is not { Length: > 0 })
-        {
-            return str;
-        }
+        public string? NullIfEmpty() => str is { Length: 0 } ? null : str;
 
-        var result = str;
+        public bool Contains(string value, StringComparison comparisonType)
+            => str is { } && str.IndexOf(value, comparisonType) != -1;
 
-        while (result.StartsWith(other))
-        {
-            result = result[other.Length..];
-        }
+        /// <summary>Matches both strings ignoring casting.</summary>
+        public bool IsMatch(string? other)
+            => string.Equals(str, other, StringComparison.OrdinalIgnoreCase);
 
-        return result;
+        /// <inheritdoc cref="NGramsCollection.Create(string?, int)" />
+        public NGramsCollection GetNGrams(int n)
+            => NGramsCollection.Create(str, n);
     }
 
-    public static string TrimEnd(this string str, string? other)
+    extension(string str)
     {
-        if (other is not { Length: > 0 })
+        public string TrimStart(string? other)
         {
-            return str;
+            if (other is not { Length: > 0 })
+            {
+                return str;
+            }
+
+            var result = str;
+
+            while (result.StartsWith(other))
+            {
+                result = result[other.Length..];
+            }
+
+            return result;
         }
 
-        var result = str;
-
-        while (result.EndsWith(other))
+        public string TrimEnd(string? other)
         {
-            result = result[..(str.Length - other.Length)];
-        }
+            if (other is not { Length: > 0 })
+            {
+                return str;
+            }
 
-        return result;
+            var result = str;
+
+            while (result.EndsWith(other))
+            {
+                result = result[..(str.Length - other.Length)];
+            }
+
+            return result;
+        }
     }
-
-    /// <inheritdoc cref="NGramsCollection.Create(string?, int)" />
-    public static NGramsCollection GetNGrams(this string? str, int n)
-        => NGramsCollection.Create(str, n);
 }

--- a/src/DotNetProjectFile.Analyzers/SemVer.cs
+++ b/src/DotNetProjectFile.Analyzers/SemVer.cs
@@ -1,0 +1,83 @@
+using System.Numerics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DotNetProjectFile;
+
+/// <summary>Implementation of Semantic Versioning.</summary>
+/// <remarks>
+/// See: https://semver.org/.
+/// </remarks>
+public sealed record SemVer()
+{
+    /// <summary>Initializes a new instance of the <see cref="SemVer"/> class.</summary>
+    public SemVer(
+        BigInteger major,
+        BigInteger minor,
+        BigInteger patch,
+        string? preRelease = null,
+        string? buildMetadata = null) : this()
+    {
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        PreRelease = preRelease;
+        BuildMetadata = buildMetadata;
+    }
+
+    /// <summary>Represents the major (should change for incompatible API changes).</summary>
+    public BigInteger Major { get; init; }
+
+    /// <summary>Represents the minor (should change for backward compatible added functionality).</summary>
+    public BigInteger Minor { get; init; }
+
+    /// <summary>Represents the minor (should change fora backward compatible bug fixes).</summary>
+    public BigInteger Patch { get; init; }
+
+    /// <summary>Aditional pre-release label (optional).</summary>
+    public string? PreRelease { get; init => field = value.NullIfEmpty(); }
+
+    /// <summary>Aditional build metadata label (optional).</summary>
+    public string? BuildMetadata { get; init => field = value.NullIfEmpty(); }
+
+    /// <inheritdoc />
+    [Pure]
+    public override string ToString()
+    {
+        var sb = new StringBuilder()
+            .Append(Major)
+            .Append('.')
+            .Append(Minor)
+            .Append('.')
+            .Append(Patch);
+
+        if (PreRelease is { })
+            sb.Append('-').Append(PreRelease);
+
+        if (BuildMetadata is { })
+            sb.Append('+').Append(BuildMetadata);
+
+        return sb.ToString();
+    }
+
+    /// <summary>Tries to parse a semantic version.</summary>
+    [Pure]
+    public static SemVer? TryParse(string? s) => s switch
+    {
+        null or "" => null,
+        _ when Pattern.Match(s) is { Success: true } match => new()
+        {
+            Major = BigInteger.Parse(match.Groups[nameof(Major)].Value),
+            Minor = BigInteger.Parse(match.Groups[nameof(Minor)].Value),
+            Patch = BigInteger.Parse(match.Groups[nameof(Patch)].Value),
+            PreRelease = match.Groups[nameof(PreRelease)].Value,
+            BuildMetadata = match.Groups[nameof(BuildMetadata)].Value,
+        },
+        _ => null,
+    };
+
+    private static readonly Regex Pattern = new(
+        @"^(?<Major>0|[1-9][0-9]*)\.(?<Minor>0|[1-9][0-9]*)\.(?<Patch>0|[1-9][0-9]*)(?:-(?<PreRelease>(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<BuildMetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        TimeSpan.FromSeconds(1));
+}


### PR DESCRIPTION
To check if `<Version>` and `<VersionPrefix>` are compliant with [Semantic Versioning](https://semver.org/) we need a way to detect that first. I've opted for a simple implementation using a `Regex` that SemVer.org advised themselves.