### PR TITLE
Make the Package_assets tests non-parallelizable so the nupkg test runs on the build server

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Package_assets_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Package_assets_specs.cs
@@ -5,6 +5,8 @@ using ProjectItem = Specs.TestTools.ProjectItem;
 
 namespace MS_Build.Package_assets_specs;
 
+[NonParallelizable] // these tests all build the shared CompliantCSharpPackage fixture (BuildalyzerContext
+// wipes its bin/obj), so running them in parallel races the pack and intermittently loses the nupkg.
 public class Builds
 {
 #if Is_Windows
@@ -201,9 +203,6 @@ public class Builds
     }
 
     [Test]
-#if !DEBUG
-    [Explicit(reason: "nupkg can not be resolved at the build server")]
-#endif
     public void Package()
     {
         using var ctx = BuildalyzerContext.ForProject("CompliantCSharpPackage/CompliantCSharpPackage.csproj");
@@ -212,11 +211,15 @@ public class Builds
         options.Arguments.Add("-p:GeneratePackageOnBuild=true");
         options.Arguments.Add("-p:Configuration=RELEASE");
 
-        ctx.Analyzer.Build(options);
+        var result = ctx.Analyzer.Build(options).Results.Single();
+        result.Succeeded.Should().BeTrue("the package build must succeed before its output can be inspected");
 
-        var package = new DirectoryInfo(Path.Combine(ctx.Location.Directory!.FullName, "../artifacts"))
-            .EnumerateFiles("*.nupkg", SearchOption.AllDirectories)
-            .First();
+        var artifacts = new DirectoryInfo(Path.Combine(ctx.Location.Directory!.FullName, "../artifacts"));
+        var packages = artifacts.Exists
+            ? artifacts.EnumerateFiles("*.nupkg", SearchOption.AllDirectories).ToArray()
+            : Array.Empty<FileInfo>();
+        packages.Should().ContainSingle("a single nupkg should be produced under {0}", artifacts.FullName);
+        var package = packages.Single();
 
         var payload = Nupkg.Read(package).Where(e => !Ignore(e));
 


### PR DESCRIPTION
Closes #834.

`Package` was `[Explicit]` because the generated nupkg "can not be resolved at the build server". The cause is a parallel race, not a path problem.

`Package`, `With_defaults` and `Does_not_add_content_with_SonarQubeIntegration_disabled` all build the same `CompliantCSharpPackage` fixture, and `BuildalyzerContext` deletes its `bin`/`obj` in the constructor. Under the assembly's `[Parallelizable(ParallelScope.All)]` they run concurrently, so one test's `bin`/`obj` wipe interrupts another's pack and `../artifacts` intermittently never gets written. The result is non-deterministic: the nupkg is sometimes there, sometimes not.

Marking the `Builds` fixture `[NonParallelizable]` (the same way the file-lock tests already are) serializes them. The pack then runs to completion every time, so `[Explicit]` is removed and the test runs on CI again.

It also hardens the test:
- assert the build succeeded before inspecting its output, so a broken build fails clearly instead of as a confusing file-not-found;
- locate exactly one nupkg with a message naming where it looked, instead of `First()`.

Verified green on a GitHub-hosted runner (full suite, `-c Release --no-build`): 0 failed, `Package` included.
