### PR TITLE
Proj0052: Prefer attributes over elements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@ reported to the [GitHub repository](https://github.com/dotnet-project-file-analy
 * [**Proj0049** Prefer the latest released language version](rules/Proj0049.md)
 * [**Proj0050** Enforce code-style in builds](rules/Proj0050.md)
 * [**Proj0051** Project reference must be case-consistent with the file system](rules/Proj0051.md)
+* [**Proj0052** Prefer attributes over element](rules/Proj0052.md)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)

--- a/docs/rules/Proj0052.md
+++ b/docs/rules/Proj0052.md
@@ -1,0 +1,52 @@
+---
+parent: General
+ancestor: MSBuild
+permalink: /rules/Proj0052
+---
+
+# Proj0052: Prefer attributes over elements
+
+The use of XML attributes is preferred over child XML elements for item metadata
+within MSBuild files. Attributes are more concise and easier to scan than nested
+elements, especially when configuring only a few metadata properties. This style
+also aligns with modern .NET SDK project conventions.
+
+## Exceptions
+* Structural Containers `<PropertyGroup>` and `<ItemDefinitionGroup>`
+  are excluded from this rule, as they are designed by MSBuild to use child
+  elements rather than attributes.
+* Content item metadata containing multi-line text is automatically recognized
+  and will not be flagged, as XML attributes are unable to properly preserve
+  line breaks.
+
+## Non-compliant
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv">
+      <Version>8.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>
+```
+
+## Compliant
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>
+```

--- a/globalconfig.verified.txt
+++ b/globalconfig.verified.txt
@@ -49,6 +49,7 @@ dotnet_diagnostic.Proj0048.severity = warning    # Language version should be se
 dotnet_diagnostic.Proj0049.severity = warning    # Prefer the latest released language version
 dotnet_diagnostic.Proj0050.severity = warning    # Enforce code-style in builds
 dotnet_diagnostic.Proj0051.severity = warning    # Project reference must be case-consistent with the file system
+dotnet_diagnostic.Proj0052.severity = warning    # Prefer attributes over elements
 dotnet_diagnostic.Proj0200.severity = warning    # Define the project packability explicitly
 dotnet_diagnostic.Proj0201.severity = warning    # Define the project version explicitly
 dotnet_diagnostic.Proj0202.severity = warning    # Define the project description explicitly

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Prefer_attributes_over_elements.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Prefer_attributes_over_elements.cs
@@ -37,6 +37,12 @@ public class Reports
         	  </CustomItem>
            </ItemGroup>
 
