### PR TITLE
Proj1002: Take actual MSBuild value into account

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseDotNetAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseDotNetAnalyzers.cs
@@ -1,15 +1,19 @@
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
+/// <summary>Impelements <see cref="Rule.UseDotNetAnalyzers"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class UseDotNetAnalyzers() : MsBuildProjectFileAnalyzer(Rule.UseDotNetAnalyzers)
 {
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
     /// <inheritdoc />
     public override ImmutableArray<ProjectFileType> ApplicableTo => ProjectFileTypes.ProjectFile;
 
     /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (!context.File.NETAnalyzersEnabled())
+        if (!context.EnableNETAnalyzers)
         {
             context.ReportDiagnostic(Descriptor, context.File);
         }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -84,6 +84,7 @@ v1.12.0
 - Proj0028: Conditions within <Target> are should be allowed. (FP)
 - Proj0813: Global package references only work when CPM is enabled. (NEW RULE)
 - Proj1000: Use the .NET project file analyzers. (DROPPED)
+- Proj1002: Take actual MSBuild value into account. (FP)
 - Proj3000: Exclude *.user files. (FP)
 - Explicitly include .globalconfig file(s). (BUG)
 - FileCache gracefully handles gone and unparsable content. (BUG)

--- a/src/DotNetProjectFile.Analyzers/Extensions/DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext.cs
@@ -9,5 +9,12 @@ internal static class DotNetProjectFile
             => context.Props.ManagePackageVersionsCentrally
             ?? context.File.Property<ManagePackageVersionsCentrally>()?.Value
             ?? MsBuildDefaults.ManagePackageVersionsCentrally;
+
+        /// <summary>Indicates that the .NET analyzers are enabled.</summary>
+        public bool EnableNETAnalyzers
+            => context.Props.EnableNETAnalyzers
+             ?? context.File.Property<EnableNETAnalyzers>()?.Value
+            ?? MsBuildDefaults.EnableNETAnalyzers;
+
     }
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildProject.Property.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildProject.Property.cs
@@ -18,9 +18,6 @@ public sealed partial class MsBuildProject
     public bool IsTestProject()
         => Property<IsTestProject>()?.Value ?? MsBuildDefaults.IsTestProject;
 
-    public bool NETAnalyzersEnabled()
-        => Property<EnableNETAnalyzers>()?.Value ?? MsBuildDefaults.EnableNETAnalyzers;
-
     public bool? NuGetAuditEnabled()
         => Property<NuGetAudit>()?.Value ?? MsBuildDefaults.NuGetAudit;
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildProps.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildProps.cs
@@ -9,6 +9,9 @@ public sealed class MsBuildProps(AnalyzerOptions options)
     /// <summary>Gets the MSBuild project file that currently is being build.</summary>
     public string? MSBuildProjectFile => Prop();
 
+    /// <summary>Indicates that the .NET analyzers are enabled.</summary>
+    public bool? EnableNETAnalyzers => Converts.String<bool>(Prop());
+
     /// <summary>Indicates if the project is a packable.</summary>
     public bool? IsPackable => Converts.String<bool>(Prop());
 

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
@@ -50,6 +50,7 @@
   <!-- Common variable that should be resolvable. -->
   <ItemGroup>
     <CompilerVisibleProperty Include="Configuration" />
+    <CompilerVisibleProperty Include="EnableNETAnalyzers" />
     <CompilerVisibleProperty Include="IsPackable" />
     <CompilerVisibleProperty Include="IsTestProject" />
     <CompilerVisibleProperty Include="LangVersion" />


### PR DESCRIPTION
By reading checking the MSBuild value, FP's can be prevented.

Closes #747 