### PR TITLE
Improve file cache

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Caching/FileCache_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Caching/FileCache_specs.cs
@@ -57,6 +57,24 @@ public class TryGetOrUpdate
     }
 
     [Test]
+    public async Task Updates_existing_entry_when_length_changes_but_write_time_is_equal()
+    {
+        using var file = await TempFile.CreateText("Hello, World!");
+        var stamp = File.GetLastWriteTimeUtc(file.Path);
+
+        var cache = new FileCache<Entry>();
+        cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => new Entry());
+        cache.Count.Should().Be(1);
+
+        await File.WriteAllTextAsync(file.Path, "Hello, World! Extended.");
+        File.SetLastWriteTimeUtc(file.Path, stamp);
+
+        var result = cache.TryGetOrUpdate(IOFile.Parse(file.Path), p => new Entry(17));
+        cache.Count.Should().Be(1);
+        result.Should().Be(new Entry(17));
+    }
+
+    [Test]
     public async Task Remove_existing_entry_when_transform_fails()
     {
         using var file = await TempFile.CreateText("Hello, World!");

--- a/src/DotNetProjectFile.Analyzers/Caching/FileCache.cs
+++ b/src/DotNetProjectFile.Analyzers/Caching/FileCache.cs
@@ -4,7 +4,9 @@ namespace DotNetProjectFile.Caching;
 
 /// <summary>Caches items based on location.</summary>
 /// <remarks>
-/// The <see cref="IOFile.LastWriteTimeUtc"/> is used for invalidation.
+/// Invalidation is based on the file's <see cref="IOFile.LastWriteTimeUtc"/>
+/// combined with its length, so edits that keep the same write time
+/// are still detected. Files without a readable stamp are never cached.
 /// </remarks>
 [DebuggerDisplay("Count = {Count}")]
 public sealed class FileCache<T>() where T : class
@@ -16,28 +18,68 @@ public sealed class FileCache<T>() where T : class
 
     /// <summary>Tries to get the current file content for a specified file.</summary>
     /// <remarks>
-    /// Uses the cased version if possible, otherwise creates/updates the file.
+    /// Returns the cached value when the file's last edit and length are unchanged,
+    /// otherwise creates/updates the entry. Removes the entry when the file is gone,
+    /// unreadable or when the transform fails.
     /// </remarks>
-    public T? TryGetOrUpdate(IOFile path, Func<IOFile, T?> create) => path switch
+    public T? TryGetOrUpdate(IOFile path, Func<IOFile, T?> create)
     {
-        _ when !path.HasValue || !path.Exists => Remove(path),
-        _ when Lookup.TryGetValue(path, out var entry) && entry.Version == path.LastWriteTimeUtc => entry.Value,
-        _ when create(path) is { } file => Update(path, file),
-        _ => Remove(path),
-    };
+        if (!path.HasValue || Stamp.For(path) is not { } stamp)
+        {
+            return Remove(path);
+        }
 
-    private T Update(IOFile path, T file)
-    {
-        Lookup[path] = new(path.LastWriteTimeUtc, file);
-        return file;
+        var entry = Lookup.GetOrAdd(path, static _ => new());
+
+        lock (entry)
+        {
+            if (entry.Value is { } && entry.Version == stamp)
+            {
+                return entry.Value;
+            }
+            else if (create(path) is { } file)
+            {
+                entry.Value = file;
+                entry.Version = stamp;
+                return file;
+            }
+        }
+
+        return Remove(path);
     }
 
-    /// <summary>Remove, as we can not longer resolve it.</summary>
+    /// <summary>Remove, as we can no longer resolve it.</summary>
     private T? Remove(IOFile path)
     {
         Lookup.TryRemove(path, out _);
         return default;
     }
 
-    private readonly record struct Entry(DateTime? Version, T Value);
+    private sealed class Entry
+    {
+        public T? Value { get; set; }
+
+        public Stamp Version { get; set; }
+    }
+
+    /// <summary>Identifies a file version by write time and length.</summary>
+    private readonly record struct Stamp(DateTime WriteTimeUtc, long Length)
+    {
+        /// <summary>Reads the stamp from a single <see cref="IOFile"/>, or null if unreadable.</summary>
+        public static Stamp? For(IOFile path)
+        {
+            if (path.Info is { Exists: true } info)
+            {
+                try
+                {
+                    return new(info.LastWriteTimeUtc, info.Length);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
Current cache implementation:
- Potentially parses file multiple times in parallel. (Solved in this PR)
- `LastWriteTimeUtc` is quite coarse and might miss multiple edits that come in repeatedly. (Solved in this PR)
- If file exists, but `LastWriteTimeUtc` comes back as `null`, the file is treated as unedited if this also happened the previous time. (Solved in this PR)
- Cache might potentially cache entire or parts of compilation due to internal/private references in `SourceText`/`AdditionalText`.
- If user switches to different solution inside same IDE instance, the cached values might linger forever. (Not solved)

The last two remaining issues can be mitigated/impact reduced by making the cache evict old/unused entries. But I wasn't sure if it was worth the time/effort investment.