### PR TITLE
Extend lexers to both work on SourceReader as ReadOnly<char>

### DIFF
--- a/specs/Specs/AwesomeAssertions/LexerAssertions.cs
+++ b/specs/Specs/AwesomeAssertions/LexerAssertions.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions.Execution;
+using Grammr;
 using Grammr.Lexers;
 using System.Diagnostics;
 
@@ -13,7 +14,7 @@ internal sealed class LexerAssertions(Lexer subject, AssertionChain? chain = nul
     [DebuggerStepThrough]
     public AndConstraint<LexerAssertions> Match(string match, string from, string because = "")
     {
-        var length = Subject.Match(new(from));
+        var length = Subject.Match(new SourceReader(match));
 
         Assert
             .ForCondition(length is { })
@@ -29,7 +30,7 @@ internal sealed class LexerAssertions(Lexer subject, AssertionChain? chain = nul
     [DebuggerStepThrough]
     public AndConstraint<LexerAssertions> NotMatch(string source, string because = "")
     {
-        var length = Subject.Match(new(source));
+        var length = Subject.Match(new SourceReader(source));
 
         Assert
             .ForCondition(length is null)

--- a/specs/Specs/AwesomeAssertions/LexerAssertions.cs
+++ b/specs/Specs/AwesomeAssertions/LexerAssertions.cs
@@ -14,7 +14,7 @@ internal sealed class LexerAssertions(Lexer subject, AssertionChain? chain = nul
     [DebuggerStepThrough]
     public AndConstraint<LexerAssertions> Match(string match, string from, string because = "")
     {
-        var length = Subject.Match(new SourceReader(match));
+        var length = Subject.Match(new SourceReader(from));
 
         Assert
             .ForCondition(length is { })

--- a/specs/Specs/Grammr/Lexer_specs.cs
+++ b/specs/Specs/Grammr/Lexer_specs.cs
@@ -94,6 +94,27 @@ public class String
     public void Has_debug_display() => lexer.ToString().Should().Be("str(grammr)");
 }
 
+public class Range
+{
+    private readonly Lexer lexer = range("x-z");
+
+    [TestCase("xylophone", "x")]
+    [TestCase("ypsilon", "y")]
+    [TestCase("zebra", "z")]
+    public void Parses(string src, string match)
+            => lexer.Should().Match(match, from: src);
+
+    [TestCase("")]
+    [TestCase("Zebra")]
+    [TestCase("water")]
+    [TestCase("{character after z}")]
+    public void Does_not_match(string src)
+        => lexer.Should().NotMatch(src);
+
+    [Test]
+    public void Has_debug_display() => lexer.ToString().Should().Be("[x-z]");
+}
+
 public class Match
 {
     private readonly Lexer lexer = match(IsDigit);

--- a/specs/Specs/Grammr/Types_specs.cs
+++ b/specs/Specs/Grammr/Types_specs.cs
@@ -1,0 +1,12 @@
+namespace Specs.Grammr_Types_specs;
+
+public class Namespaces
+{
+    [TestCaseSource(nameof(Types))]
+    public void Have_Grammr_as_root(Type type)
+        => type.Namespace.Should().StartWith("Grammr");
+
+    private static IEnumerable<Type> Types => typeof(Grammr.Source)
+        .Assembly.GetTypes()
+        .Where(t => t.Namespace?.Contains("Grammr") is true);
+}

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.ReadOnlySpan.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.ReadOnlySpan.cs
@@ -1,0 +1,10 @@
+namespace System;
+
+internal static class ReadOnlySpanExtensions
+{
+    extension(Chars span)
+    {
+        /// <summary>Indicates End of Stream/Span.</summary>
+        public bool EOS => span.Length is 0;
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Grammr/GrammrNode.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/GrammrNode.cs
@@ -36,7 +36,7 @@ public abstract partial class GrammrNode(SliceSpan span, GrammrTree tree)
     public LinePositionSpans Spans => new(SourceTree);
 
     /// <summary>Gets the full span of the node.</summary>
-    public ReadOnlySpan<char> FullSpan
+    public Chars FullSpan
     {
         get
         {

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Ch.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Ch.cs
@@ -6,8 +6,8 @@ internal sealed class Ch(char val, string? kind) : Lexer(kind)
 
     /// <inheritdoc />
     [Pure]
-    public override int? Match(SourceReader reader)
-        => reader.EOS || reader[0] != Value ? null : 1;
+    public override int? Match(Chars span)
+        => span.EOS || span[0] != Value ? null : 1;
 
     /// <inheritdoc />
     [Pure]

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/CharRange.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/CharRange.cs
@@ -1,0 +1,28 @@
+using Grammr.Lexers;
+
+namespace Grammr.Lexers;
+
+internal sealed class CharRange(uint min, uint max, string? kind) : Lexer(kind)
+{
+    private readonly uint Min = min;
+    private readonly uint Range = max - min;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Inspired by System.char.IsBetween().
+    /// <code>
+    /// <![CDATA[
+    /// (uint)(c - minInclusive) <= (uint)(maxInclusive - minInclusive)
+    /// ]]>
+    /// </code>
+    /// As the range is fixed, it is precalculated.
+    /// </remarks>
+    [Pure]
+    public override int? Match(Chars span)
+        => span.EOS
+        || (span[0] - Min) > Range
+        ? null
+        : 1;
+
+    public override string ToString() => $"[{(char)Min}-{(char)(Min + Range)}]";
+}

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Choice.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Choice.cs
@@ -25,6 +25,15 @@ internal sealed class Choice(IEnumerable<Lexer> lexers, bool isOptional = false)
     private static IEnumerable<Lexer> Flatten(Lexer l) => l is Choice s ? s.Lexers : [l];
 
     /// <inheritdoc />
+    public override int? Match(Chars span)
+    {
+        for (var i = 0; i < Lexers.Length; i++)
+            if (Lexers[i].Match(span) is { } length) return length;
+
+        return IsOptional ? 0 : null;
+    }
+
+    /// <inheritdoc />
     public override int? Match(SourceReader reader)
     {
         for (var i = 0; i < Lexers.Length; i++)

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/EndOfLine.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/EndOfLine.cs
@@ -4,11 +4,11 @@ internal sealed class EndOfLine() : Lexer(nameof(EndOfLine))
 {
     /// <inheritdoc />
     [Pure]
-    public override int? Match(SourceReader reader) => reader switch
+    public override int? Match(Chars span) => span switch
     {
         { EOS: true } => null,
-        _ when reader.Span[0] is '\n' => 1,
-        _ when reader.Span.StartsWith("\r\n") => 2,
+        _ when span[0] is '\n' => 1,
+        _ when span.StartsWith("\r\n") => 2,
         _ => null,
     };
 

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/EndOfStream.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/EndOfStream.cs
@@ -4,8 +4,8 @@ internal sealed class EndOfStream() : Lexer(nameof(EndOfStream))
 {
     /// <inheritdoc />
     [Pure]
-    public override int? Match(SourceReader reader)
-        => reader.EOS ? 0 : null;
+    public override int? Match(Chars span)
+        => span.EOS ? 0 : null;
 
     /// <inheritdoc />
     [Pure]

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Lexer.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Lexer.cs
@@ -7,7 +7,12 @@ public abstract class Lexer(string? kind)
 
     /// <summary>Tries to match, and returns the length of that match when succesful.</summary>
     [Pure]
-    public abstract int? Match(SourceReader reader);
+    public abstract int? Match(Chars span);
+
+    /// <inheritdoc cref="Match(Chars)" />
+    [Pure]
+    public virtual int? Match(SourceReader reader)
+        => Match(reader.Span);
 
     /// <summary>Makes the lexer optional, meaning it will match zero or one occurrence of the pattern.</summary>
     public virtual Lexer optional => field ??= new Optional(this, Kind);

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Line.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Line.cs
@@ -4,11 +4,9 @@ internal sealed class Line(string? kind) : Lexer(kind)
 {
     /// <inheritdoc />
     [Pure]
-    public override int? Match(SourceReader reader)
+    public override int? Match(Chars span)
     {
-        if (reader.EOS) return null;
-
-        var span = reader.Span;
+        if (span.EOS) return null;
 
         var length = span.IndexOf('\n');
 

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/LineComment.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/LineComment.cs
@@ -6,10 +6,8 @@ internal sealed class LineComment(string start, string? kind) : Lexer(kind)
 
     /// <inheritdoc />
     [Pure]
-    public override int? Match(SourceReader reader)
+    public override int? Match(Chars span)
     {
-        var span = reader.Span;
-
         if (!span.StartsWith(Start)) return null;
 
         var length = span.IndexOf('\n');

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Optional.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Optional.cs
@@ -9,6 +9,10 @@ internal sealed class Optional(Lexer lexer, string? kind) : Lexer(kind)
 
     /// <inheritdoc />
     [Pure]
+    public override int? Match(Chars span) => Lexer.Match(span) ?? 0;
+
+    /// <inheritdoc />
+    [Pure]
     public override int? Match(SourceReader reader) => Lexer.Match(reader) ?? 0;
 
     /// <inheritdoc />

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Predicates.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Predicates.cs
@@ -6,11 +6,11 @@ internal sealed class Predicates(Func<char, int, bool> predicate, string? kind) 
 
     /// <inheritdoc />
     [Pure]
-    public override int? Match(SourceReader reader)
+    public override int? Match(Chars span)
     {
         var length = 0;
 
-        while (length < reader.Span.Length && Predicate(reader.Span[length], length))
+        while (length < span.Length && Predicate(span[length], length))
             length++;
 
         return length is 0

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Reg.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Reg.cs
@@ -18,6 +18,11 @@ internal sealed class Reg(Regex pattern, string? kind) : Lexer(kind)
 
     /// <inheritdoc />
     [Pure]
+    public override int? Match(Chars span)
+        => throw new NotSupportedException("Regex is not supported as it requires a lot of string allocations.");
+
+    /// <inheritdoc />
+    [Pure]
     public override int? Match(SourceReader reader)
         => reader.Match(Pattern) is { Success: true } match && match.Index == reader.Start
         ? match.Length

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Str.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/Str.cs
@@ -6,8 +6,8 @@ internal sealed class Str(string val, string? kind) : Lexer(kind)
 
     /// <inheritdoc />
     [Pure]
-    public override int? Match(SourceReader reader)
-        => reader.Span.StartsWith(Value)
+    public override int? Match(Chars span)
+        => span.StartsWith(Value)
         ? Value.Length
         : null;
 

--- a/src/DotNetProjectFile.Analyzers/Grammr/Lexers/_shared.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Lexers/_shared.cs
@@ -87,6 +87,28 @@ public static class Shared
     /// </returns>
     public static Lexer str(string val, [CallerMemberName] string? kind = null) => new Str(val, kind);
 
+    /// <summary>Matches if the remaining source starts with a character in the specified range.</summary>
+    /// <param name="range">
+    /// The range (like "a-z").
+    /// </param>
+    /// <param name="kind">
+    /// The (optional) token kind.
+    /// </param>
+    /// <remarks>
+    /// Functional the second character in the string has no meaning, but it
+    /// allows to read as range in the way you would normally specify it.
+    /// </remarks>
+    /// <returns>
+    /// A new lexer.
+    /// </returns>
+    public static Lexer range(string range, [CallerMemberName] string? kind = null) => range.Length switch
+    {
+        3 when range[0] < range[2] && range[1] is '-'
+            => new CharRange(range[0], range[2], kind),
+
+        _ => throw new ArgumentOutOfRangeException(nameof(range), "Length must be two with the first character be before the second value."),
+    };
+
     /// <summary>Matches if the remaining source starts with the specified pattern.</summary>
     /// <param name="pattern">
     /// The expected pattern.

--- a/src/DotNetProjectFile.Analyzers/Grammr/Source.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Source.cs
@@ -19,7 +19,7 @@ public sealed class Source(string text)
     /// The length of the span.
     /// </param>
     [Pure]
-    public ReadOnlySpan<char> AsSpan(int start, int length)
+    public Chars AsSpan(int start, int length)
         => Text.AsSpan(start, length);
 
     /// <summary>Tries to match the regular expression.</summary>

--- a/src/DotNetProjectFile.Analyzers/Grammr/SourceReader.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/SourceReader.cs
@@ -14,7 +14,7 @@ public ref struct SourceReader(Source source, TokenStream? stream = null)
     public TokenStream Stream { get; set; } = stream ?? source;
 
     /// <summary>Gets the remaining span of the source starting at the current position of the reader.</summary>
-    public ReadOnlySpan<char> Span { get; private set; } = source.AsSpan(0, source.Length);
+    public Chars Span { get; private set; } = source.AsSpan(0, source.Length);
 
     /// <summary>Gets the start position of the reader in the source.</summary>
     public readonly int Start => Source.Length - Span.Length;

--- a/src/DotNetProjectFile.Analyzers/Grammr/Token.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/Token.cs
@@ -13,7 +13,7 @@ public readonly struct Token(int start, int length, Source source, string? kind)
 
     public int End => Start + Length;
 
-    public ReadOnlySpan<char> Span => Source.AsSpan(Start, Length);
+    public Chars Span => Source.AsSpan(Start, Length);
 
     /// <inheritdoc />
     [Pure]

--- a/src/DotNetProjectFile.Analyzers/Grammr/TokenStream.cs
+++ b/src/DotNetProjectFile.Analyzers/Grammr/TokenStream.cs
@@ -29,7 +29,7 @@ public readonly struct TokenStream : IReadOnlyList<Token>
     public int Length => Count is 0 ? 0 : Tokens[Count - 1].End - Tokens[0].Start;
 
     /// <summary>Gets the span repesented by the tokens.</summary>
-    public ReadOnlySpan<char> Span => Source.AsSpan(Start, Length);
+    public Chars Span => Source.AsSpan(Start, Length);
 
     /// <inheritdoc />
     public Token this[int index]

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/AnyChar.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/AnyChar.cs
@@ -10,7 +10,7 @@ internal sealed class AnyChar : Segment
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison)
+    public override bool IsMatch(Chars value, StringComparison comparison)
         => value.Length == 1;
 
     /// <inheritdoc />

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/Group.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/Group.cs
@@ -12,11 +12,11 @@ internal sealed class Group(Segment[] segments) : Segment
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison)
+    public override bool IsMatch(Chars value, StringComparison comparison)
         => IsMatch(Segments.AsSpan(), value, comparison);
 
     [Pure]
-    private static bool IsMatch(ReadOnlySpan<Segment> segments, ReadOnlySpan<char> value, StringComparison comparison)
+    private static bool IsMatch(ReadOnlySpan<Segment> segments, Chars value, StringComparison comparison)
     {
         var (minLength, maxLength) = Lengths(segments);
         var buffer = value;

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/Literal.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/Literal.cs
@@ -12,7 +12,7 @@ internal sealed class Literal(string text) : Segment
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison)
+    public override bool IsMatch(Chars value, StringComparison comparison)
         => value.Equals(Text.AsSpan(), comparison);
 
     /// <inheritdoc />

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/NotSequense.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/NotSequense.cs
@@ -4,7 +4,7 @@ internal sealed class NotSequence(string options) : Sequence(options)
 {
     /// <inheritdoc />
     [Pure]
-    public override bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison)
+    public override bool IsMatch(Chars value, StringComparison comparison)
         => value.Length is 1
         && !base.IsMatch(value, comparison);
 

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/Option.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/Option.cs
@@ -12,7 +12,7 @@ internal sealed class Option(IReadOnlyList<Segment> segments) : Segment
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison)
+    public override bool IsMatch(Chars value, StringComparison comparison)
     {
         foreach (var segment in Segments)
         {

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/RecursiveWildcard.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/RecursiveWildcard.cs
@@ -10,7 +10,7 @@ internal sealed class RecursiveWildcard : Segment
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison)
+    public override bool IsMatch(Chars value, StringComparison comparison)
         => true;
 
     /// <inheritdoc />

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/Segment.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/Segment.cs
@@ -18,5 +18,5 @@ internal abstract class Segment
 
     /// <inheritdoc cref="Glob.IsMatch(string, StringComparison)" />
     [Pure]
-    public abstract bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison);
+    public abstract bool IsMatch(Chars value, StringComparison comparison);
 }

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/Sequence.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/Sequence.cs
@@ -13,7 +13,7 @@ internal class Sequence(string options) : Segment
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison)
+    public override bool IsMatch(Chars value, StringComparison comparison)
     {
         if (value.Length != 1) return false;
 

--- a/src/DotNetProjectFile.Analyzers/IO/Segments/Wildcard.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/Segments/Wildcard.cs
@@ -10,7 +10,7 @@ internal sealed class Wildcard : Segment
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsMatch(ReadOnlySpan<char> value, StringComparison comparison)
+    public override bool IsMatch(Chars value, StringComparison comparison)
     {
         foreach (var ch in value)
         {

--- a/src/DotNetProjectFile.Analyzers/Properties/GlobalUsings.cs
+++ b/src/DotNetProjectFile.Analyzers/Properties/GlobalUsings.cs
@@ -17,6 +17,7 @@ global using System.Diagnostics.Contracts;
 global using System.Linq;
 global using System.Threading;
 global using System.Xml.Linq;
+global using Chars = System.ReadOnlySpan<char>;
 global using IniFileAnalysisContext = DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext<DotNetProjectFile.Ini.IniFile>;
 global using NuGetConfigFileAnalysisContext = DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext<DotNetProjectFile.NuGet.Configuration.NuGetConfigFile>;
 global using ProjectFileAnalysisContext = DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext<DotNetProjectFile.MsBuild.MsBuildProject>;


### PR DESCRIPTION
To be able to use `Lexer`'s both within parsers (using `SourceReader`) as while matching GLOB's, only dealing with `ReadOnlySpan<char>`.
- [x] Extend contract
- [x] Extend implementations
- [x] Alias `ReadOnlySpan<char>` as `Chars`
- [x] Implement `CharRange` for matching characters in a certain range.
