### PR TITLE
Set analyzer types correctly

### DIFF
--- a/specs/Specs/AdditionalFiles_specs.cs
+++ b/specs/Specs/AdditionalFiles_specs.cs
@@ -86,8 +86,8 @@ public class Resolves
                 ItemSpec = ".net.csproj",
                 Metadata = new Meta
                 {
-                    AnalyzerType = "SDK",
                     Visible = "false",
+                    AnalyzerType = "SDK",
                 },
             },
             new ProjectItem
@@ -137,6 +137,33 @@ public class Resolves
             },
             new ProjectItem
             {
+                ItemSpec = Full("AdditionalFilesProject/Directory.Build.props"),
+                Metadata = new Meta
+                {
+                    Visible = "false",
+                    AnalyzerType = "DirectoryBuildProps",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = Full("AdditionalFilesProject/Directory.Build.targets"),
+                Metadata = new Meta
+                {
+                    Visible = "false",
+                    AnalyzerType = "DirectoryBuildTargets",
+                },
+            },
+            new ProjectItem
+            {
+                ItemSpec = Full("AdditionalFilesProject/Directory.Packages.props"),
+                Metadata = new Meta
+                {
+                    Visible = "false",
+                    AnalyzerType = "DirectoryPackagesProps",
+                },
+            },
+            new ProjectItem
+            {
                 ItemSpec = Full("../src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.globalconfig"),
                 Metadata = new Meta
                 {
@@ -147,33 +174,6 @@ public class Resolves
             new ProjectItem
             {
                 ItemSpec = "copyright.props",
-                Metadata = new Meta
-                {
-                    Visible = "true",
-                    AnalyzerType = "MSBuildProps",
-                },
-            },
-            new ProjectItem
-            {
-                ItemSpec = "Directory.Build.props",
-                Metadata = new Meta
-                {
-                    Visible = "true",
-                    AnalyzerType = "MSBuildProps",
-                },
-            },
-            new ProjectItem
-            {
-                ItemSpec = "Directory.Build.targets",
-                Metadata = new Meta
-                {
-                    Visible = "true",
-                    AnalyzerType = "MSBuildProps",
-                },
-            },
-            new ProjectItem
-            {
-                ItemSpec = "Directory.Packages.props",
                 Metadata = new Meta
                 {
                     Visible = "true",

--- a/specs/Specs/CodeAnalysis/AnalyzerTypes_specs.cs
+++ b/specs/Specs/CodeAnalysis/AnalyzerTypes_specs.cs
@@ -1,0 +1,42 @@
+using DotNetProjectFile.CodeAnalysis;
+using DotNetProjectFile.IO;
+
+namespace CodeAnalysis.AnalyzerTypes_specs;
+
+public class MsBuild_matches
+{
+    [TestCase(".net.csproj")]
+    [TestCase(@"C:\code\repo\.net.csproj")]
+    public void SDK(IOFile file) => AnalyzerTypes.MsBuild(file).Should().Be(AnalyzerType.SDK);
+
+    [TestCase("project.csproj")]
+    [TestCase(@"C:\code\repo\project.csproj")]
+    public void MSBuildProject(IOFile file) => AnalyzerTypes.MsBuild(file).Should().Be(AnalyzerType.MSBuildProject);
+
+    [TestCase("Directory.Build.props")]
+    [TestCase(@"C:\code\repo\Directory.Build.props")]
+    [TestCase(@"C:\code\repo\directory.build.props")]
+    public void DirectoryBuildProps(IOFile file) => AnalyzerTypes.MsBuild(file).Should().Be(AnalyzerType.DirectoryBuildProps);
+
+    [TestCase("Directory.Build.targets")]
+    [TestCase(@"C:\code\repo\Directory.Build.targets")]
+    [TestCase(@"C:\code\repo\directory.build.targets")]
+    public void DirectoryBuildTargets(IOFile file) => AnalyzerTypes.MsBuild(file).Should().Be(AnalyzerType.DirectoryBuildTargets);
+
+    [TestCase("Directory.Packages.props")]
+    [TestCase(@"C:\code\repo\Directory.Packages.props")]
+    [TestCase(@"C:\code\repo\directory.packages.props")]
+    public void DirectoryPackagesProps(IOFile file) => AnalyzerTypes.MsBuild(file).Should().Be(AnalyzerType.DirectoryPackagesProps);
+
+    [TestCase("shared.props")]
+    [TestCase("shared.targets")]
+    [TestCase(@"C:\code\repo\shared.props")]
+    [TestCase(@"C:\code\repo\shared.targets")]
+    public void MSBuildProps(IOFile file) => AnalyzerTypes.MsBuild(file).Should().Be(AnalyzerType.MSBuildProps);
+
+    [TestCase("file.exe")]
+    [TestCase("file.dll")]
+    [TestCase(@"C:\code\repo\file.cs")]
+    [TestCase(@"C:\code\repo\file.vb")]
+    public void known_files_only(IOFile file) => AnalyzerTypes.MsBuild(file).Should().BeNull();
+}

--- a/specs/Specs/MS_Build/ProjectFileTypes_specs.cs
+++ b/specs/Specs/MS_Build/ProjectFileTypes_specs.cs
@@ -1,0 +1,32 @@
+using DotNetProjectFile.CodeAnalysis;
+using DotNetProjectFile.MsBuild;
+
+namespace MS_Build_ProjectFileTypes_specs;
+
+public class Defines
+{
+    [Test]
+    public void All() => ProjectFileTypes.All.Should().BeEquivalentTo([
+        AnalyzerType.MSBuildProject,
+        AnalyzerType.MSBuildProps,
+        AnalyzerType.DirectoryBuildProps,
+        AnalyzerType.DirectoryBuildTargets,
+        AnalyzerType.DirectoryPackagesProps,
+        AnalyzerType.SDK]);
+
+    [Test]
+    public void AllExceptSDK() => ProjectFileTypes.AllExceptSDK.Should().BeEquivalentTo([
+       AnalyzerType.MSBuildProject,
+        AnalyzerType.MSBuildProps,
+        AnalyzerType.DirectoryBuildProps,
+        AnalyzerType.DirectoryBuildTargets,
+        AnalyzerType.DirectoryPackagesProps]);
+
+    [Test]
+    public void AllExceptDirectoryPackages() => ProjectFileTypes.AllExceptDirectoryPackages.Should().BeEquivalentTo([
+        AnalyzerType.MSBuildProject,
+        AnalyzerType.MSBuildProps,
+        AnalyzerType.DirectoryBuildProps,
+        AnalyzerType.DirectoryBuildTargets,
+        AnalyzerType.SDK]);
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AddAdditionalFile.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AddAdditionalFile.cs
@@ -5,9 +5,6 @@ namespace DotNetProjectFile.Analyzers.MsBuild;
 public sealed class AddAdditionalFile() : MsBuildProjectFileAnalyzer(Rule.AddAdditionalFile)
 {
     /// <inheritdoc />
-    public override ImmutableArray<AnalyzerType> ApplicableTo => ProjectFileTypes.All;
-
-    /// <inheritdoc />
     public override bool DisableOnFailingImport => false;
 
     /// <inheritdoc />

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidChangingCompilerTools.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidChangingCompilerTools.cs
@@ -8,7 +8,7 @@ public sealed class AvoidChangingCompilerTools() : MsBuildProjectFileAnalyzer(Ru
     public override bool DisableOnFailingImport => false;
 
     /// <inheritdoc />
-    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var property in context.File.PropertyGroups.Children<Node>(IsCompilerTool))
         {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/LabelItemGroupsThatRemoveCompilationItems.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/LabelItemGroupsThatRemoveCompilationItems.cs
@@ -9,9 +9,6 @@ public sealed class LabelItemGroupsThatRemoveCompilationItems()
     public override bool DisableOnFailingImport => false;
 
     /// <inheritdoc />
-    public override ImmutableArray<AnalyzerType> ApplicableTo => ProjectFileTypes.All;
-
-    /// <inheritdoc />
     protected override void Register(ProjectFileAnalysisContext context)
     {
         foreach (var group in context.File.ItemGroups.Where(RequireLabel))

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/AnalyzerTypes.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/AnalyzerTypes.cs
@@ -1,13 +1,13 @@
 namespace DotNetProjectFile.CodeAnalysis;
 
-internal static class AnalyzerTypes
+public static class AnalyzerTypes
 {
     public static AnalyzerType? MsBuild(IOFile file) => file switch
     {
         _ when file.Name.IsMatch(".net.csproj") => AnalyzerType.SDK,
         _ when Languages.All.Any(lang => file.Extension.IsMatch(lang.ProjectFileExtension)) => AnalyzerType.MSBuildProject,
-        _ when file.Name.IsMatch("Directory.Build.props") => AnalyzerType.DirectoryBuildTargets,
-        _ when file.Name.IsMatch("Directory.Build.targets") => AnalyzerType.DirectoryBuildProps,
+        _ when file.Name.IsMatch("Directory.Build.props") => AnalyzerType.DirectoryBuildProps,
+        _ when file.Name.IsMatch("Directory.Build.targets") => AnalyzerType.DirectoryBuildTargets,
         _ when file.Name.IsMatch("Directory.Packages.props") => AnalyzerType.DirectoryPackagesProps,
         _ when file.Extension.IsMatch(".props")
             || file.Extension.IsMatch(".targets") => AnalyzerType.MSBuildProps,

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -79,7 +79,7 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.16.0</Version>
+    <Version>1.16.1</Version>
     <ToBeReleased>
       <![CDATA[
 ToBeDecided:
@@ -88,6 +88,8 @@ ToBeDecided:
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+v1.16.1
+- Set analyzer type of Directory.Build.props, Directory.Build.targets, and Directory.Packages.props correctly. (BUG)
 v1.16.0
 - Proj0006: Skip detecting if RESX'es are additional files. (UPDATE)
 - Proj0022: Ignore MSBuild item expressions. (FP)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ProjectFileTypes.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ProjectFileTypes.cs
@@ -2,6 +2,17 @@ namespace DotNetProjectFile.MsBuild;
 
 public static class ProjectFileTypes
 {
+    /// <summary>All.</summary>
+    public static readonly ImmutableArray<AnalyzerType> All =
+    [
+        AnalyzerType.MSBuildProject,
+        AnalyzerType.MSBuildProps,
+        AnalyzerType.DirectoryBuildProps,
+        AnalyzerType.DirectoryBuildTargets,
+        AnalyzerType.DirectoryPackagesProps,
+        AnalyzerType.SDK,
+    ];
+
     /// <summary>Project files only.</summary>
     public static readonly ImmutableArray<AnalyzerType> ProjectFile = [AnalyzerType.MSBuildProject];
 
@@ -29,38 +40,15 @@ public static class ProjectFileTypes
     public static readonly ImmutableArray<AnalyzerType> ProjectFile_DirectoryPackages =
     [
         AnalyzerType.MSBuildProject,
-         AnalyzerType.DirectoryBuildProps,
+        AnalyzerType.DirectoryBuildProps,
         AnalyzerType.DirectoryBuildTargets,
     ];
 
     /// <summary>All but Directory.Packages.props.</summary>
-    public static readonly ImmutableArray<AnalyzerType> AllExceptDirectoryPackages =
-    [
-        AnalyzerType.MSBuildProject,
-        AnalyzerType.MSBuildProps,
-        AnalyzerType.DirectoryBuildProps,
-        AnalyzerType.DirectoryBuildTargets,
-        AnalyzerType.SDK,
-    ];
+    public static readonly ImmutableArray<AnalyzerType> AllExceptDirectoryPackages
+        = All.Remove(AnalyzerType.DirectoryPackagesProps);
 
     /// <summary>All but .net.csproj SDK.</summary>
-    public static readonly ImmutableArray<AnalyzerType> AllExceptSDK =
-    [
-        AnalyzerType.MSBuildProject,
-        AnalyzerType.MSBuildProps,
-        AnalyzerType.DirectoryBuildProps,
-        AnalyzerType.DirectoryBuildTargets,
-        AnalyzerType.DirectoryPackagesProps,
-    ];
-
-    /// <summary>All.</summary>
-    public static readonly ImmutableArray<AnalyzerType> All =
-    [
-        AnalyzerType.MSBuildProject,
-        AnalyzerType.MSBuildProps,
-        AnalyzerType.DirectoryBuildProps,
-        AnalyzerType.DirectoryBuildTargets,
-        AnalyzerType.DirectoryPackagesProps,
-        AnalyzerType.SDK,
-    ];
+    public static readonly ImmutableArray<AnalyzerType> AllExceptSDK
+        = All.Remove(AnalyzerType.SDK);
 }

--- a/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.Sdk.props
@@ -38,8 +38,8 @@
   <ItemGroup>
     <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="MSBuildProject" Include="**/*.??proj" />
     <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="SLNX"           Include="**/*.slnx" />
-    <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="MSBuildProps"    Include="**/*.props" />
-    <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="MSBuildProps"    Include="**/*.targets" />
+    <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="MSBuildProps"   Include="**/*.props" />
+    <AdditionalFiles Visible="false" Exclude="@(AdditionalFiles)" AnalyzerType="MSBuildProps"   Include="**/*.targets" />
   </ItemGroup>
 
   <!-- Make visible -->

--- a/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.targets
+++ b/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.targets
@@ -22,30 +22,30 @@
 
   <!-- Directory.Build.props -->
   <ItemGroup Condition="'$(ImportDirectoryBuildProps)' == 'true'">
+    <AdditionalFiles Remove="$(DirectoryBuildPropsPath)" />
     <AdditionalFiles
       AnalyzerType="DirectoryBuildProps"
       Include="$(DirectoryBuildPropsPath)"
-      Exclude="@(AdditionalFiles)"
       Visible="false" />
     <CompilerVisibleProperty Include="DirectoryBuildPropsPath" />
   </ItemGroup>
 
   <!-- Directory.Build.targets -->
   <ItemGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true'">
+    <AdditionalFiles Remove="$(DirectoryBuildTargetsPath)" />
     <AdditionalFiles
       AnalyzerType="DirectoryBuildTargets"
       Include="$(DirectoryBuildTargetsPath)"
-      Exclude="@(AdditionalFiles)"
       Visible="false" />
     <CompilerVisibleProperty Include="DirectoryBuildTargetsPath" />
   </ItemGroup>
 
   <!-- Directory.Packages.props -->
   <ItemGroup Condition="'$(ImportDirectoryPackagesProps)' == 'true'">
+    <AdditionalFiles Remove="$(DirectoryPackagesPropsPath)" />
     <AdditionalFiles
       AnalyzerType="DirectoryPackagesProps"
       Include="$(DirectoryPackagesPropsPath)"
-      Exclude="@(AdditionalFiles)"
       Visible="false" />
     <CompilerVisibleProperty Include="DirectoryPackagesPropsPath" />
   </ItemGroup>


### PR DESCRIPTION
Due to an order problem
* Directory.Build.props
* Directory.Build.targets
* Directory.Packages.props correctly

where set to `MSBuildProps` instead of there more specific type. The existing type assumed so, so was of no help. This also has been fixed.