### PR TITLE
.net.csproj shows Directory.*, .globalconfig, and .editorconfig files

### DIFF
--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -83,6 +83,8 @@
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+v1.*
+- .net.csproj shows Directory.*, .globalconfig, and .editorconfig files. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.Sdk.props
@@ -2,11 +2,18 @@
 
   <ItemGroup>
     <!-- NuGet.config -->
-    <AdditionalFiles Include="$([MSBuild]::GetPathOfFileAbove('NuGet.config', '$(MSBuildThisFileDirectory)'))" />
+    <AdditionalFiles
+      Include="$([MSBuild]::GetPathOfFileAbove('NuGet.config', '$(MSBuildThisFileDirectory)'))"
+      Link="NuGet.config"/>
+
     <!-- .editorconfig -->
-    <AdditionalFiles Include="$([MSBuild]::GetPathOfFileAbove('.editorconfig', '$(MSBuildThisFileDirectory)'))" />
+    <AdditionalFiles
+      Include="$([MSBuild]::GetPathOfFileAbove('.editorconfig', '$(MSBuildThisFileDirectory)'))"
+      Link=".editorconfig" />
+    
     <!-- .globalconfig -->
     <AdditionalFiles Include="$(GlobalAnalyzerConfigFiles)" />
+    
     <AdditionalFiles Include=".git*" />
     <AdditionalFiles Include=".github/**" />
     <AdditionalFiles Include="*.config" />
@@ -24,29 +31,7 @@
     <AdditionalFiles Visible="false" Exclude="$(AdditionalFiles)" Include="**/*.props" />
     <AdditionalFiles Visible="false" Exclude="$(AdditionalFiles)" Include="**/*.targets" />
   </ItemGroup>
-
-  <!-- Directory.* files should be visible in the .net.csproj -->
-  <ItemGroup>
-    <!-- Directory.Build.props -->
-    <AdditionalFiles
-      Condition="'$(ImportDirectoryBuildProps)' == 'true'"
-      Update="$(DirectoryBuildPropsPath)"
-      Link="$(_DirectoryBuildPropsFile)"
-      Visible ="true" />
-    <!-- Directory.Build.targets -->
-    <AdditionalFiles
-      Condition="'$(ImportDirectoryBuildTargets)' == 'true'"
-      Update="$(DirectoryBuildTargetsPath)"
-      Link="$(_DirectoryBuildTargetsFile)"
-      Visible ="true" />
-    <!-- Directory.Packages.props -->
-    <AdditionalFiles
-      Condition="'$(ImportDirectoryPackagesProps)' == 'true'"
-      Update="$(DirectoryPackagesPropsPath)"
-      Link="$(_DirectoryPackagesPropsFile)"
-      Visible ="true" />
-  </ItemGroup>
-
+  
   <!-- Make visible -->
   <ItemGroup>
     <AdditionalFiles Visible ="true" Update="*.props" />
@@ -55,8 +40,6 @@
     <AdditionalFiles Visible ="true" Update="props/*.targets" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="**/TestResults/**" />
-  </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)None.Sdk.props" />
 
 </Project>

--- a/src/DotNetProjectFile.Analyzers/build/None.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers/build/None.Sdk.props
@@ -1,0 +1,26 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+
+    <None Include="**/TestResults/**" />
+    
+    <!-- Directory.Build.props -->
+    <None
+      Condition="'$(ImportDirectoryBuildProps)' == 'true'"
+      Include="$(DirectoryBuildPropsPath)"
+      Link="$(_DirectoryBuildPropsFile)" />
+    
+    <!-- Directory.Build.targets -->
+    <None
+      Condition="'$(ImportDirectoryBuildTargets)' == 'true'"
+      Include="$(DirectoryBuildTargetsPath)"
+      Link="$(_DirectoryBuildTargetsFile)" />
+    
+    <!-- Directory.Packages.props -->
+    <None
+      Condition="'$(ImportDirectoryPackagesProps)' == 'true'"
+      Include="$(DirectoryPackagesPropsPath)"
+      Link="$(_DirectoryPackagesPropsFile)" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Using a separate `<None>` seems to work.

Closes #795 