### PR TITLE
ci: simplify GitHub release step in publish workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -67,23 +67,12 @@ jobs:
         with:
           name: nupkg
 
-      - name: Create release notes
-        uses: johnyherangi/create-release-notes@main
-        id: create-release-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{ steps.create-release-notes.outputs.release-notes }}
-          draft: false
-          prerelease: ${{ contains(github.ref, '-') }}
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
       - name: DotNet NuGet Push  
         run: dotnet nuget push "*.nupkg" --source ${{ env.NUGET_FEED}} --api-key ${{ env.NUGET_KEY }} --skip-duplicate --no-symbols    


### PR DESCRIPTION
The GitHub Action [actions/create-release](https://github.com/actions/create-release) is no longer maintained, so this PR migrates the release step to [softprops/action-gh-release](https://github.com/softprops/action-gh-release), which is actively maintained.

This change:
- Replaces the separate release notes and release creation steps with a single [softprops/action-gh-release](https://github.com/softprops/action-gh-release) step.
- Enables automatically generated GitHub release notes.
- Switches to github.ref_name for tag and prerelease detection.
- Marks a release as prerelease when the tag contains a hyphen.

Overall, this simplifies the workflow and removes custom release-notes wiring.

Closes #841, #769.
