### PR TITLE
Run analyzers during build

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@ reported to the [GitHub repository](https://github.com/dotnet-project-file-analy
 * [**Proj0050** Enforce code-style in builds](rules/Proj0050.md)
 * [**Proj0051** Project reference must be case-consistent with the file system](rules/Proj0051.md)
 * [**Proj0052** Prefer attributes over element](rules/Proj0052.md)
+* [**Proj0053** Run analyzers during build](rules/Proj0053.md)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)

--- a/docs/rules/Proj0053.md
+++ b/docs/rules/Proj0053.md
@@ -7,7 +7,7 @@ permalink: /rules/Proj0053
 # Proj0053: Run analyzers during build
 Disabling code analysis permanently inside your project configuration turns off
 a crucial safety net for your codebase. While it might look like a quick fix to
-speed up builds, but introces severe risks.
+speed up builds, it introduces severe risks.
 
  If analysis is turned off in the project file, your build server/pipeline will
  also skip analyzer checks. This allows broken styles, security vulnerabilities,

--- a/docs/rules/Proj0053.md
+++ b/docs/rules/Proj0053.md
@@ -1,0 +1,38 @@
+---
+parent: General
+ancestor: MSBuild
+permalink: /rules/Proj0053
+---
+
+# Proj0053: Run analyzers during build
+Disabling code analysis permanently inside your project configuration turns off
+a crucial safety net for your codebase. While it might look like a quick fix to
+speed up builds, but introces severe risks.
+
+ If analysis is turned off in the project file, your build server/pipeline will
+ also skip analyzer checks. This allows broken styles, security vulnerabilities,
+ and bad practices to slip into the main branch completely undetected.
+
+ Developers lose immediate feedback. Instead of catching a mistake during
+ compilation, issues are only discovered much later during manual code reviews
+ or, worse, as bugs in production.
+
+## Non-compliant
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+  </PropertyGroup>
+
+</Project>
+```
+
+## Compliant
+If the goal is a temporary performance optimization during local development,
+disabling the analyzers entirely via commandline is a vastly superior option:
+
+```bash
+dotnet build /p:RunAnalyzersDuringBuild=false
+```

--- a/globalconfig.verified.txt
+++ b/globalconfig.verified.txt
@@ -50,6 +50,7 @@ dotnet_diagnostic.Proj0049.severity = warning    # Prefer the latest released la
 dotnet_diagnostic.Proj0050.severity = warning    # Enforce code-style in builds
 dotnet_diagnostic.Proj0051.severity = warning    # Project reference must be case-consistent with the file system
 dotnet_diagnostic.Proj0052.severity = warning    # Prefer attributes over elements
+dotnet_diagnostic.Proj0053.severity = warning    # Run analyzers during build
 dotnet_diagnostic.Proj0200.severity = warning    # Define the project packability explicitly
 dotnet_diagnostic.Proj0201.severity = warning    # Define the project version explicitly
 dotnet_diagnostic.Proj0202.severity = warning    # Define the project description explicitly

--- a/specs/Specs/Package/NuGet_package_specs.cs
+++ b/specs/Specs/Package/NuGet_package_specs.cs
@@ -24,6 +24,7 @@ public class Contains
             "build/AdditionalFiles.Sdk.props",
             "build/CompilerVisible.props", 
             "build/AdditionalFiles.targets",
+            "build/DotNetProjectFile.Analyzers.globalconfig",
             "build/DotNetProjectFile.Analyzers.props",
             "build/DotNetProjectFile.Analyzers.Sdk.props",
             "build/DotNetProjectFile.Analyzers.targets",

--- a/specs/Specs/Rules/MS_Build/Run_analyzers_during_build.cs
+++ b/specs/Specs/Rules/MS_Build/Run_analyzers_during_build.cs
@@ -3,7 +3,7 @@ namespace Rules.MS_Build.Run_analyzers_during_build;
 public class Reports
 {
     [Test]
-    public void when_dispabled() => new RunAnalyzersDuringBuild().ForInlineCsproj("""
+    public void when_disabled() => new RunAnalyzersDuringBuild().ForInlineCsproj("""
         <Project Sdk="Microsoft.NET.Sdk">
         
           <PropertyGroup>

--- a/specs/Specs/Rules/MS_Build/Run_analyzers_during_build.cs
+++ b/specs/Specs/Rules/MS_Build/Run_analyzers_during_build.cs
@@ -1,0 +1,33 @@
+namespace Rules.MS_Build.Run_analyzers_during_build;
+
+public class Reports
+{
+    [Test]
+    public void when_dispabled() => new RunAnalyzersDuringBuild().ForInlineCsproj("""
+        <Project Sdk="Microsoft.NET.Sdk">
+        
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+          </PropertyGroup>
+        
+        </Project>
+        """)
+        .HasIssue(Issue.WRN("Proj0053", "Run analyzers during build").WithSpan(04, 04, 04, 60));
+}
+
+public class Guards
+{
+    [Test]
+    public void when_enabled_explictly() => new RunAnalyzersDuringBuild().ForInlineCsproj("""
+        <Project Sdk="Microsoft.NET.Sdk">
+        
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+          </PropertyGroup>
+        
+        </Project>
+        """)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunAnalyzersDuringBuild.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunAnalyzersDuringBuild.cs
@@ -1,0 +1,23 @@
+namespace DotNetProjectFile.Analyzers.MsBuild;
+
+/// <summary>Implements <see cref="Rule.RunAnalyzersDuringBuild" />.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class RunAnalyzersDuringBuild() : MsBuildProjectFileAnalyzer(Rule.RunAnalyzersDuringBuild)
+{
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
+    public override ImmutableArray<AnalyzerType> ApplicableTo => ProjectFileTypes.ProjectFile_SDK;
+
+    /// <inheritdoc />
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        foreach (var property in context.File
+            .Properties<DotNetProjectFile.MsBuild.RunAnalyzersDuringBuild>()
+            .Where(p => p.Value is false))
+        {
+            context.ReportDiagnostic(Descriptor, property);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -87,6 +87,7 @@ ToBeDecided:
 v1.16.0
 - Proj0006: Skip detecting if RESX'es are additional files. (UPDATE)
 - Proj0052: Do not advise attributes in child nodes of the root. (FP)
+- Proj0053: Run analyzers during build. (NEW RULE)
 - Proj0220: Ignore SNUPKG setup for development dependencies. (FP)
 - Proj1101: Report on unstable versions of development dependencies. (FN)
 - Proj4000: Invalid INI file. (RE-ENABLE)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/RunAnalyzersDuringBuild.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/RunAnalyzersDuringBuild.cs
@@ -1,0 +1,4 @@
+namespace DotNetProjectFile.MsBuild;
+
+public sealed class RunAnalyzersDuringBuild(XElement element, Node? parent, MsBuildProject? project)
+    : Node<bool?>(element, parent, project);

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -54,6 +54,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0050** Enforce code-style in builds](https://dotnet-project-file-analyzers.github.io/rules/Proj0050.html)
 * [**Proj0051** Project reference must be case-consistent with the file system](https://dotnet-project-file-analyzers.github.io/rules/Proj0051.html)
 * [**Proj0052** Prefer attributes over element](https://dotnet-project-file-analyzers.github.io/rules/Proj0052.html)
+* [**Proj0053** Run analyzers during build](https://dotnet-project-file-analyzers.github.io/rules/Proj0053.html)
 
 ### Packaging
 * [**Proj0200** Define IsPackable explicitly](https://dotnet-project-file-analyzers.github.io/rules/Proj0200.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -505,6 +505,14 @@ public static partial class Rule
         tags: ["Clarity", "Readability"],
         category: Category.Formatting);
 
+    public static DiagnosticDescriptor RunAnalyzersDuringBuild => New(
+      id: 0053,
+      title: "Run analyzers during build",
+      message: "Run analyzers during build",
+      description: "Diagnostic analyzers give importent feedback that should not be ingored.",
+      tags: ["MSBuild", "analyzers"],
+      category: Category.CodeQuality);
+
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,
         title: "Define the project packability explicitly",

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -509,7 +509,7 @@ public static partial class Rule
       id: 0053,
       title: "Run analyzers during build",
       message: "Run analyzers during build",
-      description: "Diagnostic analyzers give importent feedback that should not be ingored.",
+      description: "Diagnostic analyzers give important feedback that should not be ignored.",
       tags: ["MSBuild", "analyzers"],
       category: Category.CodeQuality);
 


### PR DESCRIPTION
# Proj0053: Run analyzers during build
Disabling code analysis permanently inside your project configuration turns off a crucial safety net for your codebase. While it might look like a quick fix to speed up builds, but introces severe risks.

 If analysis is turned off in the project file, your build server/pipeline will also skip analyzer checks. This allows broken styles, security vulnerabilities,  and bad practices to slip into the main branch completely undetected.

 Developers lose immediate feedback. Instead of catching a mistake during compilation, issues are only discovered much later during manual code reviews  or, worse, as bugs in production.

## Non-compliant
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net10.0</TargetFramework>
    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
  </PropertyGroup>

</Project>
```

## Compliant
If the goal is a temporary performance optimization during local development, disabling the analyzers entirely via commandline is a vastly superior option:

```bash
dotnet build /p:RunAnalyzersDuringBuild=false
```

Closes #894