### PR TITLE
Proj1007: Non-Roslyn languages require .NET Project File Analyzers SDK

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -189,6 +189,7 @@ reported to the [GitHub repository](https://github.com/dotnet-project-file-analy
 * [**Proj1002** Use Microsoft's analyzers](rules/Proj1002.md)
 * [**Proj1003** Use Sonar analyzers](rules/Proj1003.md)
 * [**Proj1004** .NET Project File Analyzers SDK no longer requires separate package](rules/Proj1004.md)
+* [**Proj1007** Non-Roslyn languages require .NET Project File Analyzers SDK](rules/Proj1007.md)
 
 ### Design
 * [**Proj1300** Avoid project references to executables](rules/Proj1300.md)

--- a/docs/rules/Proj1007.md
+++ b/docs/rules/Proj1007.md
@@ -1,0 +1,12 @@
+---
+parent: Other
+ancestor: MSBuild
+permalink: /rules/Proj1007
+---
+
+# Proj1007: Non-Roslyn languages require .NET Project File Analyzers SDK
+Project files for languages like [F#](https://fsharp.org/) that do not use
+Roslyn to compile, require the [.NET Project File Analyzers SDK](../general/sdk.md)
+to analyze themselves.
+
+Note that this rule itself relies on MSBuild instead of Roslyn.

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -89,6 +89,7 @@ v1.13.0
 - Proj1004: .NET Project File Analyzers SDK no longer requires separate package. (NEW RULE)
 - Proj1300: Benchmark projects may depend on everything. (FP)
 - Proj1303: Avoid project references to benchmark projects. (NEW RULE)
+- Proj1007: Non-Roslyn languages require .NET Project File Analyzers SDK. (NEW RULE)
 - Proj3000: Drop difference between additional and regular files. (FP)
 ]]>
     </ToBeReleased>

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -139,7 +139,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj1002** Use Microsoft's analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1002.html)
 * [**Proj1003** Use Sonar analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1003.html)
 * [**Proj1004** .NET Project File Analyzers SDK not longer requires separate package](https://dotnet-project-file-analyzers.github.io/rules/Proj1004.html)
-* [**Proj1007**Non-Roslyn languages require .NET Project File Analyzers SDK](https://dotnet-project-file-analyzers.github.io/rules/Proj1007.html)
+* [**Proj1007** Non-Roslyn languages require .NET Project File Analyzers SDK](https://dotnet-project-file-analyzers.github.io/rules/Proj1007.html)
 
 ### Formatting
 * [**Proj1700** Indent XML](https://dotnet-project-file-analyzers.github.io/rules/Proj1700.html)

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -139,6 +139,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj1002** Use Microsoft's analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1002.html)
 * [**Proj1003** Use Sonar analyzers](https://dotnet-project-file-analyzers.github.io/rules/Proj1003.html)
 * [**Proj1004** .NET Project File Analyzers SDK not longer requires separate package](https://dotnet-project-file-analyzers.github.io/rules/Proj1004.html)
+* [**Proj1007**Non-Roslyn languages require .NET Project File Analyzers SDK](https://dotnet-project-file-analyzers.github.io/rules/Proj1007.html)
 
 ### Formatting
 * [**Proj1700** Indent XML](https://dotnet-project-file-analyzers.github.io/rules/Proj1700.html)

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
@@ -1,5 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' or '$(MSBuildProjectExtension)' == '.vbproj'">
+    <IsRoslynBased>true</IsRoslynBased>
+  </PropertyGroup>
+  
   <!--
     SonarQube can pick up issues report on files others than compiling files
     if they are reported as <Content>.
@@ -22,12 +26,21 @@
   </ItemGroup>
 
   <!--To inform users the SDK package is no longer needed. -->
-  <Target Name="Obsolete" BeforeTargets="ResolvePackageAssets">
+  <Target Name="Proj1004" BeforeTargets="ResolvePackageAssets">
     <Warning
       Condition="@(PackageReference->AnyHaveMetadataValue('Identity', 'DotNetProjectFile.Analyzers.Sdk'))"
       Code="Proj1004"
       Text="The package reference to DotNetProjectFile.Analyzers.Sdk can be removed"
       HelpLink="https://dotnet-project-file-analyzers.github.io/rules/Proj1004.html" />
+  </Target>
+
+  <!--To inform users to use .net.csproj for not Roslyn-based languages such as F#. -->
+  <Target Name="Proj1007" BeforeTargets="ResolvePackageAssets">
+    <Warning
+      Condition="'$(IsRoslynBased)' != 'true' and $([MSBuild]::GetPathOfFileAbove('.net.csproj', '$(MSBuildThisFileDirectory)')) == ''"
+      Code="Proj1007"
+      Text="Use .net.csproj to analyze this project"
+      HelpLink="https://dotnet-project-file-analyzers.github.io/rules/Proj1007.html" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This should help preventing issues like #628 being raised, as it should guide people in setting op the analyzers for non-Roslyn languages such as F#.

Closes #785