### PR TITLE
Ignore MSBuild item expressions when checking for existance

### DIFF
--- a/projects/EmptyInclude/EmptyInclude.csproj
+++ b/projects/EmptyInclude/EmptyInclude.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup Label="Ignores">
     <Compile Include="./../ignore/$(Configuration).doc" />
+	<AdditionalFiles Include="@(Compile)" />
   </ItemGroup>
 
 </Project>

--- a/specs/Specs/Rules/MS_Build/Build_action_include_should_exist.cs
+++ b/specs/Specs/Rules/MS_Build/Build_action_include_should_exist.cs
@@ -3,8 +3,7 @@ namespace Rules.MS_Build.Build_action_include_should_exist;
 public class Reports
 {
     [Test]
-    public void empty_includes()
-        => new BuildActionIncludeShouldExist()
+    public void empty_includes() => new BuildActionIncludeShouldExist()
         .ForProject("EmptyInclude.cs")
         .HasIssues(
             Issue.WRN("Proj0022", "The Include '*.txt' of <None> does not match any files" /*..........*/).WithSpan(08, 04, 08, 28),
@@ -15,8 +14,7 @@ public class Reports
         );
 
     [Test]
-    public void empty_includes_config_files()
-        => new BuildActionIncludeShouldExist()
+    public void empty_includes_config_files() => new BuildActionIncludeShouldExist()
         .ForProject("ConfigFilesExistence.cs")
         .HasIssues(
             Issue.WRN("Proj0022", "The Include 'missing.editor' of <EditorConfgFiles> does not exist" /*....*/).WithSpan(12, 04, 12, 49),
@@ -27,8 +25,7 @@ public class Reports
 public class Guards
 {
     [TestCase("CompliantCSharp.cs")]
-    public void Projects_with_analyzers(string project)
-         => new BuildActionIncludeShouldExist()
+    public void Projects_with_analyzers(string project) => new BuildActionIncludeShouldExist()
         .ForProject(project)
         .HasNoIssues();
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/BuildActionIncludeShouldExist.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/BuildActionIncludeShouldExist.cs
@@ -1,5 +1,6 @@
 namespace DotNetProjectFile.Analyzers.MsBuild;
 
+/// <summary>Implements <see cref="Rule.BuildActionIncludeShouldExist"/>.</summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class BuildActionIncludeShouldExist() : MsBuildProjectFileAnalyzer(Rule.BuildActionIncludeShouldExist)
 {

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -86,6 +86,7 @@ ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
 v1.16.0
 - Proj0006: Skip detecting if RESX'es are additional files. (UPDATE)
+- Proj0022: Ignore MSBuild items (@({ItemName})). (FP)
 - Proj0052: Do not advise attributes in child nodes of the root. (FP)
 - Proj0053: Run analyzers during build. (NEW RULE)
 - Proj0220: Ignore SNUPKG setup for development dependencies. (FP)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -86,7 +86,7 @@ ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
 v1.16.0
 - Proj0006: Skip detecting if RESX'es are additional files. (UPDATE)
-- Proj0022: Ignore MSBuild items (@({ItemName})). (FP)
+- Proj0022: Ignore MSBuild item expressions. (FP)
 - Proj0052: Do not advise attributes in child nodes of the root. (FP)
 - Proj0053: Run analyzers during build. (NEW RULE)
 - Proj0220: Ignore SNUPKG setup for development dependencies. (FP)

--- a/src/DotNetProjectFile.Analyzers/IO/IODirectory.cs
+++ b/src/DotNetProjectFile.Analyzers/IO/IODirectory.cs
@@ -177,7 +177,9 @@ public readonly struct IODirectory : IEquatable<IODirectory>, IFormattable, ICom
     private IEnumerable<T>? Iterate<T>(string path, Func<DirectoryInfo, string, IEnumerable<T>> enumerate)
     {
         // We do not support variables yet.
-        if (path.Contains("$(") || Info is null) return null;
+        if (path.Contains("$(")
+            || path.Contains("@(")
+            || Info is null) return null;
 
         IEnumerable<DirectoryInfo> enumerator = new RootDirectory(Info);
         var parts = path.Split('/', '\\');


### PR DESCRIPTION
[Proj0022](https://dotnet-project-file-analyzers.github.io/rules/Proj1002.html) tests if included or removed items match any files at all. It was not able to recognize `@(Compile)` and other MSBuild item expressions. They do not (primarily) refer to items on disk, and can not be checked (easily) within the context of a Roslyn analyzers.

Closes #899 