### PR TITLE
Proj0201: Exclude Microsoft.NET.Sdk.Web projects

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Define_package_info.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/NuGet packages/Define_package_info.cs
@@ -3,8 +3,7 @@ namespace Rules.MS_Build.NuGet_packages.Define_package_info;
 public class Reports_on_missing
 {
     [Test]
-    public void information_provided()
-       => new DefinePackageInfo()
+    public void information_provided() => new DefinePackageInfo()
        .ForProject("NoPackageInfo.cs")
        .HasIssues(
            Issue.INF("Proj0214", "Define the <PackageId> node explicitly or define the <IsPackable> node with value 'false'"),
@@ -24,99 +23,85 @@ public class Reports_on_missing
            Issue.WRN("Proj0217", "Define the <PackageRequireLicenseAcceptance> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void version()
-       => new DefinePackageInfo()
+    public void version() => new DefinePackageInfo()
        .ForProject("NoVersion.cs")
        .HasIssue(
            Issue.WRN("Proj0201", "Define the <Version> or <VersionPrefix> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void description()
-       => new DefinePackageInfo()
+    public void description() => new DefinePackageInfo()
        .ForProject("NoDescription.cs")
        .HasIssue(
            Issue.WRN("Proj0202", "Define the <Description> or <PackageDescription> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void authors()
-       => new DefinePackageInfo()
+    public void authors() => new DefinePackageInfo()
        .ForProject("NoAuthors.cs")
        .HasIssue(
            Issue.WRN("Proj0203", "Define the <Authors> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void tags()
-       => new DefinePackageInfo()
+    public void tags() => new DefinePackageInfo()
        .ForProject("NoTags.cs")
        .HasIssue(
            Issue.WRN("Proj0204", "Define the <PackageTags> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void repository_url()
-       => new DefinePackageInfo()
+    public void repository_url() => new DefinePackageInfo()
        .ForProject("NoRepositoryUrl.cs")
        .HasIssue(
            Issue.WRN("Proj0205", "Define the <RepositoryUrl> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void url()
-       => new DefinePackageInfo()
+    public void url() => new DefinePackageInfo()
        .ForProject("NoUrl.cs")
        .HasIssue(
            Issue.WRN("Proj0206", "Define the <PackageProjectUrl> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void copyright()
-       => new DefinePackageInfo()
+    public void copyright() => new DefinePackageInfo()
        .ForProject("NoCopyright.cs")
        .HasIssue(
            Issue.WRN("Proj0207", "Define the <Copyright> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void release_notes()
-       => new DefinePackageInfo()
+    public void release_notes() => new DefinePackageInfo()
        .ForProject("NoReleaseNotes.cs")
        .HasIssue(
            Issue.WRN("Proj0208", "Define the <PackageReleaseNotes> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void readme()
-       => new DefinePackageInfo()
+    public void readme() => new DefinePackageInfo()
        .ForProject("NoReadme.cs")
        .HasIssue(
            Issue.WRN("Proj0209", "Define the <PackageReadmeFile> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void license()
-       => new DefinePackageInfo()
+    public void license() => new DefinePackageInfo()
        .ForProject("NoLicense.cs")
        .HasIssue(
            Issue.WRN("Proj0210", "Define the <PackageLicenseExpression> or <PackageLicenseFile> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void icon()
-       => new DefinePackageInfo()
+    public void icon() => new DefinePackageInfo()
        .ForProject("NoIcon.cs")
        .HasIssue(
            Issue.WRN("Proj0212", "Define the <PackageIcon> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void icon_url()
-       => new DefinePackageInfo()
+    public void icon_url() => new DefinePackageInfo()
        .ForProject("NoIconUrl.cs")
        .HasIssue(
            Issue.WRN("Proj0213", "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void product_name()
-      => new DefinePackageInfo()
+    public void product_name() => new DefinePackageInfo()
       .ForProject("NoProductName.cs")
       .HasIssue(
           Issue.WRN("Proj0216", "Define the <ProductName> node explicitly or define the <IsPackable> node with value 'false'"));
 
     [Test]
-    public void missing_require_package_license_acceptance()
-      => new DefinePackageInfo()
+    public void missing_require_package_license_acceptance() => new DefinePackageInfo()
         .ForProject(@"NoPackageRequireLicenseAcceptance.cs")
         .HasIssue(Issue.WRN("Proj0217", "Define the <PackageRequireLicenseAcceptance> node explicitly or define the <IsPackable> node with value 'false'"));
 }
@@ -124,31 +109,35 @@ public class Reports_on_missing
 public class Guards
 {
     [Test]
-    public void Missing_version_when_using_MinVersion() => new DefinePackageInfo()
-       .ForInlineCsproj("""
+    public void web_SDK_project() => new DefinePackageInfo()
+        .ForProject("PublishableWebApp.cs")
+        .HasNoIssues();
+
+    [Test]
+    public void Missing_version_when_using_MinVersion() => new DefinePackageInfo().ForInlineCsproj("""
         <Project Sdk="Microsoft.NET.Sdk">
 
           <PropertyGroup>
-          <TargetFramework>net10.0</TargetFramework>
-          <Authors>.NET Project Files Analyzer community</Authors>
-          <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
-          <Description>Some package</Description>
-          <PackageLicenseExpression>MIT</PackageLicenseExpression>
-          <PackageIcon>logo_128x128.png</PackageIcon>
-          <PackageIconUrl>https://raw.githubusercontent.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/main/design/logo_128x128.png</PackageIconUrl>
-          <PackageId>Unit.Test</PackageId>
-          <PackageProjectUrl>https://dotnet-project-file-analyzers.github.io</PackageProjectUrl>
-          <PackageReadmeFile>README.md</PackageReadmeFile>
-          <PackageReleaseNotes>Not yet.</PackageReleaseNotes>
-          <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-          <PackageTags>Unit Test</PackageTags>
-          <ProductName>Unit Test</ProductName>
-          <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
-        </PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <Authors>.NET Project Files Analyzer community</Authors>
+            <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
+            <Description>Some package</Description>
+            <PackageLicenseExpression>MIT</PackageLicenseExpression>
+            <PackageIcon>logo_128x128.png</PackageIcon>
+            <PackageIconUrl>https://raw.githubusercontent.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers/main/design/logo_128x128.png</PackageIconUrl>
+            <PackageId>Unit.Test</PackageId>
+            <PackageProjectUrl>https://dotnet-project-file-analyzers.github.io</PackageProjectUrl>
+            <PackageReadmeFile>README.md</PackageReadmeFile>
+            <PackageReleaseNotes>Not yet.</PackageReleaseNotes>
+            <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+            <PackageTags>Unit Test</PackageTags>
+            <ProductName>Unit Test</ProductName>
+            <RepositoryUrl>https://github.com/dotnet-project-file-analyzers/dotnet-project-file-analyzers</RepositoryUrl>
+          </PropertyGroup>
 
-        <ItemGroup>
-          <PackageReference Include="MinVer" Version="6.1.0" PrivateAssets="All" />
-        </ItemGroup>
+          <ItemGroup>
+            <PackageReference Include="MinVer" Version="6.1.0" PrivateAssets="All" />
+          </ItemGroup>
 
         </Project>
         """)
@@ -186,8 +175,7 @@ public class Guards
         .HasNoIssues();
 
     [Test]
-    public void Test_project()
-        => new DefinePackageInfo()
+    public void Test_project() => new DefinePackageInfo()
        .ForProject("TestProject.cs")
        .HasNoIssues();
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
@@ -24,7 +24,9 @@ public sealed class DefinePackageInfo() : MsBuildProjectFileAnalyzer(
     /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (!context.File.IsPackable() || context.File.IsTestProject()) return;
+        if (!context.File.IsPackable()
+            || context.File.IsTestProject()
+            || context.File.Sdk is "Microsoft.NET.Sdk.Web") return;
 
         var available = context.File.Walk().Select(n => n.GetType()).ToImmutableHashSet();
 

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -81,6 +81,8 @@ ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
 v.13.0
 - Proj3000: Drop difference between additional and regular files. (FP)
+v1.12.2
+- Proj0201: Exclude Microsoft.NET.Sdk.Web projects. (FP)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>


### PR DESCRIPTION
Obviously, this involves all rules that are triggered on `<IsPackable>` not being set to `false`.

Closes #757