### PR TITLE
Check what's in the package

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Package/NuGet_package_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Package/NuGet_package_specs.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.IO.Compression;
+
+namespace Specs.NuGet_package_specs;
+
+#if !DEBUG
+[Explicit]
+#endif
+public class Contains
+{
+    [TestCaseSource(nameof(Packages))]
+    public void Entries(FileInfo file)
+    {
+        using var archive = ZipFile.OpenRead(file.FullName);
+
+        var entries = archive.Entries.Select(e => e.FullName).Where(e => !e.EndsWith(".psmdcp"));
+
+        foreach (var e in entries)
+            Console.WriteLine(e);
+
+
+        entries.Should().BeEquivalentTo(
+            // NuSpec
+            "DotNetProjectFile.Analyzers.nuspec",
+            "logo_128x128.png",
+            "README.md",
+
+            // Analyzer       
+            "analyzers/DotNetProjectFile.Analyzers.dll",
+
+            // Build props and targets
+            "build/AdditionalFiles.props",
+            "build/AdditionalFiles.Sdk.props",
+            "build/CompilerVisible.props",
+            "build/DotNetProjectFile.Analyzers.props",
+            "build/DotNetProjectFile.Analyzers.Sdk.props",
+            "build/DotNetProjectFile.Analyzers.targets",
+            "build/None.Sdk.props",
+            
+            // tools
+            "tools/install.ps1",
+            "tools/uninstall.ps1",
+
+            // Added by NuGet
+            "[Content_Types].xml",
+            "_rels/.rels", 
+            "_manifest/spdx_2.2/manifest.spdx.json",
+            "_manifest/spdx_2.2/manifest.spdx.json.sha256");
+    }
+
+
+    private static IEnumerable<FileInfo> Packages => Root.EnumerateFiles("*.nupkg");
+
+    private static readonly DirectoryInfo Root = new("../../../../../src/DotNetProjectFile.Analyzers/bin/Release");
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -28,6 +28,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package settings">
+    <IncludeBuildOutput>false</IncludeBuildOutput>
     <RepositoryType>git</RepositoryType>
     <PackageId>DotNetProjectFile.Analyzers</PackageId>
     <PackageProjectUrl>https://dotnet-project-file-analyzers.github.io</PackageProjectUrl>


### PR DESCRIPTION
Issue #828 claims that `build/DotNetProjectFile.Analyzers.targets` is not longer part of the package. I created a unit test that check its content. It seems that this file is included.

I also noticed that ``lib/*` is included, which does not add anything for this package, so with `<IncludeBuildOutput>` to `false` will not longer be included.

This test can not be easily run, as the `.nupkg` is not available automatically, but should be checked while developing.