### PR TITLE
Remove Specs. namespace prefix

### DIFF
--- a/specs/Specs/Caching/FileCache_specs.cs
+++ b/specs/Specs/Caching/FileCache_specs.cs
@@ -3,7 +3,7 @@ using DotNetProjectFile.IO;
 using System.IO;
 using VerifyTests;
 
-namespace Specs.Caching.FileCache_specs;
+namespace Caching.FileCache_specs;
 
 public class TryGetOrUpdate
 {

--- a/specs/Specs/Design_specs.cs
+++ b/specs/Specs/Design_specs.cs
@@ -169,6 +169,20 @@ public partial class Rules
     };
 }
 
+public class Namespaces
+{
+    [TestCaseSource(nameof(Types))]
+    public void are_compliant(Type type)
+        => IsCompliant(type).Should().BeTrue();
+
+    private static bool IsCompliant(Type type)
+        => type.Namespace is null
+        || type.Namespace.StartsWith("Specs.TestTools")
+        || !type.Namespace.StartsWith("Specs");
+
+    private static Type[] Types => typeof(Namespaces).Assembly.GetTypes();
+}
+
 /// <remarks>Wrapper for better display of test resources in IDE.</remarks>
 public sealed record Rule(DiagnosticDescriptor Descriptor)
 {

--- a/specs/Specs/Git/GitIgnoreFile_specs.cs
+++ b/specs/Specs/Git/GitIgnoreFile_specs.cs
@@ -1,6 +1,6 @@
 using DotNetProjectFile.Git;
 
-namespace Specs.Git.GitIgnoreFile_specs;
+namespace Git.GitIgnoreFile_specs;
 
 public class Parses
 {

--- a/specs/Specs/Grammr/GrammrNode_specs.cs
+++ b/specs/Specs/Grammr/GrammrNode_specs.cs
@@ -3,7 +3,7 @@ using Grammr;
 using Microsoft.CodeAnalysis.Text;
 using static Grammr.Lexers.Shared;
 
-namespace Specs.GrammrNode_specs;
+namespace GrammrNode_specs;
 
 public class Spans
 {

--- a/specs/Specs/Grammr/Lexer_specs.cs
+++ b/specs/Specs/Grammr/Lexer_specs.cs
@@ -1,7 +1,7 @@
 using Grammr.Lexers;
 using static Grammr.Lexers.Shared;
 
-namespace Specs.Lexer_specs;
+namespace Lexer_specs;
 
 public class EndOfLine
 {

--- a/specs/Specs/Grammr/SourceReader_specs.cs
+++ b/specs/Specs/Grammr/SourceReader_specs.cs
@@ -3,7 +3,7 @@ using Grammr;
 using System.Text.RegularExpressions;
 using static Grammr.Lexers.Shared;
 
-namespace Specs.SourceReader_specs;
+namespace SourceReader_specs;
 
 public class Consumes
 {

--- a/specs/Specs/Grammr/Types_specs.cs
+++ b/specs/Specs/Grammr/Types_specs.cs
@@ -1,4 +1,4 @@
-namespace Specs.Grammr_Types_specs;
+namespace Grammr_Types_specs;
 
 public class Namespaces
 {

--- a/specs/Specs/INI/IniFile_specs.cs
+++ b/specs/Specs/INI/IniFile_specs.cs
@@ -1,6 +1,6 @@
 using DotNetProjectFile.Ini;
 
-namespace Specs.INI.IniFile_specs;
+namespace INI.IniFile_specs;
 
 public class Parses
 {

--- a/specs/Specs/MS_Build/LanguageVersion_specs.cs
+++ b/specs/Specs/MS_Build/LanguageVersion_specs.cs
@@ -1,6 +1,6 @@
 using DotNetProjectFile.MsBuild;
 
-namespace Specs.MS_Build.LanguageVersion_specs;
+namespace MS_Build.LanguageVersion_specs;
 
 public class Parses
 {

--- a/specs/Specs/MS_Build/MsBuildExpression_specs.cs
+++ b/specs/Specs/MS_Build/MsBuildExpression_specs.cs
@@ -1,6 +1,6 @@
 using DotNetProjectFile.MsBuild;
 
-namespace Specs.MsBuild.MsBuildExprssion_specs;
+namespace MsBuild.MsBuildExprssion_specs;
 
 public class Parsing
 {

--- a/specs/Specs/MS_Build/SdkVersion_specs.cs
+++ b/specs/Specs/MS_Build/SdkVersion_specs.cs
@@ -1,6 +1,6 @@
 using DotNetProjectFile.MsBuild;
 
-namespace Specs.MS_Build.SdkVersion_specs;
+namespace MS_Build.SdkVersion_specs;
 
 public class Parses
 {

--- a/specs/Specs/Package/NuGet_package_specs.cs
+++ b/specs/Specs/Package/NuGet_package_specs.cs
@@ -1,6 +1,6 @@
 using System.IO;
 
-namespace Specs.NuGet_package_specs;
+namespace NuGet_package_specs;
 
 #if !DEBUG
 [Explicit]

--- a/specs/Specs/Rules/Global_package_references_only_work_with_CPM.cs
+++ b/specs/Specs/Rules/Global_package_references_only_work_with_CPM.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.Global_package_references_only_work_with_CPM;
+namespace Rules.Global_package_references_only_work_with_CPM;
 
 public class Reports
 {

--- a/specs/Specs/Rules/INI/Remove_headers_from_global_config.cs
+++ b/specs/Specs/Rules/INI/Remove_headers_from_global_config.cs
@@ -1,6 +1,6 @@
 using DotNetProjectFile.Analyzers.Ini;
 
-namespace Specs.Rules.INI.Remove_headers_from_global_config;
+namespace Rules.INI.Remove_headers_from_global_config;
 
 public class Reports
 {

--- a/specs/Specs/Rules/INI/Use_globalconfig_for_Roslyn_diagnostics.cs
+++ b/specs/Specs/Rules/INI/Use_globalconfig_for_Roslyn_diagnostics.cs
@@ -1,6 +1,6 @@
 using DotNetProjectFile.Analyzers.Ini;
 
-namespace Specs.Rules.INI.Use_globalconfig_for_Roslyn_diagnostics;
+namespace Rules.INI.Use_globalconfig_for_Roslyn_diagnostics;
 
 public class Reports
 {

--- a/specs/Specs/Rules/MS_Build/Enforce_code_style_in_builds.cs
+++ b/specs/Specs/Rules/MS_Build/Enforce_code_style_in_builds.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.MS_Build.Enforce_code_style_in_builds;
+namespace Rules.MS_Build.Enforce_code_style_in_builds;
 
 public class Reports
 {

--- a/specs/Specs/Rules/MS_Build/Prefer_attributes_over_elements.cs
+++ b/specs/Specs/Rules/MS_Build/Prefer_attributes_over_elements.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.MS_Build.Prefer_attributes_over_elements;
+namespace Rules.MS_Build.Prefer_attributes_over_elements;
 
 public class Reports
 {

--- a/specs/Specs/Rules/MS_Build/Trim_whitespace.cs
+++ b/specs/Specs/Rules/MS_Build/Trim_whitespace.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.MS_Build.Trim_whitespace;
+namespace Rules.MS_Build.Trim_whitespace;
 
 public class Reports
 {

--- a/specs/Specs/Rules/NuGet/Avoid_local_package_sources.cs
+++ b/specs/Specs/Rules/NuGet/Avoid_local_package_sources.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.NuGet.Avoid_local_package_sources;
+namespace Rules.NuGet.Avoid_local_package_sources;
 
 public class Reports
 {

--- a/specs/Specs/Rules/NuGet/Clear_previous_PackageSources.cs
+++ b/specs/Specs/Rules/NuGet/Clear_previous_PackageSources.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.NuGet.Clear_previous_PackageSources;
+namespace Rules.NuGet.Clear_previous_PackageSources;
 
 public class Reports
 {

--- a/specs/Specs/Rules/NuGet/Handle_package_source_mappings.cs
+++ b/specs/Specs/Rules/NuGet/Handle_package_source_mappings.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.NuGet.Handle_package_source_mappings;
+namespace Rules.NuGet.Handle_package_source_mappings;
 
 public class Reports
 {

--- a/specs/Specs/Rules/NuGet/NuGet_authentication_should_be_secure.cs
+++ b/specs/Specs/Rules/NuGet/NuGet_authentication_should_be_secure.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.NuGet.NuGet_authentication_should_be_secure;
+namespace Rules.NuGet.NuGet_authentication_should_be_secure;
 
 public class Reports
 {

--- a/specs/Specs/Rules/NuGet/Trim_whitespace.cs
+++ b/specs/Specs/Rules/NuGet/Trim_whitespace.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.NuGet.Trim_whitespace;
+namespace Rules.NuGet.Trim_whitespace;
 
 public class Reports
 {

--- a/specs/Specs/Rules/SLNX/Omit_project_Ids.cs
+++ b/specs/Specs/Rules/SLNX/Omit_project_Ids.cs
@@ -1,4 +1,4 @@
-namespace Specs.Rules.SLNX.Omit_project_Ids;
+namespace Rules.SLNX.Omit_project_Ids;
 
 public class Reports
 {

--- a/specs/Specs/SemVer_specs.cs
+++ b/specs/Specs/SemVer_specs.cs
@@ -1,6 +1,6 @@
 using DotNetProjectFile;
 
-namespace Specs.SemVer_specs;
+namespace SemVer_specs;
 
 public class Parses
 {


### PR DESCRIPTION
The idea about the namespaces in the Specs project is to use them to group different specs/tests. Having a prefix `Specs.` on all of them (or a random subset) is just adding noise. I've decided that `Specs.TestTools` is just fine.