### PR TITLE
Display Directory.Build.props, Directory.Build.targets, and Directory.Packages.props in .net.csproj again

### DIFF
--- a/specs/Specs/AdditionalFiles_specs.cs
+++ b/specs/Specs/AdditionalFiles_specs.cs
@@ -15,6 +15,7 @@ public class Resolves
         var result = ctx.Analyzer.Build().Results.Single();
         Log(result);
 
+        result.Properties.Should().Contain(KeyValuePair.Create("IsDotNetProjectFileSdk", "false"));
         result.Should().HaveAdditionalFiles(
 
             new ProjectItem()
@@ -79,6 +80,7 @@ public class Resolves
 
         Log(result);
 
+        result.Properties.Should().Contain(KeyValuePair.Create("IsDotNetProjectFileSdk", "true"));
         result.Should().HaveAdditionalFiles(
 
             new ProjectItem
@@ -140,7 +142,7 @@ public class Resolves
                 ItemSpec = Full("AdditionalFilesProject/Directory.Build.props"),
                 Metadata = new Meta
                 {
-                    Visible = "false",
+                    Visible = "true",
                     AnalyzerType = "DirectoryBuildProps",
                 },
             },
@@ -149,7 +151,7 @@ public class Resolves
                 ItemSpec = Full("AdditionalFilesProject/Directory.Build.targets"),
                 Metadata = new Meta
                 {
-                    Visible = "false",
+                    Visible = "true",
                     AnalyzerType = "DirectoryBuildTargets",
                 },
             },
@@ -158,7 +160,7 @@ public class Resolves
                 ItemSpec = Full("AdditionalFilesProject/Directory.Packages.props"),
                 Metadata = new Meta
                 {
-                    Visible = "false",
+                    Visible = "true",
                     AnalyzerType = "DirectoryPackagesProps",
                 },
             },

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -79,18 +79,19 @@
   </ItemGroup>
 
   <PropertyGroup Label="Version and release notes">
-    <Version>1.16.1</Version>
+    <Version>1.17.0</Version>
     <ToBeReleased>
       <![CDATA[
 ToBeDecided:
 - Proj0037: Exclude runtime when all assets are private. (NEW RULE)
-v1.17.0
-- Proj4011: Define keys once in an INI section. (NEW RULE)
-- Proj5006: Files included in an SLNX should exist. (NEW RULE)
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+v1.17.0
+- Proj4011: Define keys once in an INI section. (NEW RULE)
+- Proj5006: Files included in an SLNX should exist. (NEW RULE)
+- Display Directory.Build.props, Directory.Build.targets, and Directory.Packages.props in .net.csproj again. (BUG)
 v1.16.1
 - Set analyzer type of Directory.Build.props, Directory.Build.targets, and Directory.Packages.props correctly. (BUG)
 v1.16.0

--- a/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.targets
+++ b/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.targets
@@ -26,7 +26,7 @@
     <AdditionalFiles
       AnalyzerType="DirectoryBuildProps"
       Include="$(DirectoryBuildPropsPath)"
-      Visible="false" />
+      Visible="$(IsDotNetProjectFileSdk)" />
     <CompilerVisibleProperty Include="DirectoryBuildPropsPath" />
   </ItemGroup>
 
@@ -36,7 +36,7 @@
     <AdditionalFiles
       AnalyzerType="DirectoryBuildTargets"
       Include="$(DirectoryBuildTargetsPath)"
-      Visible="false" />
+      Visible="$(IsDotNetProjectFileSdk)" />
     <CompilerVisibleProperty Include="DirectoryBuildTargetsPath" />
   </ItemGroup>
 
@@ -46,7 +46,7 @@
     <AdditionalFiles
       AnalyzerType="DirectoryPackagesProps"
       Include="$(DirectoryPackagesPropsPath)"
-      Visible="false" />
+      Visible="$(IsDotNetProjectFileSdk)" />
     <CompilerVisibleProperty Include="DirectoryPackagesPropsPath" />
   </ItemGroup>
 

--- a/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
+++ b/src/DotNetProjectFile.Analyzers/build/DotNetProjectFile.Analyzers.props
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <SonarQubeIntegration>true</SonarQubeIntegration>
+    <IsDotNetProjectFileSdk>false</IsDotNetProjectFileSdk>
     <IsDotNetProjectFileSdk Condition="$(MSBuildProjectFile) == '.net.csproj'">true</IsDotNetProjectFileSdk>
   </PropertyGroup>
 


### PR DESCRIPTION
Broken by the emergency patch  1.16.1.

Closes #938 