### PR TITLE
Exclude <!-- SingleWord --> comments

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Generic/Remove_commented_out_code.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Generic/Remove_commented_out_code.cs
@@ -3,23 +3,22 @@ namespace Rules.Generic.Remove_commented_out_code;
 public class Reports
 {
     [Test]
-    public void on_XML_commented_out_in_MS_Build() => new RemoveCommentedOutCode()
-       .ForInlineCsproj("""
-<Project Sdk="Microsoft.NET.Sdk">
+    public void on_XML_commented_out_in_MS_Build() => new RemoveCommentedOutCode().ForInlineCsproj("""
+        <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-    <!-- ImplicitUsings>enable</ImplicitUsings -->
-  </PropertyGroup>
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <!-- ImplicitUsings>enable</ImplicitUsings -->
+          </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Reconsider adding this
-    <GlobalPackageReference Include="DotNetProjectFile.Analyzers" Version="1.5.8" />
-    -->
-  </ItemGroup>
+          <ItemGroup>
+            <!-- Reconsider adding this
+            <GlobalPackageReference Include="DotNetProjectFile.Analyzers" Version="1.5.8" />
+            -->
+          </ItemGroup>
 
-</Project>
-""")
+        </Project>
+        """)
        .HasIssues(
            Issue.WRN("Proj3002", "Remove the commented-out code").WithSpan(04, 08, 04, 47),
            Issue.WRN("Proj3002", "Remove the commented-out code").WithSpan(08, 08, 10, 04));
@@ -35,32 +34,46 @@ public class Reports
 public class Guards
 {
     [Test]
-    public void regular_comment() => new RemoveCommentedOutCode()
-      .ForInlineCsproj("""
-<Project Sdk="Microsoft.NET.Sdk">
+    public void regular_comment() => new RemoveCommentedOutCode().ForInlineCsproj("""
+        <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <!-- Only .NET 8.0 will work -->    
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
+          <PropertyGroup>
+            <!-- Only .NET 8.0 will work -->    
+            <TargetFramework>net10.0</TargetFramework>
+          </PropertyGroup>
 
-</Project>
-""")
+        </Project>
+        """)
       .HasNoIssues();
 
     [Test]
-    public void TODO_comment() => new RemoveCommentedOutCode()
-      .ForInlineCsproj("""
-        
-<Project Sdk="Microsoft.NET.Sdk">
+    public void TODO_comment() => new RemoveCommentedOutCode().ForInlineCsproj("""
+        <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <!-- TODO add .NET 9.0 too -->    
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
+          <PropertyGroup>
+            <!-- TODO add .NET 9.0 too -->    
+            <TargetFramework>net10.0</TargetFramework>
+          </PropertyGroup>
 
-</Project>
-""")
+        </Project>
+        """)
+      .HasNoIssues();
+
+    [Test]
+    public void Single_word() => new RemoveCommentedOutCode().ForInlineCsproj("""
+        <Project Sdk="Microsoft.NET.Sdk">
+
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+          </PropertyGroup>
+
+          <ItemGroup>
+            <!-- Benchmarks -->
+             <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+         </ItemGroup>
+
+        </Project>
+        """)
       .HasNoIssues();
 
     [TestCase("CompliantCSharp.cs")]

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/Helpers/CommentChecker_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/Helpers/CommentChecker_specs.cs
@@ -5,6 +5,7 @@ namespace Rules.Helpers.CommentChecker_specs;
 public class Detects_commented_out_XML
 {
     [TestCase(""" PackageReference Include="System.Text.Json"" Version="9.0.0" /""")]
+    [TestCase("""ItemGroup""")]
     public void with_replaced_tags(string comment)
         => CommentChecker.ContainsXml(comment).Should().NotBeNull();
 
@@ -14,4 +15,11 @@ public class Detects_commented_out_XML
     [TestCase("""Somewhere <br> in my text""")]
     public void containing_XML_tags(string comment)
         => CommentChecker.ContainsXml(comment).Should().NotBeNull();
+}
+
+public class Guards
+{
+    [TestCase(""" SingleWord """)]
+    public void containing_single_word_with_spacing(string comment)
+        => CommentChecker.ContainsXml(comment).Should().BeNull();
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/CommentChecker.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Helpers/CommentChecker.cs
@@ -30,14 +30,21 @@ internal sealed class CommentChecker<TFile>(
 
 public static class CommentChecker
 {
-    public static string? ContainsXml(string comment)
-        => Tag.IsMatch(comment)
-        || Tag.IsMatch($"<{comment.Trim()}>")
-        ? comment
-        : null;
+    public static string? ContainsXml(string comment) => comment switch
+    {
+        not { Length: > 0 } => null,
+        _ when SingleWord.IsMatch(comment) => null,
+        _ when Tag.IsMatch(comment)
+            || Tag.IsMatch($"<{comment.Trim()}>") => comment,
+        _ => null,
+    };
+
+    private static readonly Regex SingleWord = new(@"^\s+[A-Z]+\s+$", Options, TimeSpan.FromSeconds(1));
 
     private static readonly Regex Tag = new(
         @"<(?<Tag>[A-Z]\w+)(\s+(?<Attr>[A-Z]\w+)\s*=\s*"".*"")*\s*\/?>",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline | RegexOptions.Compiled,
+        Options,
         TimeSpan.FromSeconds(10));
+
+    private const RegexOptions Options = RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Singleline | RegexOptions.Compiled;
 }

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -90,6 +90,7 @@ v1.12.0
 - Proj1002: Take actual MSBuild value into account. (FP)
 - Proj1004: .NET Project File Analyzers SDK not longer requires separate package (NEW RULE)
 - Proj3000: Exclude *.user files and .nuget directory. (FP)
+- Proj3002: Exclude <!-- SingleWord --> comments. (FP)
 - Explicitly include .globalconfig file(s). (BUG)
 - FileCache gracefully handles gone and unparsable content. (BUG)
 ]]>


### PR DESCRIPTION
Although every single word commented out in XML can become a tag, to reduce the number of FP's, are ignored if they are have trailing and leading whitespace.

Closes #760 