### PR TITLE
Hide folders only containing invisible <Content>

### DIFF
--- a/.net.csproj
+++ b/.net.csproj
@@ -15,6 +15,8 @@
   <!-- Do not analyze the projects. -->
   <ItemGroup>
     <AdditionalFiles Remove="projects/**.*" />
+    <AdditionalFiles Remove="src\DotNetProjectFile.Analyzers\**" />
+    <None Remove="src\DotNetProjectFile.Analyzers\**" />
   </ItemGroup>
 
   <!--

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />
 

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/common.props" />
 
@@ -85,6 +85,7 @@ ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
 v1.*
 - Proj0253, Proj0254: Ignore version containing an MSBuild variable. (FP)
+- Hide folders only containing invisible <Content>. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
@@ -8,8 +8,9 @@
     SonarQube can pick up issues report on files others than compiling files
     if they are reported as <Content>.
     
-    * Exclude="@(Content)" 
-      Prevents <Content> from being added twice.
+    * Exclude="@(Content);**/bin/**/*;**/obj/**/*" 
+      Prevents <Content> from being added twice, or content being added in the
+      bin and obj folders.
       
     * CopyToOutputDirectory="never"
       Ensures that <Content> only included to satisfy SonarQube is not copied.
@@ -17,15 +18,20 @@
     * Visible="false"
       Prevents <Content> from being shown in the IDE that was included by the user.
       
+    * Link="$([System.Guid]::NewGuid())"
+      Flattens the file structure of the content file to work arround a
+      Visual Studio limitation: github.com/dotnet/project-system/issues/5859
+      
     * Pack="false"
       Prevents <Content> from being added to NuGet packages.
   -->
   <ItemGroup Condition="'$(SonarQubeIntegration)' == 'true'">
-    <Content Exclude="@(Content)" CopyToOutputDirectory="never" Visible="false" Pack="false" Include="**/*.??proj" />
-    <Content Exclude="@(Content)" CopyToOutputDirectory="never" Visible="false" Pack="false" Include="**/*.config" />
-    <Content Exclude="@(Content)" CopyToOutputDirectory="never" Visible="false" Pack="false" Include="**/*.props" />
-    <Content Exclude="@(Content)" CopyToOutputDirectory="never" Visible="false" Pack="false" Include="**/*.resx" />
-    <Content Exclude="@(Content)" CopyToOutputDirectory="never" Visible="false" Pack="false" Include="**/*.slnx" />
+    <Content Exclude="@(Content);**/bin/**/*;**/obj/**/*" CopyToOutputDirectory="never" Visible="false" Pack="false" Link="$([System.Guid]::NewGuid())" Include="**/*.??proj" />
+    <Content Exclude="@(Content);**/bin/**/*;**/obj/**/*" CopyToOutputDirectory="never" Visible="false" Pack="false" Link="$([System.Guid]::NewGuid())" Include="**/*.config" />
+    <Content Exclude="@(Content);**/bin/**/*;**/obj/**/*" CopyToOutputDirectory="never" Visible="false" Pack="false" Link="$([System.Guid]::NewGuid())" Include="**/*.props" />
+    <Content Exclude="@(Content);**/bin/**/*;**/obj/**/*" CopyToOutputDirectory="never" Visible="false" Pack="false" Link="$([System.Guid]::NewGuid())" Include="**/*.targets" />
+    <Content Exclude="@(Content);**/bin/**/*;**/obj/**/*" CopyToOutputDirectory="never" Visible="false" Pack="false" Link="$([System.Guid]::NewGuid())" Include="**/*.resx" />
+    <Content Exclude="@(Content);**/bin/**/*;**/obj/**/*" CopyToOutputDirectory="never" Visible="false" Pack="false" Link="$([System.Guid]::NewGuid())" Include="**/*.slnx" />
   </ItemGroup>
 
   <!--To inform users the SDK package is no longer needed. -->


### PR DESCRIPTION
The workaround is to flatten the rendering by using the `Link` attribute. We use `$([System.Guid]::NewGuid())` to ensure unique names.

Fixes #820 