+           <ItemDefinitionGroup>
+             <Content>
+              <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+             </Content>
+           </ItemDefinitionGroup>
+
          </Project>
         """")
        .HasIssues(

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Prefer_attributes_over_elements.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Prefer_attributes_over_elements.cs
@@ -1,0 +1,45 @@
+namespace Specs.Rules.MS_Build.Prefer_attributes_over_elements;
+
+public class Reports
+{
+    [Test]
+    public void elements_that_can_be_attributes() => new PreferAttributesOverElements()
+        .ForInlineCsproj(""""
+         <Project Sdk="Microsoft.NET.Sdk">
+
+           <PropertyGroup>
+             <TargetFramework>net10.0</TargetFramework>
+           </PropertyGroup>
+
+           <ItemGroup Label="Noncompliant">
+             <PackageReference Include="Qowaiv">
+        	   <Version>8.0.0</Version>
+        	   <PrivateAssets>
+        	   none
+        	   </PrivateAssets>
+        	 </PackageReference>
+           </ItemGroup>
+           
+           <ItemGroup Label="Compliant conditional">
+        	 <PackageReference Update="coverlet.collector">
+        	   <Version Condition="'$(Configuration)'=='Release'">10.0.0</Version>
+        	   <Version Condition="'$(Configuration)'!='Release'">10.0.1</Version>
+        	 </PackageReference>
+           </ItemGroup>
+
+           <ItemGroup Label="Compliant multi-line">
+              <CustomItem Include="reference">
+        	    <Documentation>
+        	      Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean
+        		  commodo ligula eget dolor. Aenean massa. Cum sociis natoque
+        		  penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+        		</Documentation>
+        	  </CustomItem>
+           </ItemGroup>
+
+         </Project>
+        """")
+       .HasIssues(
+            Issue.WRN("Proj0052", "Consider <Version> as an attribute"/*..*/).WithSpan(08, 04, 08, 28),
+            Issue.WRN("Proj0052", "Consider <PrivateAssets> as an attribute").WithSpan(09, 04, 11, 20));
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PreferAttributesOverElements.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PreferAttributesOverElements.cs
@@ -1,0 +1,32 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+/// <summary>Implements <see cref="Rule.PreferAttributesOverElements"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class PreferAttributesOverElements() : MsBuildProjectFileAnalyzer(Rule.PreferAttributesOverElements)
+{
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
+    protected override void Register(ProjectFileAnalysisContext context) => Walk(context.File, context);
+
+    private void Walk(Node node, ProjectFileAnalysisContext context)
+    {
+        if (node.Children.Any())
+        {
+            foreach (var child in node.Children.Where(Applicable))
+                Walk(child, context);
+        }
+        else if (CanBeAttribute(node))
+        {
+            context.ReportDiagnostic(Descriptor, node, node.LocalName);
+        }
+    }
+
+    private static bool Applicable(Node node)
+        => node is not PropertyGroup;
+
+    private static bool CanBeAttribute(Node node)
+        => node.Element.Attributes().None()
+        && !node.Element.Value.Trim().Contains('\n');
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PreferAttributesOverElements.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/PreferAttributesOverElements.cs
@@ -23,8 +23,9 @@ public sealed class PreferAttributesOverElements() : MsBuildProjectFileAnalyzer(
         }
     }
 
-    private static bool Applicable(Node node)
-        => node is not PropertyGroup;
+    private static bool Applicable(Node node) => node
+        is not PropertyGroup
+        and not ItemDefinitionGroup;
 
     private static bool CanBeAttribute(Node node)
         => node.Element.Attributes().None()

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -78,19 +78,19 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.14.1</Version>
+    <Version>1.15.0</Version>
     <ToBeReleased>
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
-v1.*
-- Proj0052: Prefer attributes over elements. (NEW RULE)
-- Proj0253, Proj0254: Ignore version containing an MSBuild variable. (FP)
-- Hide folders only containing invisible <Content>. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+v1.15.0
+- Proj0052: Prefer attributes over elements. (NEW RULE)
+- Proj0253, Proj0254: Ignore version containing an MSBuild variable. (FP)
+- Hide folders only containing invisible <Content>. (BUG)
 v1.14.1
 - Ignore <Target> nodes when reading properties. (BUG)
 - <Content> to improve the SonarQube experience should not be packed. (BUG)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -84,6 +84,7 @@
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
 v1.*
+- Proj0052: Prefer attributes over elements. (NEW RULE)
 - Proj0253, Proj0254: Ignore version containing an MSBuild variable. (FP)
 - Hide folders only containing invisible <Content>. (BUG)
 ]]>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ItemDefinitionGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ItemDefinitionGroup.cs
@@ -1,0 +1,5 @@
+namespace DotNetProjectFile.MsBuild;
+
+/// <summary>Represents an item definition group in a Visual Studio project file.</summary>
+public sealed class ItemDefinitionGroup(XElement element, Node parent, MsBuildProject project)
+    : Node(element, parent, project);

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -53,6 +53,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0049** Prefer the latest released language version](https://dotnet-project-file-analyzers.github.io/rules/Proj0049.html)
 * [**Proj0050** Enforce code-style in builds](https://dotnet-project-file-analyzers.github.io/rules/Proj0050.html)
 * [**Proj0051** Project reference must be case-consistent with the file system](https://dotnet-project-file-analyzers.github.io/rules/Proj0051.html)
+* [**Proj0052** Prefer attributes over element](https://dotnet-project-file-analyzers.github.io/rules/Proj0052.html)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](https://dotnet-project-file-analyzers.github.io/rules/Proj0200.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -502,7 +502,7 @@ public static partial class Rule
         title: "Prefer attributes over elements",
         message: "Consider <{0}> as an attribute",
         description: "Attributes are more concise and readable than elements for (simple) values.",
-        tags: ["Clearity", "Readabillity"],
+        tags: ["Clearity", "Readability"],
         category: Category.Formatting);
 
     public static DiagnosticDescriptor DefineIsPackable => New(

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -497,6 +497,14 @@ public static partial class Rule
         tags: ["dependencies", "dependency", "file system", "UNIX", "case-consistent"],
         category: Category.Bug);
 
+    public static DiagnosticDescriptor PreferAttributesOverElements => New(
+        id: 0052,
+        title: "Prefer attributes over elements",
+        message: "Consider <{0}> as an attribute",
+        description: "Attributes are more concise and readable than elements for (simple) values.",
+        tags: ["Clearity", "Readabillity"],
+        category: Category.Formatting);
+
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,
         title: "Define the project packability explicitly",


### PR DESCRIPTION
The use of XML attributes is preferred over child XML elements for item metadata within MSBuild files. Attributes are more concise and easier to scan than nested elements, especially when configuring only a few metadata properties. This style also aligns with modern .NET SDK project conventions.

## Exceptions
* Structural Containers `<PropertyGroup>` and `<ItemDefinitionGroup>`  are excluded from this rule, as they are designed by MSBuild to use child  elements rather than attributes.
* Content item metadata containing multi-line text is automatically recognized and will not be flagged, as XML attributes are unable to properly preserve  line breaks.

Closes #485