### PR TITLE
Proj6010: global.json should exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![.NET Project File Analyzers logo](design/logo_128x128.png)
 # .NET Project File Analyzers
-Contains 170+ [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
+Contains 180+ [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/)
 (static code) [diagnostic analyzers](https://docs.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.diagnostics.diagnosticanalyzer)
 that report issues on .NET project files.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -267,6 +267,10 @@ reported to the [GitHub repository](https://github.com/dotnet-project-file-analy
 * [**Proj5005** Omit Project ID's](rules/Proj5005.md)
 * [**Proj5006** Included files should exist](rules/Proj5006.md)
 
+## JSON
+* [**Proj6000** Invalid JSON file](rules/Proj6000.md)
+* [**Proj6010** global.json should exist](rules/Proj6010.md)
+
 ## SonarQube integration
 By default, results by .NET project file analyzers are included in SonarQube
 reports. Read [here](general/sonar-integration.md) more about how this works.

--- a/docs/navigation/json_rules.md
+++ b/docs/navigation/json_rules.md
@@ -1,0 +1,6 @@
+---
+title: JSON
+parent: Rules
+nav_order: 5
+permalink: /rules/json
+---

--- a/docs/rules/Proj6000.md
+++ b/docs/rules/Proj6000.md
@@ -1,0 +1,9 @@
+---
+parent: JSON
+ancestor: Rules
+permalink: /rules/Proj6000
+---
+
+# Proj6000: Invalid JSON file
+A [JSON file](https://www.json.org/) is a plain text file with a lightweight
+data-interchange format.

--- a/docs/rules/Proj6010.md
+++ b/docs/rules/Proj6010.md
@@ -1,0 +1,32 @@
+---
+parent: JSON
+ancestor: Rules
+permalink: /rules/Proj6010
+---
+
+# Proj6010: global.json should exist
+To ensure a predictable .NET SDK version is used across different machines,
+CI/CD pipelines, and local development environments, a [`global.json`](https://learn.microsoft.com/dotnet/core/tools/global-json)
+file should exist for every MSBuild project.
+
+When a `global.json` file is missing, the .NET CLI and MSBuild will resolve to
+the latest installed .NET SDK version on the compiling host machine. This can
+introduce subtle bugs, build failures, or differences in compiler diagnostics
+if developers have different SDK versions installed.
+
+## Non-compliant
+No `global.json` file is present in the project directory or any parent
+directories up to the repository root.
+
+## Compliant
+A `global.json` file is defined at the project directory level or in a parent
+directory, specifying the .NET SDK version:
+
+```json
+{
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "latestPatch"
+  }
+}
+```

--- a/globalconfig.verified.txt
+++ b/globalconfig.verified.txt
@@ -176,3 +176,5 @@ dotnet_diagnostic.Proj5000.severity = warning    # Use SLNX solution files
 dotnet_diagnostic.Proj5001.severity = warning    # Remove SLN solution files
 dotnet_diagnostic.Proj5005.severity = warning    # Omit Project ID's
 dotnet_diagnostic.Proj5006.severity = warning    # Included files should exist
+dotnet_diagnostic.Proj6000.severity = error      # Invalid JSON file
+dotnet_diagnostic.Proj6010.severity = warning    # global.json should exist

--- a/specs/Specs/AdditionalFiles_specs.cs
+++ b/specs/Specs/AdditionalFiles_specs.cs
@@ -130,6 +130,15 @@ public class Resolves
             },
             new ProjectItem
             {
+                ItemSpec = Full("../global.json"),
+                Metadata = new Meta
+                {
+                    Link = "global.json",
+                    AnalyzerType = "GlobalJson",
+                },
+            },
+            new ProjectItem
+            {
                 ItemSpec = Full("../NuGet.config"),
                 Metadata = new Meta
                 {

--- a/specs/Specs/Rules/GlobalJson/Gobal_json_must_exist.cs
+++ b/specs/Specs/Rules/GlobalJson/Gobal_json_must_exist.cs
@@ -1,0 +1,40 @@
+using DotNetProjectFile.Analyzers.GlobalJson;
+
+namespace Rules.Global_json_must_exist;
+
+public class Reports
+{
+    [Test]
+    public void missing_global_json() => new GlobalJsonMustExist().ForInlineCsproj("""
+        <Project Sdk="Microsoft.NET.Sdk">
+
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+          </PropertyGroup>
+
+        </Project>
+        """)
+        .HasIssue(Issue.WRN("Proj6010", "global.json does not exist"));
+}
+public class Guards
+{
+    [Test]
+    public void available_global_json() => new GlobalJsonMustExist().ForInlineCsproj("""
+        <Project Sdk="Microsoft.NET.Sdk">
+
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+          </PropertyGroup>
+
+        </Project>
+        """)
+        .WithFile("global.json", """
+        {
+          "sdk": {
+            "version": "10.0.400",
+            "rollForward": "latestPatch"
+          }
+        }
+        """)
+        .HasNoIssues();
+}

--- a/specs/Specs/Rules/SLNX/Use_SLNX_files.cs
+++ b/specs/Specs/Rules/SLNX/Use_SLNX_files.cs
@@ -5,15 +5,14 @@ namespace Rules.SLNX.Use_SLNX_files;
 public class Reports
 {
     [Test]
-    public void missing_SLNX() => new UseSlnxFiles()
-       .ForInlineSdkProject("""
-<Project Sdk="Microsoft.NET.Sdk">
+    public void missing_SLNX() => new UseSlnxFiles().ForInlineSdkProject("""
+        <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
-  </PropertyGroup>
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+          </PropertyGroup>
 
-</Project>
-""")
+        </Project>
+        """)
        .HasIssue(Issue.WRN("Proj5000", "Use a SLNX solution file instead"));
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/AnalyzerRegistry.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/AnalyzerRegistry.cs
@@ -39,6 +39,16 @@ internal static class AnalyzerRegistry
                 }
             });
 
+        /// <summary>Registers an register on <see cref="SolutionFileAnalysisContext"/>.</summary>
+        public void RegisterJsonFileAction(Action<JsonFileAnalysisContext> register)
+            => context.RegisterAdditionalFileAction(c =>
+            {
+                if (ProjectFiles.Global.UpdateJsonFile(c) is { } json)
+                {
+                    register(new(json.File, json.Type, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
+                }
+            });
+
         /// <summary>Registers an register on <see cref="NuGetConfigFileAnalysisContext"/>.</summary>
         public void RegisterNuGetConfigFileAction(Action<NuGetConfigFileAnalysisContext> register)
             => context.RegisterAdditionalFileAction(c =>

--- a/src/DotNetProjectFile.Analyzers/Analyzers/GlobalJson/GlobalJsonMustExist.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/GlobalJson/GlobalJsonMustExist.cs
@@ -1,0 +1,21 @@
+namespace DotNetProjectFile.Analyzers.GlobalJson;
+
+/// <summary>Implements <see cref="Rule.Json.GlobalJsonMustExist"/>.</summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class GlobalJsonMustExist() : MsBuildProjectFileAnalyzer(Rule.Json.GlobalJsonMustExist)
+{
+    /// <inheritdoc />
+    public override ImmutableArray<AnalyzerType> ApplicableTo => ProjectFileTypes.ProjectFile;
+
+    /// <inheritdoc />
+    public override bool DisableOnFailingImport => false;
+
+    /// <inheritdoc />
+    protected override void Register(ProjectFileAnalysisContext<MsBuildProject> context)
+    {
+        if (context.File.GlobalJson is null)
+        {
+            context.ReportDiagnostic(Descriptor, context.File);
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/JsonFileAnalyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/JsonFileAnalyzer.cs
@@ -1,0 +1,17 @@
+using DotNetProjectFile.Json;
+
+namespace DotNetProjectFile.Analyzers;
+
+/// <summary>
+/// Base for <see cref="DiagnosticAnalyzer"/>s to analyze JSON solution files.
+/// </summary>
+public abstract class JsonFileAnalyzer(
+    DiagnosticDescriptor primaryDiagnostic,
+    params DiagnosticDescriptor[] supportedDiagnostics)
+    : ProjectFileAnalyzer<JsonFile>(primaryDiagnostic, supportedDiagnostics)
+{
+    /// <summary>Registers the analyzer for all SLNX solution files.</summary>
+    /// <inheritdoc />
+    protected override void Register(AnalysisContext context)
+        => context.RegisterJsonFileAction(Register);
+}

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/AnalyzerType.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/AnalyzerType.cs
@@ -24,6 +24,10 @@ public enum AnalyzerType
     GlobalConfig,
     INI,
 
+    // JSON
+    GlobalJson,
+    Json,
+
     NuGetConfig,
 
     RESX,

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/AnalyzerTypes.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/AnalyzerTypes.cs
@@ -21,4 +21,11 @@ public static class AnalyzerTypes
         _ when file.Extension.IsMatch(".ini") => AnalyzerType.INI,
         _ => null,
     };
+
+    public static AnalyzerType? Json(IOFile file) => file switch
+    {
+        _ when file.Name.IsMatch("global.json") => AnalyzerType.GlobalJson,
+        _ when file.Extension.IsMatch(".json") => AnalyzerType.Json,
+        _ => null,
+    };
 }

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
@@ -24,6 +24,9 @@ public sealed partial class ProjectFiles
     public IniFile? IniFile(IOFile file)
         => IniFiles.TryGetOrUpdate(file, Create_IniFile);
 
+    public JsonFile? JsonFile(IOFile file)
+        => JsonFiles.TryGetOrUpdate(file, Create_JsonFile);
+
     public MsBuildProject? MsBuildProject(IOFile file)
         => MsBuildProjects.TryGetOrUpdate(file, Create_MsBuildProject);
 
@@ -103,7 +106,7 @@ public sealed partial class ProjectFiles
            AnalyzerType.Json,
            AnalyzerType.GlobalJson) is { } type
 
-       && JsonFiles.TryGetOrUpdate(context, _ => JsonFile.Load(context.AdditionalFile)) is { } file
+       && JsonFiles.TryGetOrUpdate(context, _ => Json.JsonFile.Load(context.AdditionalFile)) is { } file
            ? new(file, type)
            : null;
 
@@ -139,6 +142,8 @@ public sealed partial class ProjectFiles
 
     private static IniFile Create_IniFile(IOFile file)
         => Ini.IniFile.Load(file)!;
+
+    private static JsonFile? Create_JsonFile(IOFile file) => Json.JsonFile.Load(file)!;
 
     private MsBuildProject? Create_MsBuildProject(IOFile file)
        => MsBuild.MsBuildProject.Load(file, this);

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/ProjectFiles.cs
@@ -1,5 +1,6 @@
 using DotNetProjectFile.Git;
 using DotNetProjectFile.Ini;
+using DotNetProjectFile.Json;
 using DotNetProjectFile.Resx;
 using DotNetProjectFile.Slnx;
 
@@ -11,6 +12,7 @@ public sealed partial class ProjectFiles
 
     private readonly FileCache<GitIgnoreFile> GitIgnoredFiles = new();
     private readonly FileCache<IniFile> IniFiles = new();
+    private readonly FileCache<JsonFile> JsonFiles = new();
     private readonly FileCache<MsBuildProject> MsBuildProjects = new();
     private readonly FileCache<NuGet.Configuration.NuGetConfigFile> NuGetConfigFiles = new();
     private readonly FileCache<Resource> ResourceFiles = new();
@@ -95,6 +97,16 @@ public sealed partial class ProjectFiles
             ? new(file, type)
             : null;
 
+    public AnalyzerFileInfo<JsonFile>? UpdateJsonFile(AdditionalFileAnalysisContext context)
+       => context.AnyOf(
+           AnalyzerTypes.Json,
+           AnalyzerType.Json,
+           AnalyzerType.GlobalJson) is { } type
+
+       && JsonFiles.TryGetOrUpdate(context, _ => JsonFile.Load(context.AdditionalFile)) is { } file
+           ? new(file, type)
+           : null;
+
     public AnalyzerFileInfo<Resource>? UpdateResourceFile(AdditionalFileAnalysisContext context)
          => context.AnyOf(
             path => path.Extension.IsMatch(".resx") ? AnalyzerType.RESX : null,
@@ -114,9 +126,9 @@ public sealed partial class ProjectFiles
             : null;
 
     public AnalyzerFileInfo<SolutionFile>? UpdateSolutionFile(AdditionalFileAnalysisContext context)
-          => context.AnyOf(
-            path => path.Extension.IsMatch(".slnx") ? AnalyzerType.SLNX : null,
-            AnalyzerType.SLNX) is { } type
+        => context.AnyOf(
+           path => path.Extension.IsMatch(".slnx") ? AnalyzerType.SLNX : null,
+           AnalyzerType.SLNX) is { } type
 
         && SolutionFiles.TryGetOrUpdate(context, _ => Slnx.SolutionFile.Load(context.AdditionalFile, this)) is { } file
             ? new(file, type)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildProject.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildProject.cs
@@ -23,6 +23,12 @@ public sealed partial class MsBuildProject : Node, ProjectFile
         Language = Language.Parse(path.Extension);
     }
 
+    public Json.JsonFile? GlobalJson => Path.Directory
+        .AncestorsAndSelf()
+        .Select(dir => ProjectFiles.JsonFile(dir.File("global.json")))
+        .OfType<Json.JsonFile>()
+        .FirstOrDefault();
+
     public MsBuildProject? DirectoryBuildProps => Path.Directory
         .AncestorsAndSelf()
         .Select(dir => ProjectFiles.MsBuildProject(dir.File("Directory.Build.props")))

--- a/src/DotNetProjectFile.Analyzers/Properties/GlobalUsings.cs
+++ b/src/DotNetProjectFile.Analyzers/Properties/GlobalUsings.cs
@@ -19,6 +19,7 @@ global using System.Threading;
 global using System.Xml.Linq;
 global using Chars = System.ReadOnlySpan<char>;
 global using IniFileAnalysisContext = DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext<DotNetProjectFile.Ini.IniFile>;
+global using JsonFileAnalysisContext = DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext<DotNetProjectFile.Json.JsonFile>;
 global using NuGetConfigFileAnalysisContext = DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext<DotNetProjectFile.NuGet.Configuration.NuGetConfigFile>;
 global using ProjectFileAnalysisContext = DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext<DotNetProjectFile.MsBuild.MsBuildProject>;
 global using ResourceFileAnalysisContext = DotNetProjectFile.Diagnostics.ProjectFileAnalysisContext<DotNetProjectFile.Resx.Resource>;

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -216,3 +216,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj5001** Remove SLN solution files](https://dotnet-project-file-analyzers.github.io/rules/Proj5001.html)
 * [**Proj5005** Omit Project ID's](https://dotnet-project-file-analyzers.github.io/rules/Proj5005.html)
 * [**Proj5006** Included files should exist](https://dotnet-project-file-analyzers.github.io/rules/Proj5006.html)
+
+## JSON
+* [**Proj6000** Invalid JSON file](https://dotnet-project-file-analyzers.github.io/rules/Proj6000.html)
+* [**Proj6010** global.json should exist](https://dotnet-project-file-analyzers.github.io/rules/Proj6010.html)

--- a/src/DotNetProjectFile.Analyzers/Rule.Json.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.Json.cs
@@ -18,8 +18,11 @@ public static partial class Rule
             id: 6010,
             title: "global.json should exist",
             message: "global.json does not exist",
-            description: "?",
-            tags: ["?"],
+            description:
+                "To ensure a predictable .NET SDK version is used across " +
+                "different machines and environments, a global.json file should " +
+                "exist for every compiled project.",
+            tags: ["global.json", "configuration", "SDK"],
             category: Category.CodeQuality);
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Rule.Json.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.Json.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile;
 
 public static partial class Rule
 {
-    internal static class Json
+    public static class Json
     {
         public static DiagnosticDescriptor Invalid => New(
            id: 6000,
@@ -13,5 +13,13 @@ public static partial class Rule
            description: "A part of the JSON file could not be parsed.",
            tags: ["JSON", "syntax error"],
            category: Category.SyntaxError);
+
+        public static DiagnosticDescriptor GlobalJsonMustExist => New(
+            id: 6010,
+            title: "global.json should exist",
+            message: "global.json does not exist",
+            description: "?",
+            tags: ["?"],
+            category: Category.CodeQuality);
     }
 }

--- a/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.Sdk.props
+++ b/src/DotNetProjectFile.Analyzers/build/AdditionalFiles.Sdk.props
@@ -1,12 +1,19 @@
 <Project>
 
   <ItemGroup>
-    
+
     <!-- SDK -->
     <AdditionalFiles
       Include=".net.csproj"
       AnalyzerType="SDK"
       Visible="false"/>
+
+    <!-- global.json -->
+    <AdditionalFiles
+      Include="$([MSBuild]::GetPathOfFileAbove('global.json', $(MSBuildProjectDirectory)))"
+      Exclude="@(AdditionalFiles)"
+      AnalyzerType="GlobalJson"
+      Link="global.json" />
 
     <!-- .editorconfig -->
     <AdditionalFiles
@@ -26,13 +33,13 @@
       Exclude="@(AdditionalFiles)"
       AnalyzerType="GlobalConfig"
       Link=".globalconfig" />
-    
+
     <!-- NuGet.config -->
     <AdditionalFiles
       Include="$([MSBuild]::GetPathOfFileAbove('NuGet.config', $(MSBuildProjectDirectory)))"
       AnalyzerType="NuGetConfig"
       Link="NuGet.config" />
-    
+
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
To ensure a predictable .NET SDK version is used across different machines, CI/CD pipelines, and local development environments, a [`global.json`](https://learn.microsoft.com/dotnet/core/tools/global-json) file should exist for every MSBuild project.

When a `global.json` file is missing, the .NET CLI and MSBuild will resolve to the latest installed .NET SDK version on the compiling host machine. This can introduce subtle bugs, build failures, or differences in compiler diagnostics if developers have different SDK versions installed.

## Non-compliant
No `global.json` file is present in the project directory or any parent directories up to the repository root.

## Compliant
A `global.json` file is defined at the project directory level or in a parent directory, specifying the .NET SDK version:

```json
{
  "sdk": {
    "version": "10.0.400",
    "rollForward": "latestPatch"
  }
}
```

See: #942 