### PR TITLE
Use AnalyzerType metadata on AdditionalFiles

### DIFF
--- a/projects/AdditionalFilesProject/.net.csproj
+++ b/projects/AdditionalFilesProject/.net.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <Import Project="../../src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="../../src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets" />
+
+</Project>

--- a/projects/AdditionalFilesProject/AdditionalFilesProject/AdditionalFilesProject.csproj
+++ b/projects/AdditionalFilesProject/AdditionalFilesProject/AdditionalFilesProject.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../../src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project="../../../src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets" />
+
+</Project>

--- a/projects/AdditionalFilesProject/AdditionalFilesProject/Tooling.cs
+++ b/projects/AdditionalFilesProject/AdditionalFilesProject/Tooling.cs
@@ -1,0 +1,6 @@
+namespace AdditionalFilesProject;
+
+internal static class Tooling
+{
+	public static bool IsAnwer(int value) => value is 42;
+}

--- a/projects/AdditionalFilesProject/Directory.Build.props
+++ b/projects/AdditionalFilesProject/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <PropertyGroup>
+    <Description>
+      <![CDATA[
+      Project to test the included props and targets by the package.
+      ]]>
+    </Description>
+  </PropertyGroup>
+
+</Project>

--- a/projects/AdditionalFilesProject/Directory.Build.targets
+++ b/projects/AdditionalFilesProject/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/projects/AdditionalFilesProject/Directory.Packages.props
+++ b/projects/AdditionalFilesProject/Directory.Packages.props
@@ -1,0 +1,14 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="SonarAnalyzer.CSharp" Version="10.28.0.143324" />
+  </ItemGroup>
+  <ItemGroup>
+    <ThirdPartyLicense Include="SonarAnalyzer.CSharp" Hash="IBM9yngU7omFyJOMSFSy0w" />
+  </ItemGroup>
+</Project>

--- a/projects/AdditionalFilesProject/additional-files.slnx
+++ b/projects/AdditionalFilesProject/additional-files.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path=".net.csproj" />
+  <Project Path="AdditionalFilesProject/AdditionalFilesProject.csproj" />
+</Solution>

