### PR TITLE
Proj0253/4: Fix runtime TypeConverter resolvement

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Conversion/TypeConverters_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Conversion/TypeConverters_specs.cs
@@ -1,0 +1,44 @@
+using DotNetProjectFile.MsBuild.Conversion;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace Conversion.TypeConverters_specs;
+
+public class Converts
+{
+    [Test]
+    public void null_string_to_string_as_null()
+        => TypeConverters.TryConvert<string?>(null).Should().BeNull();
+
+    [Test]
+    public void empty_string_to_string_as_null()
+        => TypeConverters.TryConvert<string?>(string.Empty).Should().BeNull();
+
+    [Test]
+    public void null_to_nullable_bool_as_null()
+        => TypeConverters.TryConvert<bool?>(null).Should().BeNull();
+
+    [Test]
+    public void null_to_bool_as_false()
+        => TypeConverters.TryConvert<bool>(null).Should().Be(false);
+
+    [Test]
+    public void true_to_bool_as_true()
+        => TypeConverters.TryConvert<bool>("true").Should().Be(true);
+}
+
+
+public class Registered
+{
+    private static IEnumerable<Type> Decorated
+        => typeof(DotNetProjectFile.Analyzers.MsBuildProjectFileAnalyzer)
+        .Assembly.GetTypes()
+        .Where(t => t.GetCustomAttributes<TypeConverterAttribute>().Any());
+
+    [TestCaseSource(nameof(Decorated))]
+    public void For(Type type)
+    {
+        var attr = type.GetCustomAttributes<TypeConverterAttribute>().Single();
+        attr.ConverterTypeName.Should().Be(TypeConverters.Get(type).GetType().AssemblyQualifiedName);
+    }
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Semantic_versioning_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Semantic_versioning_specs.cs
@@ -41,6 +41,7 @@ public class Reports
 
 public class Guards
 {
+    [TestCase("1.0.0")]
     [TestCase("3.14.1596")]
     [TestCase("1.1.0-rc.1+e471d15")]
     public void semantic_version(string version) => new VersionShouldBeSemVerCompliant()

--- a/specs/DotNetProjectFile.Analyzers.Specs/SemVer_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/SemVer_specs.cs
@@ -16,6 +16,7 @@ public class Parses
     public void With_trimming_whitespace(string str)
         => SemVer.TryParse(str).Should().Be(new SemVer(3, 1, 41596));
 
+    [TestCase("1.0.0", 1, 0, 0)]
     [TestCase("1.2.0", 1, 2, 0)]
     [TestCase("1.2.9", 1, 2, 9)]
     [TestCase("2.71828.182845904", 2, 71828, 182845904)]

--- a/src/DotNetProjectFile.Analyzers/Conversion/IODirectoryConverter.cs
+++ b/src/DotNetProjectFile.Analyzers/Conversion/IODirectoryConverter.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 namespace DotNetProjectFile.Conversion;
 
 /// <summary>Implements a <see cref="TypeConverter"/> for <see cref="IODirectory"/>.</summary>
-internal sealed class IODirectoryTypeConverter : TypeConverter
+internal sealed class IODirectoryConverter : TypeConverter
 {
     /// <inheritdoc />
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)

--- a/src/DotNetProjectFile.Analyzers/Conversion/IOFileConverter.cs
+++ b/src/DotNetProjectFile.Analyzers/Conversion/IOFileConverter.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 namespace DotNetProjectFile.Conversion;
 
 /// <summary>Implements a <see cref="TypeConverter"/> for <see cref="IOFile"/>.</summary>
-internal sealed class IOFileTypeConverter : TypeConverter
+internal sealed class IOFileConverter : TypeConverter
 {
     /// <inheritdoc />
     public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)

--- a/src/DotNetProjectFile.Analyzers/Conversion/SemVerConverter.cs
+++ b/src/DotNetProjectFile.Analyzers/Conversion/SemVerConverter.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using System.Globalization;
+
+namespace DotNetProjectFile.Conversion;
+
+/// <summary>Implements a <see cref="TypeConverter"/> for <see cref="SemVer"/>.</summary>
+internal sealed class SemVerConverter : TypeConverter
+{
+    /// <inheritdoc />
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+        => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+    /// <inheritdoc />
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value) => value switch
+    {
+        null => null,
+        string str => SemVer.TryParse(str),
+        _ => base.ConvertFrom(context, culture, value),
+    };
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.12.1</Version>
+    <Version>1.12.1-beta004</Version>
     <ToBeReleased>
       <![CDATA[
 ToBeDecided:
@@ -87,6 +87,8 @@ v1.12.2
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+v1.12.2
+- Proj0253/4: Fix runtime TypeConverter resolvement. (FP)
 v1.12.1
 - Proj3000: Ignore Additional File status when checking for UTF8-BOM. (FP)
 v1.12.0

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.12.1-beta004</Version>
+    <Version>1.12.1</Version>
     <ToBeReleased>
       <![CDATA[
 ToBeDecided:
@@ -83,12 +83,11 @@ v.13.0
 - Proj3000: Drop difference between additional and regular files. (FP)
 v1.12.2
 - Proj0201: Exclude Microsoft.NET.Sdk.Web projects. (FP)
+- Proj0253/4: Fix runtime TypeConverter resolvement. (FP)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
-v1.12.2
-- Proj0253/4: Fix runtime TypeConverter resolvement. (FP)
 v1.12.1
 - Proj3000: Ignore Additional File status when checking for UTF8-BOM. (FP)
 v1.12.0

--- a/src/DotNetProjectFile.Analyzers/IO/IODirectory.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/IODirectory.cs
@@ -7,7 +7,7 @@ using System.IO;
 namespace DotNetProjectFile.IO;
 
 /// <summary>Represents an (IO) directory.</summary>
-[TypeConverter(typeof(Conversion.IODirectoryTypeConverter))]
+[TypeConverter(typeof(Conversion.IODirectoryConverter))]
 public readonly struct IODirectory : IEquatable<IODirectory>, IFormattable, IComparable<IODirectory>
 {
     /// <summary>Represents none/an empty path.</summary>

--- a/src/DotNetProjectFile.Analyzers/IO/IOFile.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/IOFile.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace DotNetProjectFile.IO;
 
 /// <summary>Represents an (IO) file.</summary>
-[TypeConverter(typeof(Conversion.IOFileTypeConverter))]
+[TypeConverter(typeof(Conversion.IOFileConverter))]
 public readonly struct IOFile : IEquatable<IOFile>, IFormattable, IComparable<IOFile>
 {
     /// <summary>Represents none/an empty path.</summary>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Conversion/TypeConverters.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Conversion/TypeConverters.cs
@@ -8,12 +8,11 @@ public static class TypeConverters
 {
     public static T? TryConvert<T>(string? value)
     {
-        var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
         try
         {
             if (value is { Length: > 0 })
             {
-                return (T?)Get(type).ConvertFromInvariantString(value);
+                return (T?)Get(typeof(T)).ConvertFromInvariantString(value);
             }
         }
         catch
@@ -24,9 +23,12 @@ public static class TypeConverters
     }
 
     public static TypeConverter Get(Type type)
-        => TypeStore.TryGetValue(type, out var custom)
-        ? custom
-        : TypeDescriptor.GetConverter(type);
+    {
+        var not_null = Nullable.GetUnderlyingType(type) ?? type;
+        return TypeStore.TryGetValue(not_null, out var custom)
+            ? custom
+            : TypeDescriptor.GetConverter(not_null);
+    }
 
     private static readonly FrozenDictionary<Type, TypeConverter> TypeStore = new Dictionary<Type, TypeConverter>()
     {

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Conversion/TypeConverters.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Conversion/TypeConverters.cs
@@ -4,19 +4,15 @@ using System.ComponentModel;
 
 namespace DotNetProjectFile.MsBuild.Conversion;
 
-internal sealed class TypeConverters
+public static class TypeConverters
 {
-    public T? TryConvert<T>(string? value)
+    public static T? TryConvert<T>(string? value)
     {
         try
         {
             if (value is { Length: > 0 })
             {
-                var converter = TypeStore.TryGetValue(typeof(T), out var custom)
-                    ? custom
-                    : TypeDescriptor.GetConverter(typeof(T));
-
-                return (T?)converter.ConvertFromInvariantString(value);
+                return (T?)Get(typeof(T)).ConvertFromInvariantString(value);
             }
         }
         catch
@@ -26,7 +22,12 @@ internal sealed class TypeConverters
         return default;
     }
 
-    private readonly FrozenDictionary<Type, TypeConverter> TypeStore = new Dictionary<Type, TypeConverter>()
+    public static TypeConverter Get(Type type)
+        => TypeStore.TryGetValue(type, out var custom)
+        ? custom
+        : TypeDescriptor.GetConverter(type);
+
+    private static readonly FrozenDictionary<Type, TypeConverter> TypeStore = new Dictionary<Type, TypeConverter>()
     {
         [typeof(string)] = new StringConverter(),
         [typeof(bool)] = new BooleanConverter(),

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Conversion/TypeConverters.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Conversion/TypeConverters.cs
@@ -8,11 +8,12 @@ public static class TypeConverters
 {
     public static T? TryConvert<T>(string? value)
     {
+        var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
         try
         {
             if (value is { Length: > 0 })
             {
-                return (T?)Get(typeof(T)).ConvertFromInvariantString(value);
+                return (T?)Get(type).ConvertFromInvariantString(value);
             }
         }
         catch

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Conversion/TypeConverters.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Conversion/TypeConverters.cs
@@ -1,18 +1,22 @@
 using DotNetProjectFile.Conversion;
+using System.Collections.Frozen;
 using System.ComponentModel;
-using System.Reflection;
 
 namespace DotNetProjectFile.MsBuild.Conversion;
 
 internal sealed class TypeConverters
 {
-    public T? TryConvert<T>(string? value, Type classType, string propertyName)
+    public T? TryConvert<T>(string? value)
     {
         try
         {
-            if (value is { })
+            if (value is { Length: > 0 })
             {
-                return (T?)Get(classType, propertyName!).ConvertFromInvariantString(value);
+                var converter = TypeStore.TryGetValue(typeof(T), out var custom)
+                    ? custom
+                    : TypeDescriptor.GetConverter(typeof(T));
+
+                return (T?)converter.ConvertFromInvariantString(value);
             }
         }
         catch
@@ -22,44 +26,14 @@ internal sealed class TypeConverters
         return default;
     }
 
-    public TypeConverter Get(Type classType, string propertyName)
-    {
-        var property = classType.GetProperty(propertyName);
-
-        if (PropertyStore.TryGetValue(property, out TypeConverter converter))
-        {
-            return converter;
-        }
-
-        lock (locker)
-        {
-            if (!PropertyStore.TryGetValue(property, out converter))
-            {
-                if (property.GetCustomAttribute<TypeConverterAttribute>(true) is { } attr)
-                {
-                    converter = (TypeConverter)Activator.CreateInstance(Type.GetType(attr.ConverterTypeName));
-                }
-                else if (!TypeStore.TryGetValue(property.PropertyType, out converter))
-                {
-                    var type = Nullable.GetUnderlyingType(property.PropertyType)
-                        ?? property.PropertyType;
-
-                    converter = TypeDescriptor.GetConverter(type);
-                    TypeStore[property.PropertyType] = converter;
-                }
-                PropertyStore[property] = converter;
-            }
-        }
-        return converter;
-    }
-
-    private readonly Dictionary<PropertyInfo, TypeConverter> PropertyStore = [];
-    private readonly Dictionary<Type, TypeConverter> TypeStore = new()
+    private readonly FrozenDictionary<Type, TypeConverter> TypeStore = new Dictionary<Type, TypeConverter>()
     {
         [typeof(string)] = new StringConverter(),
         [typeof(bool)] = new BooleanConverter(),
+        [typeof(IOFile)] = new IOFileConverter(),
+        [typeof(IODirectory)] = new IODirectoryConverter(),
         [typeof(LanguageVersion)] = new LanguageVersionConverter(),
-    };
-
-    private readonly object locker = new();
+        [typeof(SemVer)] = new SemVerConverter(),
+    }
+    .ToFrozenDictionary();
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -93,8 +93,8 @@ public abstract class Node : XmlAnalysisNode
 
     internal Node Create(XElement element) => Factory.Create(element, this, Project);
 
-    protected T? Convert<T>(string? value, [CallerMemberName] string? propertyName = null)
-        => Converters.TryConvert<T>(value, GetType(), propertyName!);
+    protected T? Convert<T>(string? value)
+        => Converters.TryConvert<T>(value);
 
     IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -94,9 +94,7 @@ public abstract class Node : XmlAnalysisNode
     internal Node Create(XElement element) => Factory.Create(element, this, Project);
 
     protected T? Convert<T>(string? value)
-        => Converters.TryConvert<T>(value);
+        => TypeConverters.TryConvert<T>(value);
 
     IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
-
-    private static readonly TypeConverters Converters = new();
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Version.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Version.cs
@@ -1,5 +1,4 @@
 namespace DotNetProjectFile.MsBuild;
 
 public sealed class Version(XElement element, Node parent, MsBuildProject project)
-    : Node<SemVer>(element, parent, project)
-{ }
+    : Node<SemVer>(element, parent, project);

--- a/src/DotNetProjectFile.Analyzers/MsBuild/VersionPrefix.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/VersionPrefix.cs
@@ -1,5 +1,4 @@
 namespace DotNetProjectFile.MsBuild;
 
 public sealed class VersionPrefix(XElement element, Node parent, MsBuildProject project)
-    : Node<SemVer>(element, parent, project)
-{ }
+    : Node<SemVer>(element, parent, project);

--- a/src/DotNetProjectFile.Analyzers/NuGet/Configuration/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Configuration/Node.cs
@@ -87,9 +87,7 @@ public abstract class Node : XmlAnalysisNode
     internal Node Create(XElement element) => Factory.Create(element, this, ConfigFile);
 
     protected T? Convert<T>(string? value)
-        => Converters.TryConvert<T>(value);
+        => TypeConverters.TryConvert<T>(value);
 
     IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
-
-    private static readonly TypeConverters Converters = new();
 }

--- a/src/DotNetProjectFile.Analyzers/NuGet/Configuration/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/NuGet/Configuration/Node.cs
@@ -86,8 +86,8 @@ public abstract class Node : XmlAnalysisNode
 
     internal Node Create(XElement element) => Factory.Create(element, this, ConfigFile);
 
-    protected T? Convert<T>(string? value, [CallerMemberName] string? propertyName = null)
-        => Converters.TryConvert<T>(value, GetType(), propertyName!);
+    protected T? Convert<T>(string? value)
+        => Converters.TryConvert<T>(value);
 
     IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
 

--- a/src/DotNetProjectFile.Analyzers/SemVer.cs
+++ b/src/DotNetProjectFile.Analyzers/SemVer.cs
@@ -10,7 +10,7 @@ namespace DotNetProjectFile;
 /// <remarks>
 /// See: https://semver.org/.
 /// </remarks>
-[TypeConverter(typeof(Converter))]
+[TypeConverter(typeof(Conversion.SemVerConverter))]
 public sealed record SemVer()
 {
     /// <summary>Initializes a new instance of the <see cref="SemVer"/> class.</summary>
@@ -83,19 +83,4 @@ public sealed record SemVer()
         @"^(?<Major>0|[1-9][0-9]*)\.(?<Minor>0|[1-9][0-9]*)\.(?<Patch>0|[1-9][0-9]*)(?:-(?<PreRelease>(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<BuildMetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled,
         TimeSpan.FromSeconds(1));
-
-    private sealed class Converter : TypeConverter
-    {
-        /// <inheritdoc />
-        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
-            => sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
-
-        /// <inheritdoc />
-        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value) => value switch
-        {
-            null => null,
-            string str => TryParse(str),
-            _ => base.ConvertFrom(context, culture, value),
-        };
-    }
 }

--- a/src/DotNetProjectFile.Analyzers/Slnx/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Slnx/Node.cs
@@ -84,9 +84,7 @@ public abstract class Node : XmlAnalysisNode
     internal Node Create(XElement element) => Factory.Create(element, this, Solution);
 
     protected T? Convert<T>(string? value)
-        => Converters.TryConvert<T>(value);
+        => TypeConverters.TryConvert<T>(value);
 
     IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
-
-    private static readonly TypeConverters Converters = new();
 }

--- a/src/DotNetProjectFile.Analyzers/Slnx/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Slnx/Node.cs
@@ -83,8 +83,8 @@ public abstract class Node : XmlAnalysisNode
 
     internal Node Create(XElement element) => Factory.Create(element, this, Solution);
 
-    protected T? Convert<T>(string? value, [CallerMemberName] string? propertyName = null)
-        => Converters.TryConvert<T>(value, GetType(), propertyName!);
+    protected T? Convert<T>(string? value)
+        => Converters.TryConvert<T>(value);
 
     IEnumerable<XmlAnalysisNode> XmlAnalysisNode.Children() => Children;
 


### PR DESCRIPTION
It turns out that the `TypeConverter` resolvement does work in our test setup, but not within a `dotnet build` context. By simplifying this dramatically ([YAGNI](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it)) the problem was resolved.

Closes #773
Closes #779