### PR TITLE
Centralize .NET SDK version definition

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v5.2.0
-        with:
-          dotnet-version: '10.0.101'
 
       - name: Build
         run: dotnet build dotnet-project-file-analyzers.slnx -c Release
@@ -61,6 +59,9 @@ jobs:
       contents: write
     needs: build
     steps:
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v5.2.0
+
       - name: Download Artifact
         uses: actions/download-artifact@v4
         with:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.101",
+    "rollForward": "latestPatch"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.101",
+    "version": "10.0.300",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
Moves the .NET SDK version specification from the GitHub Actions workflow to a `global.json` file. This aligns with standard .NET project practices for managing SDK versions, ensures consistency across all projects in the repository, and simplifies future updates for both build and publish jobs.

fixes #811 