--- a/specs/Specs/AdditionalFiles_specs.cs
+++ b/specs/Specs/AdditionalFiles_specs.cs
@@ -1,0 +1,175 @@
+using Buildalyzer;
+using DotNetProjectFile.IO;
+using System.IO;
+using Meta = Specs.TestTools.ProjectItem.Meta;
+using ProjectItem = Specs.TestTools.ProjectItem;
+
+namespace AdditionalFiles_specs;
+
+public class Resolves
+{
+    [Test]
+    public void For_Project()
+    {
+        using var ctx = BuildalyzerContext.ForProject("AdditionalFilesProject/AdditionalFilesProject/AdditionalFilesProject.csproj");
+
+        var result = ctx.Analyzer.Build().Results.Single();
+        
+        Log(result);
+
+        result.Should().HaveAdditionalFiles(
+
+            new ProjectItem()
+            {
+                ItemSpec = "AdditionalFilesProject.csproj",
+                Metadata = new Meta
+                {
+                    AnalyzerType = "MSBuildProject",
+                    Visible = "false",
+                }
+            },
+
+            new ProjectItem()
+            {
+                ItemSpec = Full("AdditionalFilesProject/Directory.Build.props"),
+                Metadata = new Meta
+                {
+                    AnalyzerType = "DirectoryBuildProps",
+                    Visible= "false",
+                    Link = "Directory.Build.props",
+                }
+            },
+            
+            new ProjectItem()
+            {
+                ItemSpec = Full("AdditionalFilesProject/Directory.Build.targets"),
+                Metadata = new Meta
+                {
+                    AnalyzerType = "DirectoryBuildTargets",
+                    Visible = "false",
+                    Link = "Directory.Build.targets",
+                }
+            },
+
+            new ProjectItem()
+            {
+                ItemSpec = Full("AdditionalFilesProject/Directory.Packages.props"),
+                Metadata = new Meta
+                {
+                    AnalyzerType = "DirectoryPackagesProps",
+                    Visible = "false",
+                    Link = "Directory.Packages.props",
+                }
+            });
+    }
+
+    [Test]
+    public void For_SDK()
+    {
+        using var ctx = BuildalyzerContext.ForProject("AdditionalFilesProject/.net.csproj");
+
+        var result = ctx.Analyzer.Build().Results.Single();
+
+        Log(result);
+
+        result.Should().HaveAdditionalFiles(
+
+            new ProjectItem
+            {
+                ItemSpec = ".net.csproj",
+                Metadata = new Meta
+                {
+                    AnalyzerType = "SDK",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = "additional-files.slnx",
+                Metadata = new Meta
+                {
+                    Visible = "false",
+                    AnalyzerType = "SLNX",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = Relative("AdditionalFilesProject/AdditionalFilesProject.csproj"),
+                Metadata = new Meta
+                {
+                    Visible = "false",
+                    AnalyzerType = "MSBuildProject",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = Full("../.globalconfig"),
+                Metadata = new Meta
+                {
+                    Link = ".globalconfig",
+                    Visible = "false",
+                    AnalyzerType = "GlobalConfig",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = Full("../.editorconfig"),
+                Metadata = new Meta
+                {
+                    Link = ".editorconfig",
+                    AnalyzerType = "EditorConfig",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = Full("../NuGet.config"),
+                Metadata = new Meta
+                {
+                    Link = "NuGet.config",
+                    AnalyzerType = "NuGetConfig",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = "Directory.Build.props",
+                Metadata = new Meta
+                {
+                    Visible = "true",
+                    AnalyzerType = "MSBuildProp",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = "Directory.Build.targets",
+                Metadata = new Meta
+                {
+                    Visible = "true",
+                    AnalyzerType = "MSBuildProp",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = "Directory.Packages.props",
+                Metadata = new Meta
+                {
+                    Visible = "true",
+                    AnalyzerType = "MSBuildProp",
+                },
+            });
+    }
+
+    private static void Log(IAnalyzerResult result)
+    {
+#if DEBUG
+        ProjectItem.Generate(result.Items.OfType("AdditionalFiles"));
+#endif
+    }
+
+    private static string Relative(string path) => IOFile.Parse(path).ToString();
+
+    private static string Full(string path)
+    {
+        var dir = new DirectoryInfo("../../../../../projects");
+        var combined = Path.Combine(dir.FullName, path);
+        return IOFile.Parse(combined).ToString();
+    }
+}

--- a/specs/Specs/AdditionalFiles_specs.cs
+++ b/specs/Specs/AdditionalFiles_specs.cs
@@ -13,14 +13,13 @@ public class Resolves
         using var ctx = BuildalyzerContext.ForProject("AdditionalFilesProject/AdditionalFilesProject/AdditionalFilesProject.csproj");
 
         var result = ctx.Analyzer.Build().Results.Single();
-        
         Log(result);
 
         result.Should().HaveAdditionalFiles(
 
             new ProjectItem()
             {
-                ItemSpec = Full("AdditionalFilesProject/AdditionalFilesProject.csproj"),
+                ItemSpec = Full("AdditionalFilesProject/AdditionalFilesProject/AdditionalFilesProject.csproj"),
                 Metadata = new Meta
                 {
                     AnalyzerType = "MSBuildProject",

--- a/specs/Specs/AdditionalFiles_specs.cs
+++ b/specs/Specs/AdditionalFiles_specs.cs
@@ -1,6 +1,5 @@
 using Buildalyzer;
-using DotNetProjectFile.IO;
-using System.IO;
+using static Specs.TestTools.TestPath;
 using Meta = Specs.TestTools.ProjectItem.Meta;
 using ProjectItem = Specs.TestTools.ProjectItem;
 
@@ -21,7 +20,7 @@ public class Resolves
 
             new ProjectItem()
             {
-                ItemSpec = "AdditionalFilesProject.csproj",
+                ItemSpec = Full("AdditionalFilesProject/AdditionalFilesProject.csproj"),
                 Metadata = new Meta
                 {
                     AnalyzerType = "MSBuildProject",
@@ -80,6 +79,7 @@ public class Resolves
                 Metadata = new Meta
                 {
                     AnalyzerType = "SDK",
+                    Visible = "false",
                 },
             },
             new ProjectItem
@@ -162,14 +162,5 @@ public class Resolves
 #if DEBUG
         ProjectItem.Generate(result.Items.OfType("AdditionalFiles"));
 #endif
-    }
-
-    private static string Relative(string path) => IOFile.Parse(path).ToString();
-
-    private static string Full(string path)
-    {
-        var dir = new DirectoryInfo("../../../../../projects");
-        var combined = Path.Combine(dir.FullName, path);
-        return IOFile.Parse(combined).ToString();
     }
 }

--- a/specs/Specs/AwesomeAssertions/AnalyzerResultAssertions.cs
+++ b/specs/Specs/AwesomeAssertions/AnalyzerResultAssertions.cs
@@ -1,4 +1,5 @@
 using Buildalyzer;
+using System.Diagnostics;
 
 namespace AwesomeAssertions;
 
@@ -6,6 +7,7 @@ public sealed class AnalyzerResultAssertions(IAnalyzerResult subject)
 {
     public IAnalyzerResult Subject { get; } = subject;
 
+    [DebuggerStepThrough]
     public AndConstraint<AnalyzerResultAssertions> HaveProperties(Dictionary<string, string> expected)
     {
         var properties = Subject.Properties;
@@ -15,6 +17,7 @@ public sealed class AnalyzerResultAssertions(IAnalyzerResult subject)
         return new(this);
     }
 
+    [DebuggerStepThrough]
     public AndConstraint<AnalyzerResultAssertions> HaveCompilerVisibleProperties(params string[] expected)
     {
         var items = (Subject.Items.TryGetValue("CompilerVisibleProperty", out var actual) ? actual : [])
@@ -27,11 +30,14 @@ public sealed class AnalyzerResultAssertions(IAnalyzerResult subject)
         return new(this);
     }
 
+    [DebuggerStepThrough]
+    public AndConstraint<AnalyzerResultAssertions> HaveAdditionalFiles(params Specs.TestTools.ProjectItem[] expected)
+        => HaveItems("AdditionalFiles", expected);
+
+    [DebuggerStepThrough]
     public AndConstraint<AnalyzerResultAssertions> HaveItems(string name, params Specs.TestTools.ProjectItem[] expected)
     {
-        var items = (Subject.Items.TryGetValue(name, out var actual) ? actual : [])
-            .OrderBy(x => x.ItemSpec)
-            .ToArray();
+        var items = Subject.Items.OfType(name).ToArray();
 
         items.Should().BeEquivalentTo(expected);
 

--- a/specs/Specs/MS_Build/Package_assets_specs.cs
+++ b/specs/Specs/MS_Build/Package_assets_specs.cs
@@ -40,7 +40,7 @@ public class Builds
             .And.HaveAdditionalFiles(
                 new()
                 {
-                    ItemSpec = "CompliantCSharpPackage.csproj",
+                    ItemSpec = Full("CompliantCSharpPackage/CompliantCSharpPackage.csproj"),
                     Metadata = new Meta
                     {
                         AnalyzerType = "MSBuildProject",
@@ -143,11 +143,11 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = "CompliantCSharpPackage.csproj",
+                    ItemSpec = Full("CompliantCSharpPackage/CompliantCSharpPackage.csproj"),
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
-                        Link = "CompliantCSharpPackage.csproj",
+                        Link = Full("CompliantCSharpPackage/CompliantCSharpPackage.csproj").Replace(':', '_').Replace('\\', '_').Replace('/', '_'),
                         Visible = "false",
                         SonarQubeContent = "true",
                         AnalyzerType = "MSBuildProject",

--- a/specs/Specs/MS_Build/Package_assets_specs.cs
+++ b/specs/Specs/MS_Build/Package_assets_specs.cs
@@ -42,8 +42,7 @@ public class Builds
                 "RestoreLockedMode",
                 "SolutionDir")
 
-            .And.HaveItems(
-                "AdditionalFiles",
+            .And.HaveAdditionalFiles(
                 new()
                 {
                     ItemSpec = """CompliantCSharpPackage.csproj""",

--- a/specs/Specs/MS_Build/Package_assets_specs.cs
+++ b/specs/Specs/MS_Build/Package_assets_specs.cs
@@ -1,5 +1,6 @@
 using Buildalyzer.Environment;
 using System.IO;
+using static Specs.TestTools.TestPath;
 using Meta = Specs.TestTools.ProjectItem.Meta;
 using ProjectItem = Specs.TestTools.ProjectItem;
 
@@ -9,12 +10,6 @@ namespace MS_Build.Package_assets_specs;
 // wipes its bin/obj), so running them in parallel races the pack and intermittently loses the nupkg.
 public class Builds
 {
-#if Is_Windows
-    private const char Slash = '\\';
-#else
-    private const char Slash = '/';
-#endif
-
     [Test]
     public void With_defaults()
     {
@@ -23,9 +18,9 @@ public class Builds
         var result = ctx.Analyzer.Build().Results.Single();
 
         result.Should().HaveProperties(new()
-        {
-            ["SonarQubeIntegration"] = "true"
-        })
+            {
+                ["SonarQubeIntegration"] = "true"
+            })
 
             .And.HaveCompilerVisibleProperties(
                 "Configuration",
@@ -45,8 +40,12 @@ public class Builds
             .And.HaveAdditionalFiles(
                 new()
                 {
-                    ItemSpec = """CompliantCSharpPackage.csproj""",
-                    Metadata = new Meta { Visible = "false" },
+                    ItemSpec = "CompliantCSharpPackage.csproj",
+                    Metadata = new Meta
+                    {
+                        AnalyzerType = "MSBuildProject",
+                        Visible = "false",
+                    },
                 },
                 new() { ItemSpec = "compliant-package.slnx" },
                 new() { ItemSpec = "Messages.resx" })
@@ -55,7 +54,7 @@ public class Builds
                 "Content",
                 new()
                 {
-                    ItemSpec = """../../design/logo_128x128.png""",
+                    ItemSpec = "../../design/logo_128x128.png",
                     Metadata = new Meta
                     {
                         Link = "logo_128x128.png",
@@ -85,7 +84,7 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = $"""build{Slash}CompliantCSharpPackage.props""",
+                    ItemSpec = Relative("build/CompliantCSharpPackage.props"),
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
@@ -96,7 +95,7 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = $"""build{Slash}CompliantCSharpPackage.props""",
+                    ItemSpec = Relative("build/CompliantCSharpPackage.props"),
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
@@ -109,7 +108,7 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = $"""build{Slash}CompliantCSharpPackage.targets""",
+                    ItemSpec = Relative("build/CompliantCSharpPackage.targets"),
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
@@ -120,7 +119,7 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = $"""build{Slash}CompliantCSharpPackage.targets""",
+                    ItemSpec = Relative("build/CompliantCSharpPackage.targets"),
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
@@ -144,18 +143,19 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = """CompliantCSharpPackage.csproj""",
+                    ItemSpec = "CompliantCSharpPackage.csproj",
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
                         Link = "CompliantCSharpPackage.csproj",
                         Visible = "false",
                         SonarQubeContent = "true",
+                        AnalyzerType = "MSBuildProject",
                     },
                 },
                 new()
                 {
-                    ItemSpec = """Messages.resx""",
+                    ItemSpec = "Messages.resx",
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
@@ -166,7 +166,7 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = """packages.lock.json""",
+                    ItemSpec = "packages.lock.json",
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
@@ -177,7 +177,7 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = """README.md""",
+                    ItemSpec = "README.md",
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
@@ -188,7 +188,7 @@ public class Builds
                 },
                 new()
                 {
-                    ItemSpec = """README.md""",
+                    ItemSpec = "README.md",
                     Metadata = new Meta
                     {
                         CopyToOutputDirectory = "never",
@@ -256,7 +256,7 @@ public class Builds
             "Content",
             new ProjectItem()
             {
-                ItemSpec = """../../design/logo_128x128.png""",
+                ItemSpec = "../../design/logo_128x128.png",
                 Metadata = new Meta { Link = "logo_128x128.png" },
             });
     }
@@ -277,7 +277,7 @@ public class Builds
             "Content",
             new ProjectItem()
             {
-                ItemSpec = """../../design/logo_128x128.png""",
+                ItemSpec = "../../design/logo_128x128.png",
                 Metadata = new Meta { Link = "logo_128x128.png" },
             });
     }
@@ -298,7 +298,7 @@ public class Builds
             "Content",
             new ProjectItem()
             {
-                ItemSpec = """../../design/logo_128x128.png""",
+                ItemSpec = "../../design/logo_128x128.png",
                 Metadata = new Meta { Link = "logo_128x128.png" },
             });
     }

--- a/specs/Specs/Package/NuGet_package_specs.cs
+++ b/specs/Specs/Package/NuGet_package_specs.cs
@@ -25,7 +25,7 @@ public class Contains
             "analyzers/DotNetProjectFile.Analyzers.dll",
 
             // Build props and targets
-            "build/AdditionalFiles.props",
+            "build/AdditionalFiles.targets",
             "build/AdditionalFiles.Sdk.props",
             "build/CompilerVisible.props",
             "build/DotNetProjectFile.Analyzers.props",

--- a/specs/Specs/Package/NuGet_package_specs.cs
+++ b/specs/Specs/Package/NuGet_package_specs.cs
@@ -10,38 +10,29 @@ public class Contains
     [TestCaseSource(nameof(Packages))]
     public void Entries(FileInfo file)
     {
-        var entries = Nupkg.Read(file);
+        var entries = Nupkg.Read(file).Order();
 
         foreach (var e in entries)
             Console.WriteLine(e);
 
         entries.Should().BeEquivalentTo(
-            // NuSpec
-            "DotNetProjectFile.Analyzers.nuspec",
-            "logo_128x128.png",
-            "README.md",
-
-            // Analyzer       
+            "_manifest/spdx_2.2/manifest.spdx.json",
+            "_manifest/spdx_2.2/manifest.spdx.json.sha256",
+            "_rels/.rels",
+            "[Content_Types].xml",
             "analyzers/DotNetProjectFile.Analyzers.dll",
-
-            // Build props and targets
-            "build/AdditionalFiles.targets",
             "build/AdditionalFiles.Sdk.props",
-            "build/CompilerVisible.props",
+            "build/CompilerVisible.props", 
+            "build/AdditionalFiles.targets",
             "build/DotNetProjectFile.Analyzers.props",
             "build/DotNetProjectFile.Analyzers.Sdk.props",
             "build/DotNetProjectFile.Analyzers.targets",
             "build/None.Sdk.props",
-
-            // tools
+            "DotNetProjectFile.Analyzers.nuspec",
+            "logo_128x128.png",
+            "README.md",
             "tools/install.ps1",
-            "tools/uninstall.ps1",
-
-            // Added by NuGet
-            "[Content_Types].xml",
-            "_rels/.rels",
-            "_manifest/spdx_2.2/manifest.spdx.json",
-            "_manifest/spdx_2.2/manifest.spdx.json.sha256");
+            "tools/uninstall.ps1");
     }
 
 

--- a/specs/Specs/Rules/MS_Build/Build_actions_should_have_single_task.cs
+++ b/specs/Specs/Rules/MS_Build/Build_actions_should_have_single_task.cs
@@ -30,7 +30,7 @@ public class Reports
 
           <ItemGroup>
             <GlobalAnalyzerConfigFiles
-              Include="$([MSBuild]::GetPathOfFileAbove('.globalconfig')"
+              Include="$([MSBuild]::GetPathOfFileAbove('.globalconfig'))"
               Exclude="$(GlobalAnalyzerConfigFiles)" />
           </ItemGroup>
 

--- a/specs/Specs/Rules/MS_Build/Build_actions_should_have_single_task.cs
+++ b/specs/Specs/Rules/MS_Build/Build_actions_should_have_single_task.cs
@@ -30,7 +30,7 @@ public class Reports
 
           <ItemGroup>
             <GlobalAnalyzerConfigFiles
-              Include="$([MSBuild]::GetPathOfFileAbove('.globalconfig', '$(MSBuildThisFileDirectory)'))"
+              Include="$([MSBuild]::GetPathOfFileAbove('.globalconfig')"
               Exclude="$(GlobalAnalyzerConfigFiles)" />
           </ItemGroup>
 

--- a/specs/Specs/TestTools/ProjectItem.cs
+++ b/specs/Specs/TestTools/ProjectItem.cs
@@ -11,12 +11,12 @@ public sealed record ProjectItem
     public override string ToString()
         => $"ItemSpec = {ItemSpec}, Metadata = {{ {string.Join(", ", Metadata.Select(x => $"{x.Key} = {x.Value}"))} }}";
 
-    internal static void Generate(IProjectItem[] content)
+    internal static void Generate(IEnumerable<IProjectItem> content)
     {
         foreach (var item in content)
         {
             Console.WriteLine("new ProjectItem\n{");
-            Console.WriteLine($""""    ItemSpec = """{item.ItemSpec}""", """");
+            Console.WriteLine($"""    ItemSpec = "{item.ItemSpec.Replace('\\', '/')}", """);
             Console.WriteLine("    Metadata = new Meta\n    {");
             foreach (var (key, value) in item.Metadata)
             {
@@ -30,6 +30,7 @@ public sealed record ProjectItem
     {
         private readonly Dictionary<string, string> Lookup = [];
 
+        public string? AnalyzerType { get => Get(nameof(AnalyzerType)); init => Set(nameof(AnalyzerType), value); }
         public string? CopyToOutputDirectory { get => Get(nameof(CopyToOutputDirectory)); init => Set(nameof(CopyToOutputDirectory), value); }
         public string? Link { get => Get(nameof(Link)); init => Set(nameof(Link), value); }
         public string? Visible { get => Get(nameof(Visible)); init => Set(nameof(Visible), value); }
@@ -47,5 +48,15 @@ public sealed record ProjectItem
         }
 
         public static implicit operator Dictionary<string, string>(Meta metadata) => metadata.Lookup;
+    }
+}
+
+internal static class ProjectItemExtensions
+{
+    extension(IReadOnlyDictionary<string, IProjectItem[]> items)
+    {
+        public IEnumerable<IProjectItem> OfType(string name)
+            => (items.TryGetValue(name, out var selection) ? selection : [])
+            .OrderBy(x => x.ItemSpec);
     }
 }

--- a/specs/Specs/TestTools/TestPath.cs
+++ b/specs/Specs/TestTools/TestPath.cs
@@ -1,0 +1,16 @@
+using DotNetProjectFile.IO;
+using System.IO;
+
+namespace Specs.TestTools;
+
+public static class TestPath
+{
+    public static string Relative(string path) => IOFile.Parse(path).ToString();
+
+    public static string Full(string path)
+    {
+        var dir = new DirectoryInfo("../../../../../projects");
+        var combined = Path.Combine(dir.FullName, path);
+        return IOFile.Parse(combined).ToString();
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.Sdk.props
@@ -1,43 +1,61 @@
 <Project>
 
   <ItemGroup>
-    <!-- NuGet.config -->
+    
+    <!-- SDK -->
     <AdditionalFiles
-      Include="$([MSBuild]::GetPathOfFileAbove('NuGet.config', '$(MSBuildThisFileDirectory)'))"
-      Link="NuGet.config"/>
+      Include=".net.csproj"
+      AnalyzerType="SDK"
+      Visible="false"/>
 
     <!-- .editorconfig -->
     <AdditionalFiles
-      Include="$([MSBuild]::GetPathOfFileAbove('.editorconfig', '$(MSBuildThisFileDirectory)'))"
+      Include="$([MSBuild]::GetPathOfFileAbove('.editorconfig'))"
+      Exclude="@(AdditionalFiles)"
+      AnalyzerType="EditorConfig"
       Link=".editorconfig" />
+
+    <!-- globalconfig files -->
+    <AdditionalFiles
+      Include="@(GlobalAnalyzerConfigFiles)"
+      Exclude="@(AdditionalFiles)"
+      AnalyzerType="GlobalConfig" />
+
+    <!-- NuGet.config -->
+    <AdditionalFiles
+      Include="$([MSBuild]::GetPathOfFileAbove('NuGet.config'))"
+      AnalyzerType="NuGetConfig"
+      Link="NuGet.config" />
     
-    <!-- .globalconfig -->
-    <AdditionalFiles Include="$(GlobalAnalyzerConfigFiles)" />
-    
-    <AdditionalFiles Include=".git*" />
-    <AdditionalFiles Include=".github/**" />
-    <AdditionalFiles Include="*.config" />
-    <AdditionalFiles Include="*.ini" />
-    <AdditionalFiles Include="*.json" />
-    <AdditionalFiles Include="*.md" />
-    <AdditionalFiles Include="*.txt" />
-    <AdditionalFiles Include="*.yaml" />
-    <AdditionalFiles Include="*.yml" />
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Visible="false" Exclude="$(AdditionalFiles)" Include="**/*.??proj" />
-    <AdditionalFiles Visible="false" Exclude="$(AdditionalFiles)" Include="**/*.slnx" />
-    <AdditionalFiles Visible="false" Exclude="$(AdditionalFiles)" Include="**/*.props" />
-    <AdditionalFiles Visible="false" Exclude="$(AdditionalFiles)" Include="**/*.targets" />
+    <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="MSBuildProject" Include="**/*.??proj" />
+    <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="SLNX"           Include="**/*.slnx" />
+    <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="MSBuildProp"    Include="**/*.props" />
+    <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="MSBuildProp"    Include="**/*.targets" />
   </ItemGroup>
-  
+
   <!-- Make visible -->
   <ItemGroup>
-    <AdditionalFiles Visible ="true" Update="*.props" />
-    <AdditionalFiles Visible ="true" Update="*.targets" />
-    <AdditionalFiles Visible ="true" Update="props/*.props" />
-    <AdditionalFiles Visible ="true" Update="props/*.targets" />
+    <AdditionalFiles Visible="true" Update="*.props" />
+    <AdditionalFiles Visible="true" Update="*.targets" />
+    <AdditionalFiles Visible="true" Update="props/*.props" />
+    <AdditionalFiles Visible="true" Update="props/*.targets" />
+  </ItemGroup>
+
+  <!--
+    Remove what is most likely in the .gitignore
+    
+    It is put here, because both the .net.csproj additonal files as well as the regular
+    set has been added, and can therefor safely be filtered.
+    -->
+  <ItemGroup>
+    <AdditionalFiles Remove="**/bin/**" />
+    <AdditionalFiles Remove="**/obj/**" />
+    <AdditionalFiles Remove="**/.git/**" />
+    <AdditionalFiles Remove="**/.nuget/**" />
+    <AdditionalFiles Remove="**/.vs/**" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)None.Sdk.props" />

--- a/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.targets
+++ b/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.targets
@@ -1,20 +1,26 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Non-compiling files to analyze. -->
   <ItemGroup>
+    <!-- Current project file -->  
     <AdditionalFiles
-      Include="$(MSBuildProjectFile)"
+      AnalyzerType="MSBuildProject"
+      Include="*.??proj"
       Exclude="@(AdditionalFiles)"
       Visible="false" />
+    
+    <!-- XML Resources -->
     <AdditionalFiles
+      AnalyzerType="RESX"
       Include="**/*.resx"
       Exclude="@(AdditionalFiles)"
       Visible="false" />
+
   </ItemGroup>
 
   <!-- Directory.Build.props -->
   <ItemGroup Condition="'$(ImportDirectoryBuildProps)' == 'true'">
     <AdditionalFiles
+      AnalyzerType="DirectoryBuildProps"
       Include="$(DirectoryBuildPropsPath)"
       Exclude="@(AdditionalFiles)"
       Visible="false" />
@@ -24,6 +30,7 @@
   <!-- Directory.Build.targets -->
   <ItemGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true'">
     <AdditionalFiles
+      AnalyzerType="DirectoryBuildTargets"
       Include="$(DirectoryBuildTargetsPath)"
       Exclude="@(AdditionalFiles)"
       Visible="false" />
@@ -33,6 +40,7 @@
   <!-- Directory.Packages.props -->
   <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
     <AdditionalFiles
+      AnalyzerType="DirectoryPackagesProps"
       Include="$(DirectoryPackagesPropsPath)"
       Exclude="@(AdditionalFiles)"
       Visible="false" />

--- a/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.targets
+++ b/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.targets
@@ -4,7 +4,7 @@
     <!-- Current project file -->  
     <AdditionalFiles
       AnalyzerType="MSBuildProject"
-      Include="*.??proj"
+      Include="$(MSBuildProjectFullPath)"
       Exclude="@(AdditionalFiles)"
       Visible="false" />
     

--- a/src/DotNetProjectFile.Analyzers/build/CompilerVisible.props
+++ b/src/DotNetProjectFile.Analyzers/build/CompilerVisible.props
@@ -1,10 +1,19 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!--
+    By making the AnalyzerType metadata visible for the compiler, MSBuild can
+    catagorize the file to analyze, and the Roslyn Analyzers can be triggered
+    based on the metadata, instead of file names and/or extensions.
+    -->
+  <ItemGroup>
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="AnalyzerType" />
+  </ItemGroup>
+  
   <!-- 
     Common variable that should be resolvable.
    
     These variables are read by the analyzers to make decisions about them.
-  -->
+    -->
   <ItemGroup>
     <CompilerVisibleProperty Include="Configuration" />
     <CompilerVisibleProperty Include="EnableNETAnalyzers" />

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
@@ -16,8 +16,8 @@
     -->
   <ItemGroup>
     <GlobalAnalyzerConfigFiles
-      Include="$([MSBuild]::GetPathOfFileAbove('.globalconfig', '$(MSBuildThisFileDirectory)'))"
-      Exclude="$(GlobalAnalyzerConfigFiles)"
+      Include="$([MSBuild]::GetPathOfFileAbove('.globalconfig'))"
+      Exclude="@(GlobalAnalyzerConfigFiles)"
       Visible="false" />
   </ItemGroup>
 
@@ -29,20 +29,5 @@
   <Import
      Condition="$(IsDotNetProjectFileSdk) == 'true'"
      Project="$(MSBuildThisFileDirectory)DotNetProjectFile.Analyzers.Sdk.props" />
-
-
-  <!--
-    Remove what is most likely in the .gitignore
-    
-    It is put here, because both the .net.csproj additonal files as well as the regular
-    set has been added, and can therefor safely be filtered.
-    -->
-  <ItemGroup>
-    <AdditionalFiles Remove="**/bin/**" />
-    <AdditionalFiles Remove="**/obj/**" />
-    <AdditionalFiles Remove="**/.git/**" />
-    <AdditionalFiles Remove="**/.nuget/**" />
-    <AdditionalFiles Remove="**/.vs/**" />
-  </ItemGroup>
 
 </Project>

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.targets
@@ -41,7 +41,7 @@
       CopyToOutputDirectory="never"
       Visible="false"
       SonarQubeContent="true"
-      Link="$([System.String]::Copy('%(Identity)').Replace('\', '_').Replace('/', '_'))" />
+      Link="$([System.String]::Copy('%(Identity)').Replace('\', '_').Replace('/', '_').Replace(':', '_'))" />
   </ItemGroup>
 
   <!--

--- a/src/DotNetProjectFile.Analyzers/build/None.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers/build/None.Sdk.props
@@ -2,6 +2,16 @@
 
   <ItemGroup>
 
+    <None Visible="true" Include=".git*" />
+    <None Visible="true" Include=".github/**" />
+    <None Visible="true" Include="*.config" />
+    <None Visible="true" Include="*.ini" />
+    <None Visible="true" Include="*.json" />
+    <None Visible="true" Include="*.md" />
+    <None Visible="true" Include="*.txt" />
+    <None Visible="true" Include="*.yaml" />
+    <None Visible="true" Include="*.yml" />
+
     <None Include="**/TestResults/**" />
     
     <!-- Directory.Build.props -->


### PR DESCRIPTION
By adding metadata (`AnalyzerType`) to the `<AdditionalFiles>` it should become easier to assign the right analyzers to the files to analyze. Ideally, we should not have to check the file system anymore.