### PR TITLE
Skip SonarQube <Content> when building inside Visual Studio

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Package_assets_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Package_assets_specs.cs
@@ -242,6 +242,27 @@ public class Builds
     }
 
     [Test]
+    public void Does_not_add_content_when_building_inside_Visual_Studio()
+    {
+        using var ctx = BuildalyzerContext.ForProject("CompliantCSharpPackage/CompliantCSharpPackage.csproj");
+
+        var options = new EnvironmentOptions() { DesignTime = false };
+        options.Arguments.Add("-p:BuildingInsideVisualStudio=true");
+
+        var build = ctx.Analyzer.Build(options);
+
+        var result = build.Results.Single();
+
+        result.Should().HaveItems(
+            "Content",
+            new ProjectItem()
+            {
+                ItemSpec = """../../design/logo_128x128.png""",
+                Metadata = new Meta { Link = "logo_128x128.png" },
+            });
+    }
+
+    [Test]
     public void Does_not_add_content_with_SonarQubeIntegration_disabled()
     {
         using var ctx = BuildalyzerContext.ForProject("CompliantCSharpPackage/CompliantCSharpPackage.csproj");

--- a/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Package_assets_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Package_assets_specs.cs
@@ -263,6 +263,27 @@ public class Builds
     }
 
     [Test]
+    public void Does_not_add_content_when_building_by_ReSharper()
+    {
+        using var ctx = BuildalyzerContext.ForProject("CompliantCSharpPackage/CompliantCSharpPackage.csproj");
+
+        var options = new EnvironmentOptions() { DesignTime = false };
+        options.Arguments.Add("-p:BuildingByReSharper=true");
+
+        var build = ctx.Analyzer.Build(options);
+
+        var result = build.Results.Single();
+
+        result.Should().HaveItems(
+            "Content",
+            new ProjectItem()
+            {
+                ItemSpec = """../../design/logo_128x128.png""",
+                Metadata = new Meta { Link = "logo_128x128.png" },
+            });
+    }
+
+    [Test]
     public void Does_not_add_content_with_SonarQubeIntegration_disabled()
     {
         using var ctx = BuildalyzerContext.ForProject("CompliantCSharpPackage/CompliantCSharpPackage.csproj");

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -84,6 +84,7 @@
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
+- Skip SonarQube <Content> when building inside Visual Studio. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -84,7 +84,7 @@
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
-- Skip SonarQube <Content> when building inside Visual Studio. (BUG)
+- Skip SonarQube <Content> when building inside Visual Studio, Rider, or ReSharper. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -84,12 +84,12 @@
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
-- Skip SonarQube <Content> when building inside Visual Studio, Rider, or ReSharper. (BUG)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
 v1.15.2
+- Skip SonarQube <Content> when building inside Visual Studio, Rider, or ReSharper. (BUG)
 - Add <EmbeddedResource> to <AdditionalFiles> once. (BUG)
 - Improve file cache. 
 v1.15.1

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
@@ -25,8 +25,12 @@
     * Link="$([System.String]::Copy('%(Identity)').Replace('\', '_').Replace('/', '_'))"
       Flattens the file structure of the content file to work arround a
       Visual Studio limitation: github.com/dotnet/project-system/issues/5859
+
+    * Condition '$(BuildingInsideVisualStudio)' != 'true'
+      Visual Studio does not run SonarQube analysis, and its project tree
+      crashes on the linked items when they arrive as a project update (#842).
   -->
-  <ItemGroup Condition="'$(SonarQubeIntegration)' == 'true'">
+  <ItemGroup Condition="'$(SonarQubeIntegration)' == 'true' and '$(BuildingInsideVisualStudio)' != 'true'">
     <Content
       Include="@(None);@(AdditionalFiles)"
       Exclude="@(Content)"

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
@@ -29,8 +29,12 @@
     * Condition '$(BuildingInsideVisualStudio)' != 'true'
       Visual Studio does not run SonarQube analysis, and its project tree
       crashes on the linked items when they arrive as a project update (#842).
+
+    * Condition '$(BuildingByReSharper)' != 'true'
+      Set by Rider and ReSharper for all their builds. Rider's solution view
+      hides the real files when the invisible linked duplicates are present.
   -->
-  <ItemGroup Condition="'$(SonarQubeIntegration)' == 'true' and '$(BuildingInsideVisualStudio)' != 'true'">
+  <ItemGroup Condition="'$(SonarQubeIntegration)' == 'true' and '$(BuildingInsideVisualStudio)' != 'true' and '$(BuildingByReSharper)' != 'true'">
     <Content
       Include="@(None);@(AdditionalFiles)"
       Exclude="@(Content)"


### PR DESCRIPTION
Fixes #842.

The SonarQube `<Content>` projection introduced in 1.15.1 crashes the Visual Studio project system. The flattened `Link` only replaces slashes, so items from outside the project directory (`Directory.Build.props`, `Directory.Build.targets`, `Directory.Packages.props`, included as absolute paths) keep the drive colon in their link: `C:_Users_..._Directory.Build.props`.

When such an item reaches VS as part of a project update (for example right after bumping the package version, which is how #842 was hit):

1. `PhysicalProjectTreeProvider.FindOrCreateItem` computes `Path.GetDirectoryName("C:_Users_...")`, which for a drive-relative string is `"C:"`.
2. `FindOrCreateFolder` refuses a first segment with a volume separator and returns null.
3. `HandleAddedItems` then leaves its folder cursor on the previously added file node, and the next item in the batch throws `ArgumentException: FindExcludedItem only accepts folder as the first parameter`.

That is the exact stack in #842. It only fires on incremental updates, never on a clean first load, and it depends on the order of the added-items batch. Small test projects sometimes survive, real solutions with many files practically never do. There is a second variant from the same item group: the `$(MSBuildProjectFile)` entry gets `Link="MyProject.csproj"`, which collides with the hidden project file node VS keeps in its tree and fails in `RenameDuplicateItemInSameFolder`.

Repro: a project with a `Directory.Build.props` above it and a few loose files, referencing 1.14.1. Open the solution in VS, then bump the reference to 1.15.1 with the solution open. Result is the "Visual Studio ran into an unexpected problem with one or more projects" bar with the #842 stack in the ActivityLog.

The fix skips the item group when `$(BuildingInsideVisualStudio)` is true. VS never runs the SonarQube scanner (that happens on command line builds), so the items serve no purpose there. Verified against the repro with a patched package on VS 2026 (18.0): the same 1.14.1 to 1.15.1 bump that crashes with the stock targets loads clean with the gated one, both exception variants gone, while `dotnet build` still gets all items. The new spec mirrors `Does_not_add_content_with_SonarQubeIntegration_disabled` and fails without the targets change.
